### PR TITLE
Cleanup of Makefiles

### DIFF
--- a/core/compiler/make/Makefile.msys2-clang.amd64
+++ b/core/compiler/make/Makefile.msys2-clang.amd64
@@ -1,6 +1,5 @@
 ARGS=-O3 -Wall -Wno-unused-function -D_X64 -D_MSYS2_CLANG -std=c++17 -Wno-sequence-point
 
-CC=clang++
 SRC=types.o tree.o scanner.o parser.o linker.o context.o intermediate.o optimization.o emit.o compiler.o posix_main.o
 OBJ_LIBS=sys.a objeck.res
 LOGGER_PATH=../shared

--- a/core/compiler/make/Makefile.msys2-clang.amd64.mod
+++ b/core/compiler/make/Makefile.msys2-clang.amd64.mod
@@ -1,4 +1,3 @@
-CC=clang++
 ARGS=-O3 -Wall -D_MODULE -std=c++17 -Wno-unused-function -Wno-sequence-point
 SRC=types.o tree.o scanner.o parser.o linker.o context.o intermediate.o optimization.o emit.o compiler.o 
 OBJ_LIBS=sys.a

--- a/core/debugger/make/Makefile.msys2-clang.amd64
+++ b/core/debugger/make/Makefile.msys2-clang.amd64
@@ -1,6 +1,5 @@
 ARGS=-O3 -Wall -std=c++17 -Wno-strict-overflow -pthread -D_X64 -D_MSYS2 -D_MSYS2_CLANG -D_OBJECK_NATIVE_LIB_PATH -D_DEBUGGER -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast
 
-CC=clang++
 SRC=tree.o scanner.o parser.o debugger.o
 OBJ_LIBS=../vm/vm.a ../vm/jit_amd_lp64.a ../vm/memory.a ../vm/win32.a objeck.res
 VM_PATH=../vm

--- a/core/module/example/make/Makefile.msys2-clang.amd64
+++ b/core/module/example/make/Makefile.msys2-clang.amd64
@@ -1,4 +1,3 @@
-CC=clang++
 ARGS=-O3 -Wall -std=c++17 -D_X64 -D_OBJECK_NATIVE_LIB_PATH -Wno-unused-function
 SRC=example.o
 OBJ_LIBS=../module.a

--- a/core/module/make/Makefile.msys2-clang.amd64
+++ b/core/module/make/Makefile.msys2-clang.amd64
@@ -1,6 +1,5 @@
 ARGS=-O3 -Wall -std=c++17 -D_SANITIZE -D_X64 -D_OBJECK_NATIVE_LIB_PATH -D__MSYS2_CLANG -D_MODULE -Wint-to-pointer-cast -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast
 
-CC=clang++
 SRC=lang.o
 OBJ_LIBS=../shared/sys.cpp ../compiler/compiler.a ../vm/vm.a
 COMPILER_PATH=../compiler

--- a/core/utils/launcher/make/Makefile.obb.msys2-clang.amd64
+++ b/core/utils/launcher/make/Makefile.obb.msys2-clang.amd64
@@ -1,6 +1,5 @@
 ARGS=-O3 -Wall -std=c++17 -Wno-unused-function
 
-CC=clang++
 SRC=builder.o
 OBJ_LIBS=objeck.res
 EXE=obb

--- a/core/utils/launcher/make/Makefile.obn.msys2-clang.amd64
+++ b/core/utils/launcher/make/Makefile.obn.msys2-clang.amd64
@@ -1,6 +1,5 @@
 ARGS=-O3 -D_MSYS2 -Wall -D_MSYS2 -Wno-unused-function -std=c++17
 
-CC=clang++
 SRC=launcher.o
 EXE=obn
 

--- a/core/vm/arch/jit/amd64/make/Makefile.msys2-clang.amd64
+++ b/core/vm/arch/jit/amd64/make/Makefile.msys2-clang.amd64
@@ -1,6 +1,5 @@
 ARGS=-O3 -D_X64 -Wall -Wno-unused-function -std=c++17 -Wno-deprecated-declarations -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wpointer-bool-conversion
 
-CC=clang++
 AR=ar
 COMMON_LIBS=jit_common.a
 COMMON_PATH=..

--- a/core/vm/arch/jit/make/Makefile.msys2-clang.amd64
+++ b/core/vm/arch/jit/make/Makefile.msys2-clang.amd64
@@ -1,6 +1,5 @@
 ARGS=-O3 -Wall -std=c++17 -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unused-but-set-variable
 
-CC=clang++
 AR=ar
 SRC=jit_common.o
 LIB=amd64/jit_common.a

--- a/core/vm/arch/make/Makefile.msys2-clang.amd64
+++ b/core/vm/arch/make/Makefile.msys2-clang.amd64
@@ -1,6 +1,5 @@
 ARGS=-O3 -Wall -D_X64 -D_MSYS2 -std=c++17 -Wno-unused-command-line-argument -Wno-unused-function 
 
-CC=clang++
 AR=ar
 SRC=memory.o 
 LIB=../memory.a

--- a/core/vm/arch/win32/make/Makefile.msys2-clang.amd64
+++ b/core/vm/arch/win32/make/Makefile.msys2-clang.amd64
@@ -1,6 +1,5 @@
 ARGS=-O3 -Wall -Wno-unused-function -std=c++17 -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast 
 
-CC=clang++
 AR=ar
 SRC=win32.o
 LIB=../../win32.a

--- a/core/vm/make/Makefile.msys2-clang.amd64
+++ b/core/vm/make/Makefile.msys2-clang.amd64
@@ -1,6 +1,5 @@
 ARGS=-O3 -Wall -std=c++17 -pthread -D_MSYS2 -D_MSYS2_CLANG -D_X64 -D_WIN32 -D_OBJECK_NATIVE_LIB_PATH -Wno-uninitialized -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas -Wno-unused-but-set-variable -Wno-deprecated-declarations
 
-CC=clang++
 SRC=common.o interpreter.o loader.o vm.o win_main.o
 OBJ_LIBS=win32.a jit_amd_lp64.a memory.a objeck.res
 MEM_PATH=arch

--- a/core/vm/make/Makefile.msys2-clang.amd64.mod
+++ b/core/vm/make/Makefile.msys2-clang.amd64.mod
@@ -1,6 +1,5 @@
 ARGS=-O3 -Wall -D_MODULE -D_X64 -D_OBJECK_NATIVE_LIB_PATH -D_MSYS2 -D_MSYS2_CLANG -std=c++17 -Wno-uninitialized -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas -Wno-unused-but-set-variable
 
-CC=clang++
 SRC=common.o interpreter.o loader.o vm.o posix_main.o 
 OBJ_LIBS=win32.a jit_amd_lp64.a memory.a
 MEM_PATH=arch

--- a/core/vm/make/Makefile.msys2-clang.amd64.obd
+++ b/core/vm/make/Makefile.msys2-clang.amd64.obd
@@ -1,6 +1,5 @@
 ARGS=-O3 -Wall -std=c++17 -Wno-strict-overflow -pthread -Wall -D_WIN32 -D_MSYS2 -D_MSYS2_CLANG -D_X64 -D_DEBUGGER -D_OBJECK_NATIVE_LIB_PATH -D_NO_JIT -Wno-uninitialized -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas -Wno-unused-but-set-variable
 
-CC=clang++
 SRC=common.o interpreter.o loader.o vm.o posix_main.o 
 OBJ_LIBS=jit_amd_lp64.a memory.a
 MEM_PATH=arch


### PR DESCRIPTION
Remove `CC=clang++` as Makefiles are using `$(CXX)` now.