### PR TITLE
Update Makefile.msys2-clang.amd64

### DIFF
--- a/core/module/example/make/Makefile.msys2-clang.amd64
+++ b/core/module/example/make/Makefile.msys2-clang.amd64
@@ -6,7 +6,7 @@ MODULE_PATH=..
 EXE=example
 
 $(EXE): $(SRC) $(OBJ_LIBS)
-	$(CXX) -m64 -o $(EXE) $(SRC) $(OBJ_LIBS) ../../compiler/compiler.a ../../compiler/logger.a ../../vm/vm.a ../vm/memory.a ../../vm/arch/jit/amd64/jit_common.a ../../vm/arch/win32/win32.o ../../vm/arch/jit/amd64/jit_amd_lp64.o -lssl -lcrypto -lz -pthread -lwsock32 -luserenv -lws2_32 -lz
+	$(CXX) -m64 -o $(EXE) $(SRC) $(OBJ_LIBS) ../../compiler/compiler.a ../../compiler/logger.a ../../vm/vm.a ../../vm/memory.a ../../vm/arch/jit/amd64/jit_common.a ../../vm/arch/win32/win32.o ../../vm/arch/jit/amd64/jit_amd_lp64.o -lssl -lcrypto -lz -pthread -lwsock32 -luserenv -lws2_32 -lz
 
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 


### PR DESCRIPTION
Fix building `module/example` on MSYS2 CLANG64.