### PR TITLE
Potential fix for code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/programs/frameworks/openai/chat_ui/chatbot.js
+++ b/programs/frameworks/openai/chat_ui/chatbot.js
@@ -8,8 +8,8 @@ const createChatLi = (message, className) => {
 	const chatLi = document.createElement("li");
 	chatLi.classList.add("chat", className);
 	
-	let chatContent = className === "chat-outgoing" ? `<p>${message}</p>` : `<p>${message}</p>`;
-	chatLi.innerHTML = chatContent;
+	let chatContent = className === "chat-outgoing" ? message : message;
+	chatLi.textContent = chatContent;
 
 	return chatLi;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/objeck/objeck-lang/security/code-scanning/8](https://github.com/objeck/objeck-lang/security/code-scanning/8)

To fix the issue, user input should be properly sanitized or escaped before being inserted into the DOM. Instead of using `innerHTML`, which interprets the string as HTML, we can use `textContent` to safely set the text content without parsing it as HTML. This ensures that any malicious HTML or scripts included in the user input are treated as plain text and do not execute.

**Steps to fix:**
1. Replace `innerHTML` on line 12 with `textContent`.
2. Modify the logic on line 11 to ensure `chatContent` is a plain string, directly assignable to `textContent`.

No additional methods, imports, or definitions are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
