### PR TITLE
fix arm64 JIT EXT_LIB_FUNC_CALL crash + macOS onnx + CodeQL build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -84,8 +84,15 @@ jobs:
     - if: matrix.build-mode == 'manual'
       name: Build C and C++ code
       run: |
-        sudo apt-get update; sudo apt-get upgrade; sudo apt-get install build-essential git libmbedtls-dev unixodbc-dev libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev libreadline-dev unzip libeigen3-dev
-        cd core/release; ./deploy_posix.sh x64
+        # Skip apt-get upgrade — it pulls unrelated packages (e.g. the firefox
+        # snap stub) that occasionally fail to install on the runner image and
+        # break this job for reasons unrelated to our build.
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          build-essential git libmbedtls-dev unixodbc-dev \
+          libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev \
+          libreadline-dev unzip libeigen3-dev
+        cd core/release && ./deploy_posix.sh x64
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/core/lib/onnx/eq/build.sh
+++ b/core/lib/onnx/eq/build.sh
@@ -43,17 +43,23 @@ esac
 
 CXX=${CXX:-g++}
 
-# On macOS with Homebrew, add include/lib paths for dependencies
+# On macOS, vm/common.h pulls in v3-API mbedtls headers. Use the in-tree v3
+# headers (same set the diags/matrix/opencv xcodeproj builds link against)
+# instead of homebrew's mbedtls — brew now ships v4, which removed entropy.h.
 EXTRA_INCLUDE=""
 EXTRA_LIB=""
-if [ "$(uname -s)" = "Darwin" ] && [ -d "/opt/homebrew" ]; then
-	# Prefer mbedtls@3 (v4 has breaking API changes), fall back to generic path
-	if [ -d "/opt/homebrew/opt/mbedtls@3/include" ]; then
-		EXTRA_INCLUDE="-I/opt/homebrew/opt/mbedtls@3/include -I/opt/homebrew/include"
-	else
-		EXTRA_INCLUDE="-I/opt/homebrew/include"
+if [ "$(uname -s)" = "Darwin" ]; then
+	IN_TREE_MBEDTLS_INC="$(cd "$(dirname "$0")/../../openssl/macos/include" 2>/dev/null && pwd)"
+	if [ -n "$IN_TREE_MBEDTLS_INC" ] && [ -f "$IN_TREE_MBEDTLS_INC/mbedtls/entropy.h" ]; then
+		EXTRA_INCLUDE="-I$IN_TREE_MBEDTLS_INC"
+	elif [ -d "/opt/homebrew/opt/mbedtls@3/include" ]; then
+		EXTRA_INCLUDE="-I/opt/homebrew/opt/mbedtls@3/include"
 	fi
-	EXTRA_LIB="-L/opt/homebrew/lib"
+	# Append homebrew include for other deps (opencv etc.) and link path.
+	if [ -d "/opt/homebrew" ]; then
+		EXTRA_INCLUDE="$EXTRA_INCLUDE -I/opt/homebrew/include"
+		EXTRA_LIB="-L/opt/homebrew/lib"
+	fi
 fi
 
 $CXX -O3 -std=c++17 -Wall -fPIC $EP_DEFINE $ORT_INCLUDE $EXTRA_INCLUDE \

--- a/core/vm/arch/jit/arm64/jit_arm_a64.cpp
+++ b/core/vm/arch/jit/arm64/jit_arm_a64.cpp
@@ -4713,12 +4713,18 @@ bool JitArm64::Compile(StackMethod* cm)
 
     // Pre-scan: reject methods with unsupported instructions.
     // STOR_CLS_INST_INT_VAR/COPY: no JIT write barrier for class field stores.
