### PR TITLE
Some very minor makefile corrections

### DIFF
--- a/core/debugger/make/Makefile.msys2-clang.amd64
+++ b/core/debugger/make/Makefile.msys2-clang.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -Wall -std=c++17 -Wno-strict-overflow -pthread -D_X64 -D_MSYS2  -D_MSYS2_CLANG -D_OBJECK_NATIVE_LIB_PATH -D_DEBUGGER -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas
+ARGS=-O3 -Wall -std=c++17 -Wno-strict-overflow -pthread -D_X64 -D_MSYS2 -D_MSYS2_CLANG -D_OBJECK_NATIVE_LIB_PATH -D_DEBUGGER -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas
 
 CC=clang++
 SRC=tree.o scanner.o parser.o debugger.o

--- a/core/debugger/make/Makefile.msys2-ucrt.amd64
+++ b/core/debugger/make/Makefile.msys2-ucrt.amd64
@@ -34,8 +34,8 @@ objeck.res:
 	$(CC) -m64 $(ARGS) -c $< 
 
 clean:
-	cd $(WIN32_PATH); make -f make/Makefile.msys2-clang.amd64 clean
-	cd $(JIT_PATH); make -f make/Makefile.msys2-clang.amd64 clean
-	cd $(MEM_PATH); make -f make/Makefile.msys2-clang.amd64 clean
-	cd $(VM_PATH); make -f make/Makefile.msys2-clang.amd64.obd clean
+	cd $(WIN32_PATH); make -f make/Makefile.msys2-ucrt.amd64 clean
+	cd $(JIT_PATH); make -f make/Makefile.msys2-ucrt.amd64 clean
+	cd $(MEM_PATH); make -f make/Makefile.msys2-ucrt.amd64 clean
+	cd $(VM_PATH); make -f make/Makefile.msys2-ucrt.amd64.obd clean
 	rm -f $(EXE) $(EXE).exe *.o *~ *.res

--- a/core/debugger/make/Makefile.msys2-ucrt.amd64
+++ b/core/debugger/make/Makefile.msys2-ucrt.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -Wall -std=c++17 -Wno-strict-overflow -pthread -D_X64  -D_MSYS2 -D_OBJECK_NATIVE_LIB_PATH -D_DEBUGGER -Wno-dangling-pointer -Wno-maybe-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas
+ARGS=-O3 -Wall -std=c++17 -Wno-strict-overflow -pthread -D_X64 -D_MSYS2 -D_OBJECK_NATIVE_LIB_PATH -D_DEBUGGER -Wno-dangling-pointer -Wno-maybe-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas
 
 CC=g++
 SRC=tree.o scanner.o parser.o debugger.o

--- a/core/vm/arch/jit/amd64/make/Makefile.msys2-clang.amd64
+++ b/core/vm/arch/jit/amd64/make/Makefile.msys2-clang.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -D_X64 -Wall -Wno-unused-function -std=c++17 -Wno-deprecated-declarations  -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas
+ARGS=-O3 -D_X64 -Wall -Wno-unused-function -std=c++17 -Wno-deprecated-declarations -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas
 
 CC=clang++
 AR=ar

--- a/core/vm/make/Makefile.msys2-clang.amd64
+++ b/core/vm/make/Makefile.msys2-clang.amd64
@@ -27,7 +27,7 @@ objeck.res:
 	$(CC) -m64 $(ARGS) -c $< 
 
 clean:
-	cd $(MEM_PATH); make -f make/Makefile.msys2-ucrt.amd64 clean
-	cd $(JIT_PATH); make -f make/Makefile.msys2-ucrt.amd64 clean
-	cd $(WIN32_PATH); make -f make/Makefile.msys2-ucrt.amd64 clean
+	cd $(MEM_PATH); make -f make/Makefile.msys2-clang.amd64 clean
+	cd $(JIT_PATH); make -f make/Makefile.msys2-clang.amd64 clean
+	cd $(WIN32_PATH); make -f make/Makefile.msys2-clang.amd64 clean
 	rm -f $(EXE).exe $(EXE) *.exe *.dll *.o *~ *.res

--- a/core/vm/make/Makefile.msys2-clang.amd64.obd
+++ b/core/vm/make/Makefile.msys2-clang.amd64.obd
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++17 -Wno-strict-overflow -pthread -Wall -D_WIN32 -D_MSYS2 -D_MSYS2_CLANG -D_X64 -D_DEBUGGER -D_OBJECK_NATIVE_LIB_PATH  -D_NO_JIT  -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas -Wno-unused-but-set-variable
+ARGS=-O3 -Wall -std=c++17 -Wno-strict-overflow -pthread -Wall -D_WIN32 -D_MSYS2 -D_MSYS2_CLANG -D_X64 -D_DEBUGGER -D_OBJECK_NATIVE_LIB_PATH -D_NO_JIT -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas -Wno-unused-but-set-variable
 
 CC=clang++
 SRC=common.o interpreter.o loader.o vm.o posix_main.o 

--- a/core/vm/make/Makefile.msys2-clang.amd64.obd
+++ b/core/vm/make/Makefile.msys2-clang.amd64.obd
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++17 -Wno-strict-overflow -pthread -Wall -D_WIN32 -D_MSYS2 -D_MSYS2_CLANG -D_X64 -D_DEBUGGER  -D_OBJECK_NATIVE_LIB_PATH  -D_NO_JIT  -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas -Wno-unused-but-set-variable
+ARGS=-O3 -Wall -std=c++17 -Wno-strict-overflow -pthread -Wall -D_WIN32 -D_MSYS2 -D_MSYS2_CLANG -D_X64 -D_DEBUGGER -D_OBJECK_NATIVE_LIB_PATH  -D_NO_JIT  -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas -Wno-unused-but-set-variable
 
 CC=clang++
 SRC=common.o interpreter.o loader.o vm.o posix_main.o 

--- a/core/vm/make/Makefile.msys2-ucrt.amd64.obd
+++ b/core/vm/make/Makefile.msys2-ucrt.amd64.obd
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++17 -Wno-strict-overflow -pthread -Wall -D_WIN32 -D_MSYS2 -D_X64 -D_DEBUGGER  -D_OBJECK_NATIVE_LIB_PATH  -D_NO_JIT -Wno-dangling-pointer -Wno-maybe-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas
+ARGS=-O3 -Wall -std=c++17 -Wno-strict-overflow -pthread -Wall -D_WIN32 -D_MSYS2 -D_X64 -D_DEBUGGER -D_OBJECK_NATIVE_LIB_PATH -D_NO_JIT -Wno-dangling-pointer -Wno-maybe-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas
 
 CC=g++
 SRC=common.o interpreter.o loader.o vm.o posix_main.o 


### PR DESCRIPTION
I discovered them when trying to have Objeck build on MINGW64 (MSVCRT, not UCRT64). Finally I was able to build it and it worked well. The only thing depends on UCRT64 on Objeck code is `_dupenv_s` that doesn't available on MSVCRT, replace it with the plain old `getenv` and it compiled and worked (Unicode strings printed on the screen just fine). I decided to not upstream it because I have trouble with the macros logic. It's impossible for me to use macros to have it build on both MSVCRT and UCRT64. It will only build on MSVCRT if I replaced `_dupenv_s` by `getenv` completely. After all it's a just an adventure of me and it's not worth to do so as `getenv` is deprecated as it's neither secure nor thread-safe and UCRT64 is superior to MSVCRT. But the only thing I know now is I could hack Objeck to build on MINGW64 (MSVCRT). I will not go any further. It's enough work for today ^^