### PR TITLE
Cleanup of Makefiles

### DIFF
--- a/core/debugger/make/Makefile.msys2-clang.amd64
+++ b/core/debugger/make/Makefile.msys2-clang.amd64
@@ -10,7 +10,7 @@ JIT_PATH=../vm/arch/jit/amd64
 EXE=obd
 
 $(EXE): $(SRC) $(OBJ_LIBS)
-	$(CXX) -m64 -pthread -o $(EXE) $(SRC) $(OBJ_LIBS) -Wunused-function -lssl -lcrypto -lz -pthread -lwsock32 -luserenv -lws2_32 -lz
+	$(CXX) -m64 -o $(EXE) $(SRC) $(OBJ_LIBS) -Wunused-function -lssl -lcrypto -lz -pthread -lwsock32 -luserenv -lws2_32 -lz
 
 ../vm/vm.a:
 	cd $(VM_PATH); $(MAKE) -f make/Makefile.msys2-clang.amd64.obd

--- a/core/debugger/make/Makefile.msys2-ucrt.amd64
+++ b/core/debugger/make/Makefile.msys2-ucrt.amd64
@@ -9,7 +9,7 @@ JIT_PATH=../vm/arch/jit/amd64
 EXE=obd
 
 $(EXE): $(SRC) $(OBJ_LIBS)
-	$(CXX) -m64 -pthread -o $(EXE) $(SRC) $(OBJ_LIBS) -Wunused-function -lssl -lcrypto -lz -pthread -lwsock32 -luserenv -lws2_32 -lz
+	$(CXX) -m64 -o $(EXE) $(SRC) $(OBJ_LIBS) -Wunused-function -lssl -lcrypto -lz -pthread -lwsock32 -luserenv -lws2_32 -lz
 
 ../vm/vm.a:
 	cd $(VM_PATH); $(MAKE) -f make/Makefile.msys2-ucrt.amd64.obd


### PR DESCRIPTION
Clang warned about the duplicated `-pthread` but GCC doesn't. This PR is to satisfy Clang.