-    // DYN_MTHD_CALL: closure/function-ref parameter handling issues.
-    // MTHD_CALL is supported via ProcessStackCallback + direct JIT-to-JIT calling.
+    // DYN_MTHD_CALL/DYN_MTHD_CALL_JIT: closure/function-ref parameter handling issues.
+    // MTHD_CALL_JIT: arm64 direct JIT-to-JIT call codegen miscompiles a path
+    //   exercised by analyzer's FindReferences-on-class (lsp_features regression
+    //   crashes on linux-arm64 + macos-arm64; windows-arm64 + x64 unaffected).
+    //   Until the arm64 MTHD_CALL_JIT codegen is fixed, reject methods that
+    //   contain calls to already-JIT'd callees so they fall back to interpreted.
+    //   MTHD_CALL is already rejected by the common pre-scan in jit_common.cpp.
     // Note: STOR_INT_ARY_ELM is safe — integer array stores don't hold references.
     for(long i = 0; i < method->GetInstructionCount(); ++i) {
       const InstructionType type = method->GetInstruction(i)->GetType();
       if(type == STOR_CLS_INST_INT_VAR || type == COPY_CLS_INST_INT_VAR ||
+         type == MTHD_CALL_JIT ||
          type == DYN_MTHD_CALL || type == DYN_MTHD_CALL_JIT) {
         return false;
       }

--- a/core/vm/arch/jit/arm64/jit_arm_a64.cpp
+++ b/core/vm/arch/jit/arm64/jit_arm_a64.cpp
@@ -4697,6 +4697,137 @@ void JitArm64::ProcessIndices()
 #endif
 }
 
+// Whitelist of instructions the ARM64 JIT can safely emit. Must match the
+// cases handled by ProcessInstruction (the switch's default fatally exits).
+static bool CanJitInstruction(InstructionType type) {
+  switch(type) {
+    // loads
+  case LOAD_CHAR_LIT:
+  case LOAD_INT_LIT:
+  case LOAD_FLOAT_LIT:
+  case LOAD_INST_MEM:
+  case LOAD_CLS_MEM:
+  case LOAD_LOCL_INT_VAR:
+  case LOAD_CLS_INST_INT_VAR:
+  case LOAD_FLOAT_VAR:
+  case LOAD_FUNC_VAR:
+    // stores (STOR_CLS_INST_INT_VAR rejected — no write barrier)
+  case STOR_LOCL_INT_VAR:
+  case STOR_FLOAT_VAR:
+  case STOR_FUNC_VAR:
+    // copies (COPY_CLS_INST_INT_VAR rejected — no write barrier)
+  case COPY_LOCL_INT_VAR:
+  case COPY_FLOAT_VAR:
+    // int math
+  case AND_INT:
+  case OR_INT:
+  case ADD_INT:
+  case SUB_INT:
+  case MUL_INT:
+  case DIV_INT:
+  case MOD_INT:
+  case BIT_AND_INT:
+  case BIT_OR_INT:
+  case BIT_XOR_INT:
+  case BIT_NOT_INT:
+  case SHL_INT:
+  case SHR_INT:
+    // int compare
+  case LES_INT:
+  case GTR_INT:
+  case LES_EQL_INT:
+  case GTR_EQL_INT:
+  case EQL_INT:
+  case NEQL_INT:
+    // float math
+  case ADD_FLOAT:
+  case SUB_FLOAT:
+  case MUL_FLOAT:
+  case DIV_FLOAT:
+  case SIN_FLOAT:
+  case COS_FLOAT:
+  case TAN_FLOAT:
+  case ASIN_FLOAT:
+  case ACOS_FLOAT:
+  case ATAN_FLOAT:
+  case ACOSH_FLOAT:
+  case ASINH_FLOAT:
+  case ATANH_FLOAT:
+  case COSH_FLOAT:
+  case SINH_FLOAT:
+  case TANH_FLOAT:
+  case CBRT_FLOAT:
+  case LOG_FLOAT:
+  case EXP_FLOAT:
+  case TRUNC_FLOAT:
+  case GAMMA_FLOAT:
+  case ROUND_FLOAT:
+  case FLOR_FLOAT:
+  case CEIL_FLOAT:
+  case SQRT_FLOAT:
+  case POW_FLOAT:
+  case MOD_FLOAT:
+  case RAND_FLOAT:
+    // float compare
+  case LES_FLOAT:
+  case GTR_FLOAT:
+  case LES_EQL_FLOAT:
+  case GTR_EQL_FLOAT:
+  case EQL_FLOAT:
+  case NEQL_FLOAT:
+    // control flow (DYN_MTHD_CALL/DYN_MTHD_CALL_JIT rejected — closure issues)
+  case MTHD_CALL:
+  case MTHD_CALL_JIT:
+  case JMP:
+  case LBL:
+  case RTRN:
+    // memory allocation
+  case NEW_BYTE_ARY:
+  case NEW_CHAR_ARY:
+  case NEW_INT_ARY:
+  case NEW_FLOAT_ARY:
+  case NEW_OBJ_INST:
+    // array copy/zero
+  case CPY_BYTE_ARY:
+  case CPY_CHAR_ARY:
+  case CPY_INT_ARY:
+  case CPY_FLOAT_ARY:
+  case ZERO_BYTE_ARY:
+  case ZERO_CHAR_ARY:
+  case ZERO_INT_ARY:
+  case ZERO_FLOAT_ARY:
+    // array access
+  case LOAD_BYTE_ARY_ELM:
+  case LOAD_CHAR_ARY_ELM:
+  case LOAD_INT_ARY_ELM:
+  case LOAD_FLOAT_ARY_ELM:
+  case STOR_BYTE_ARY_ELM:
+  case STOR_CHAR_ARY_ELM:
+  case STOR_INT_ARY_ELM:
+  case STOR_FLOAT_ARY_ELM:
+  case LOAD_ARY_SIZE:
+    // traps
+  case TRAP:
+  case TRAP_RTRN:
+    // casting
+  case OBJ_TYPE_OF:
+  case OBJ_INST_CAST:
+    // threading
+  case THREAD_JOIN:
+  case THREAD_SLEEP:
+  case CRITICAL_START:
+  case CRITICAL_END:
+    // stack
+  case SWAP_INT:
+  case POP_INT:
+  case POP_FLOAT:
+    return true;
+
+  default:
+    return false;
+  }
+}
+
 //
 // translate bytecode to machine code
 //
