### PR TITLE
Objeck syntax coloring for Geany

### DIFF
--- a/docs/syntax/geany/LICENSE
+++ b/docs/syntax/geany/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 tqo50396
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/syntax/geany/README.md
+++ b/docs/syntax/geany/README.md
@@ -1,0 +1,8 @@
+# Objeck syntax coloring for Geany
+
+Download the file `filetypes.Objeck.conf` and copy it to:
+
+- Linux: `~/.config/geany/filedefs/`
+- Windows: `%AppData%\geany\filedefs` or `"Installation directory of Geany"\data\filedefs`
+
+Register `filetypes.Objeck.conf` with Geany: `Tools -> Configuration Files -> filetype_extensions.conf` and add `Objeck=*.obs;` to `[Extensions]`

--- a/docs/syntax/geany/filetypes.Objeck.conf
+++ b/docs/syntax/geany/filetypes.Objeck.conf
@@ -46,10 +46,10 @@ context_action_cmd=
 
 [build-menu]
 FT_00_LB=_Compile
-FT_00_CM=obc -src "%f" -alt -lib "ml,math,gen_collect,diags,net,rss,misc,regex,csv,xml,json,encrypt,odbc,query,sdl2,sdl_game"
+FT_00_CM=obc -src "%f" -lib "ml,math,gen_collect,diags,net,rss,misc,regex,csv,xml,json,encrypt,odbc,query,sdl2,sdl_game"
 FT_00_WD=
 FT_01_LB=_Build
-FT_01_CM=obc -src "%f" -alt -lib "ml,math,gen_collect,diags,net,rss,misc,regex,csv,xml,json,encrypt,odbc,query,sdl2,sdl_game" -dest "%e".obe
+FT_01_CM=obc -src "%f" -lib "ml,math,gen_collect,diags,net,rss,misc,regex,csv,xml,json,encrypt,odbc,query,sdl2,sdl_game" -dest "%e".obe
 FT_01_WD=
 EX_00_LB=_Run
 EX_00_CM=obr "%e"

--- a/docs/syntax/geany/filetypes.Objeck.conf
+++ b/docs/syntax/geany/filetypes.Objeck.conf
@@ -1,0 +1,56 @@
+# For complete documentation of this file, please see Geany's main documentation
+
+[styling=C]
+
+[keywords]
+# all items must be in one line
+primary=class method function public abstract private static native virtual Parent As from implements interface enum alias consts bundle use leaving if else do while select break continue other for each reverse label return critical New and or xor true false
+secondary=Nil Byte ByteRef Int IntRef Float FloatRef Char CharRef Bool BoolRef String BaseArrayRef BoolArrayRef ByteArrayRef CharArrayRef FloatArrayRef IntArrayRef StringArrayRef Func2Ref Func3Ref Func4Ref FuncRef
+
+[lexer_properties=C]
+
+[settings]
+lexer_filetype=C
+
+# default extension used when saving files
+extension=obs
+
+# MIME type
+mime_type=text/x-objeck
+
+# these characters define word boundaries when making selections and searching
+# using word matching options
+#wordchars=_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
+
+# single comments, like # in this file
+comment_single=//
+# multiline comments
+comment_open=/*
+comment_close=*/
+
+# set to false if a comment character/string should start at column 0 of a line, true uses any
+# indentation of the line, e.g. setting to true causes the following on pressing CTRL+d
+# 		#command_example();
+# setting to false would generate this
+# #		command_example();
+# This setting works only for single line comments
+comment_use_indent=true
+
+# context action command (please see Geany's main documentation for details)
+context_action_cmd=
+
+[indentation]
+#width=4
+# 0 is spaces, 1 is tabs, 2 is tab & spaces
+#type=1
+
+[build-menu]
+FT_00_LB=_Compile
+FT_00_CM=obc -src "%f" -alt -lib "ml,math,gen_collect,diags,net,rss,misc,regex,csv,xml,json,encrypt,odbc,query,sdl2,sdl_game"
+FT_00_WD=
+FT_01_LB=_Build
+FT_01_CM=obc -src "%f" -alt -lib "ml,math,gen_collect,diags,net,rss,misc,regex,csv,xml,json,encrypt,odbc,query,sdl2,sdl_game" -dest "%e".obe
+FT_01_WD=
+EX_00_LB=_Run
+EX_00_CM=obr "%e"
+EX_00_WD=


### PR DESCRIPTION
Note: Geany doesn't support highlighting of Objeck style comments. Use C style comments instead.