### PR TITLE
A minor fix

### DIFF
--- a/core/debugger/debugger.cpp
+++ b/core/debugger/debugger.cpp
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
     
     WSADATA data;
     if(WSAStartup(MAKEWORD(2, 2), &data)) {
-      std::cerr << L"Unable to load Winsock 2.2!" << std::endl;
+      std::wcerr << L"Unable to load Winsock 2.2!" << std::endl;
       exit(1);
     }
 #endif

--- a/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
+++ b/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
@@ -3296,7 +3296,7 @@ void JitAmd64::cmov_reg(Register reg, InstructionType oper) {
     break;
 
   default:
-    std::cerr << L">>> Unknown compare! <<<" << std::endl;
+    std::wcerr << L">>> Unknown compare! <<<" << std::endl;
     exit(1);
     break;
   }

--- a/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
+++ b/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
@@ -1017,7 +1017,7 @@ void JitAmd64::ProcessJump(StackInstr* instr) {
         break;
 
       default:
-        std::cerr << L">>> Should never occur (compiler bug?) type=" << left->GetType() << L" <<<" << std::endl;
+        std::wcerr << L">>> Should never occur (compiler bug?) type=" << left->GetType() << L" <<<" << std::endl;
         exit(1);
         break;
       }

--- a/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
+++ b/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
@@ -914,7 +914,7 @@ void JitAmd64::ProcessInstructions() {
       
     default: {
       InstructionType error = (InstructionType)instr->GetType();
-      std::cerr << L"Unknown instruction: " << error << L"!" << std::endl;
+      std::wcerr << L"Unknown instruction: " << error << L"!" << std::endl;
       exit(1);
     }
       break;

--- a/core/vm/lib_api.h
+++ b/core/vm/lib_api.h
@@ -627,7 +627,7 @@ void APITools_CallMethod(VMContext &context, size_t * instance, const wchar_t* q
 #endif
   }
   else {
-    std::cerr << L">>> DLL_CALL: Invalid method name: '" << qualified_name << L"'" << std::endl;
+    std::wcerr << L">>> DLL_CALL: Invalid method name: '" << qualified_name << L"'" << std::endl;
     exit(1);
   }
 }


### PR DESCRIPTION
You are using `std:cerr` to print a wide string. `std:wcerr` should be used instead.

Note: As I only build on MSYS2 UCRT64 and MSYS2 CLANG64, other targets like macOS, POSIX and ARM64 are not checked by me. You should have a look at them for the sake of code correctness.