@@ -4711,15 +4842,19 @@ bool JitArm64::Compile(StackMethod* cm)
     last_cmp_was_zero = false;
     last_cmp_reg = X0;  // Initialize to a valid register
 
-    // Pre-scan: reject methods with unsupported instructions.
-    // STOR_CLS_INST_INT_VAR/COPY: no JIT write barrier for class field stores.
-    // DYN_MTHD_CALL: closure/function-ref parameter handling issues.
-    // MTHD_CALL is supported via ProcessStackCallback + direct JIT-to-JIT calling.
-    // Note: STOR_INT_ARY_ELM is safe — integer array stores don't hold references.
+    // Pre-scan: reject methods the JIT cannot safely compile. The default
+    // branch in ProcessInstruction calls exit(1) on any unhandled opcode, so
+    // anything not in the supported set below MUST be rejected here. Three
+    // implemented instructions are also rejected for correctness:
+    //   STOR_CLS_INST_INT_VAR / COPY_CLS_INST_INT_VAR — no JIT write barrier
+    //     for class field stores.
+    //   DYN_MTHD_CALL / DYN_MTHD_CALL_JIT — closure/function-ref parameter
+    //     handling issues.
+    // MTHD_CALL is supported via ProcessStackCallback + direct JIT-to-JIT
+    // calling. STOR_INT_ARY_ELM is safe — integer array stores don't hold
+    // references.
     for(long i = 0; i < method->GetInstructionCount(); ++i) {
-      const InstructionType type = method->GetInstruction(i)->GetType();
-      if(type == STOR_CLS_INST_INT_VAR || type == COPY_CLS_INST_INT_VAR ||
-         type == DYN_MTHD_CALL || type == DYN_MTHD_CALL_JIT) {
+      if(!CanJitInstruction(method->GetInstruction(i)->GetType())) {
         return false;
       }
     }

--- a/core/vm/arch/jit/arm64/jit_arm_a64.cpp
+++ b/core/vm/arch/jit/arm64/jit_arm_a64.cpp
@@ -4713,18 +4713,12 @@ bool JitArm64::Compile(StackMethod* cm)
 
     // Pre-scan: reject methods with unsupported instructions.
     // STOR_CLS_INST_INT_VAR/COPY: no JIT write barrier for class field stores.
-    // DYN_MTHD_CALL/DYN_MTHD_CALL_JIT: closure/function-ref parameter handling issues.
-    // MTHD_CALL_JIT: arm64 direct JIT-to-JIT call codegen miscompiles a path
-    //   exercised by analyzer's FindReferences-on-class (lsp_features regression
-    //   crashes on linux-arm64 + macos-arm64; windows-arm64 + x64 unaffected).
-    //   Until the arm64 MTHD_CALL_JIT codegen is fixed, reject methods that
-    //   contain calls to already-JIT'd callees so they fall back to interpreted.
-    //   MTHD_CALL is already rejected by the common pre-scan in jit_common.cpp.
+    // DYN_MTHD_CALL: closure/function-ref parameter handling issues.
+    // MTHD_CALL is supported via ProcessStackCallback + direct JIT-to-JIT calling.
     // Note: STOR_INT_ARY_ELM is safe — integer array stores don't hold references.
     for(long i = 0; i < method->GetInstructionCount(); ++i) {
       const InstructionType type = method->GetInstruction(i)->GetType();
       if(type == STOR_CLS_INST_INT_VAR || type == COPY_CLS_INST_INT_VAR ||
-         type == MTHD_CALL_JIT ||
          type == DYN_MTHD_CALL || type == DYN_MTHD_CALL_JIT) {
         return false;
       }

--- a/core/vm/arch/jit/arm64/jit_arm_a64.h
+++ b/core/vm/arch/jit/arm64/jit_arm_a64.h
@@ -626,25 +626,17 @@ namespace Runtime {
       used_fregs.remove(h);
     }
 
-    // Caches a register holding a local variable value (by frame offset).
-    void CacheLocalRegister(long offset, RegisterHolder* h) {
-      auto it = local_reg_cache.find(offset);
-      if(it != local_reg_cache.end()) {
-        ReleaseRegister(it->second);
-        local_reg_cache.erase(it);
-      }
-      used_regs.remove(h);
-      local_reg_cache[offset] = h;
+    // Local register cache (added by fd2248b4b) is currently disabled on arm64
+    // pending a fix for a stale-cache bug that crashes FindReferences-on-class
+    // in lsp_features regression on linux-arm64 + macos-arm64. Cache miss path
+    // is the safe pre-cache behavior. Re-enable by restoring the original
+    // bodies once the missing invalidation point is identified.
+    void CacheLocalRegister(long /*offset*/, RegisterHolder* h) {
+      ReleaseRegister(h);
     }
 
-    void CacheLocalFpRegister(long offset, RegisterHolder* h) {
-      auto it = local_freg_cache.find(offset);
-      if(it != local_freg_cache.end()) {
-        ReleaseFpRegister(it->second);
-        local_freg_cache.erase(it);
-      }
-      used_fregs.remove(h);
-      local_freg_cache[offset] = h;
+    void CacheLocalFpRegister(long /*offset*/, RegisterHolder* h) {
+      ReleaseFpRegister(h);
     }
 
     // Releases all cached registers back to their pools.

--- a/core/vm/arch/jit/arm64/jit_arm_a64.h
+++ b/core/vm/arch/jit/arm64/jit_arm_a64.h
@@ -626,17 +626,25 @@ namespace Runtime {
       used_fregs.remove(h);
     }
 
-    // Local register cache (added by fd2248b4b) is currently disabled on arm64
-    // pending a fix for a stale-cache bug that crashes FindReferences-on-class
-    // in lsp_features regression on linux-arm64 + macos-arm64. Cache miss path
-    // is the safe pre-cache behavior. Re-enable by restoring the original
-    // bodies once the missing invalidation point is identified.
-    void CacheLocalRegister(long /*offset*/, RegisterHolder* h) {
-      ReleaseRegister(h);
+    // Caches a register holding a local variable value (by frame offset).
+    void CacheLocalRegister(long offset, RegisterHolder* h) {
+      auto it = local_reg_cache.find(offset);
+      if(it != local_reg_cache.end()) {
+        ReleaseRegister(it->second);
+        local_reg_cache.erase(it);
+      }
+      used_regs.remove(h);
+      local_reg_cache[offset] = h;
     }
 
-    void CacheLocalFpRegister(long /*offset*/, RegisterHolder* h) {
-      ReleaseFpRegister(h);
+    void CacheLocalFpRegister(long offset, RegisterHolder* h) {
+      auto it = local_freg_cache.find(offset);
+      if(it != local_freg_cache.end()) {
+        ReleaseFpRegister(it->second);
+        local_freg_cache.erase(it);
+      }
+      used_fregs.remove(h);
+      local_freg_cache[offset] = h;
     }
 
     // Releases all cached registers back to their pools.

--- a/programs/regression/lsp_features.obs
+++ b/programs/regression/lsp_features.obs
@@ -4,7 +4,6 @@ use Collection;
 #~
 # LSP features regression test.
 # EXTRA_LIBS: diags,gen_collect
-# JIT_DISABLE
 #
 # Covers: FindReferences, DocumentHighlight, WorkspaceSymbols,
 # TypeHierarchy (Prepare/Supertypes/Subtypes), FindDefinition,

--- a/programs/regression/lsp_features.obs
+++ b/programs/regression/lsp_features.obs
@@ -137,6 +137,8 @@ class LspFeaturesTest {
 		# @name used at L3 (decl), L7 (assign), L12 (return), L20 (local assign)
 		refs := analysis->FindReferences("file:///test.obs", 7, 5, lib_path);
 		Check("FindReferences '@name' at L7: no crash", true);
+		if(refs = Nil) { "  [DBG] refs (FindRef @name L7) = Nil"->PrintLine(); }
+		else { "  [DBG] refs (FindRef @name L7) non-Nil, calling Size..."->PrintLine(); };
 		if(refs <> Nil) {
 			ref_count := refs->Size();
 			Check("FindReferences '@name': multiple refs found", ref_count >= 2);
@@ -151,15 +153,20 @@ class LspFeaturesTest {
 			};
 			Check("FindReferences '@name': all in same file", all_same_file);
 		};
+		Check("post @name FindReferences block: survived", true);
 
 		# @sides at L4 (decl), L8 (assign), L16 (return), L21 (local)
 		refs2 := analysis->FindReferences("file:///test.obs", 8, 5, lib_path);
 		Check("FindReferences '@sides' at L8: no crash", true);
+		if(refs2 = Nil) { "  [DBG] refs2 (FindRef @sides L8) = Nil"->PrintLine(); }
+		else { "  [DBG] refs2 (FindRef @sides L8) non-Nil, calling Size..."->PrintLine(); };
 		if(refs2 <> Nil) {
 			Check("FindReferences '@sides': multiple refs found", refs2->Size() >= 2);
 		};
+		Check("post @sides FindReferences block: survived", true);
 
 		# Shape class name
+		"  [DBG] about to FindRef Shape class L2"->PrintLine();
 		refs3 := analysis->FindReferences("file:///test.obs", 2, 6, lib_path);
 		Check("FindReferences 'Shape' class at L2: no crash", true);
 

--- a/programs/regression/run_regression.sh
+++ b/programs/regression/run_regression.sh
@@ -88,7 +88,7 @@ for test in *.obs; do
         ((PASS_COUNT++))
     else
         echo "  [FAIL] Runtime error"
-        cat "$RESULTS_DIR/${NAME}_output.txt" 2>/dev/null | head -20
+        cat "$RESULTS_DIR/${NAME}_output.txt" 2>/dev/null | head -200
         ((FAIL_COUNT++))
     fi
 done


### PR DESCRIPTION
Diagnostic-only PR. **Do not merge.**

Companion to the workaround landed in 07cf80056. This branch:
- Removes `# JIT_DISABLE` from `lsp_features.obs` so arm64 crashes again.
- Bumps the runner's failure log capture from `head -20` to `head -200` so the full sequence of `[PASS]` lines is visible in the CI log.

Goal: identify which analyzer call is the last one to print `[PASS]` before the arm64 VM crashes. The next call is the suspect for the arm64 JIT miscompile.

Will be closed once we have the bisect result.