### PR TITLE
copy dlls

### DIFF
--- a/core/release/deploy_msys2-clang.sh
+++ b/core/release/deploy_msys2-clang.sh
@@ -80,6 +80,48 @@ cp programs/deploy/*.obs core/release/deploy-msys2-clang/examples
 cp programs/deploy/media/*.png core/release/deploy-msys2-clang/examples/media
 cp programs/deploy/media/*.wav core/release/deploy-msys2-clang/examples/media
 
+# copy dlls
+cp /clang64/bin/libc++.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libunwind.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libwinpthread-1.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/zlib1.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libcrypto-3-x64.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libssl-3-x64.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libodbc-2.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libiconv-2.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libltdl-7.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/SDL2.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/SDL2_image.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/SDL2_mixer.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/SDL2_ttf.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libjpeg-8.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libjxl.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libpng16-16.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libtiff-6.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libwebp-7.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libmpg123-0.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libopusfile-0.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libfreetype-6.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libharfbuzz-0.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libbrotlidec.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libbrotlienc.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libhwy.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/liblcms2-2.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libdeflate.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libjbig-0.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libLerc.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/liblzma-5.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libzstd.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libsharpyuv-0.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libogg-0.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libopus-0.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libbz2-1.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libglib-2.0-0.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libgraphite2.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libintl-8.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libbrotlicommon.dll core/release/deploy-msys2-clang/bin
+cp /clang64/bin/libpcre2-8-0.dll core/release/deploy-msys2-clang/bin
+
 cd core/release
 
 # deploy

--- a/core/release/deploy_msys2-ucrt.sh
+++ b/core/release/deploy_msys2-ucrt.sh
@@ -80,6 +80,48 @@ cp programs/deploy/*.obs core/release/deploy-msys2-ucrt/examples
 cp programs/deploy/media/*.png core/release/deploy-msys2-ucrt/examples/media
 cp programs/deploy/media/*.wav core/release/deploy-msys2-ucrt/examples/media
 
+# copy dlls
+cp /ucrt64/bin/libgcc_s_seh-1.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libstdc++-6.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libwinpthread-1.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/zlib1.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libcrypto-3-x64.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libssl-3-x64.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libodbc-2.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libiconv-2.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libltdl-7.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/SDL2.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/SDL2_image.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/SDL2_mixer.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/SDL2_ttf.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libjpeg-8.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libjxl.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libpng16-16.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libtiff-6.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libwebp-7.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libmpg123-0.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libopusfile-0.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libfreetype-6.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libharfbuzz-0.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libbrotlidec.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libbrotlienc.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libhwy.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/liblcms2-2.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libdeflate.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libjbig-0.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libLerc.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/liblzma-5.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libzstd.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libsharpyuv-0.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libogg-0.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libopus-0.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libbz2-1.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libglib-2.0-0.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libgraphite2.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libintl-8.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libbrotlicommon.dll core/release/deploy-msys2-ucrt/bin
+cp /ucrt64/bin/libpcre2-8-0.dll core/release/deploy-msys2-ucrt/bin
+
 cd core/release
 
 # deploy


### PR DESCRIPTION
truly standalone, no longer need to put ucrt64/bin or clang64/bin to PATH