### PR TITLE
perf(ci): native cross-language perf gate (P3)

### DIFF
--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -1,0 +1,111 @@
+name: Perf Gate
+
+# Native (non-Docker) cross-language perf gate. Builds Objeck on the runner and
+# runs it head-to-head against Java (HotSpot) and LuaJIT in one pass, then checks
+# the Objeck-vs-peer time ratios against a committed baseline. Ratios on the same
+# run cancel CI machine noise, so a relative regression (like the GC-safepoint
+# one) is caught regardless of how fast the runner is.
+#
+# Rollout: currently REPORT-ONLY (--no-fail) because the committed baseline is an
+# approximation from a dev box. To enforce hard failures: run this workflow once,
+# download the "perf-baseline-measured" artifact, commit it as
+# perf-results/perf_baseline.json, then remove the `--no-fail` flag below.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'core/vm/**'
+      - 'core/compiler/**'
+      - 'core/shared/**'
+      - 'perf-results/**'
+      - '.github/workflows/perf-gate.yml'
+  pull_request:
+    paths:
+      - 'core/vm/**'
+      - 'core/compiler/**'
+      - 'core/shared/**'
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: 'Runs per benchmark'
+        required: false
+        default: '3'
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  perf-gate:
+    name: Perf gate (linux-x64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install build deps + peer runtimes
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential libmbedtls-dev libnghttp2-dev libngtcp2-dev \
+            libngtcp2-crypto-gnutls-dev libnghttp3-dev libgnutls28-dev \
+            zlib1g-dev libreadline-dev ccache bc \
+            default-jdk-headless luajit
+
+      - name: Cache ccache
+        uses: actions/cache@v5
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-perfgate-ccache-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-perfgate-ccache-
+
+      - name: Setup ccache
+        run: ccache --max-size=500M && ccache --set-config=compression=true
+
+      - name: Build Objeck (obc + obr)
+        working-directory: core/vm
+        env: { CC: ccache gcc, CXX: ccache g++ }
+        run: |
+          cp make/Makefile.amd64 Makefile
+          make -j$(nproc)
+          # compiler too
+          cd ../compiler
+          cp make/Makefile.amd64 Makefile
+          make -j$(nproc) OBJECK_LIB_PATH=///".///"
+
+      - name: Assemble minimal bin dir (obc, obr, libs)
+        id: bindir
+        run: |
+          BIN=/tmp/objk/bin
+          mkdir -p "$BIN"
+          cp core/compiler/obc core/vm/obr "$BIN"/
+          cp core/lib/*.obl "$BIN"/ 2>/dev/null || true
+          cp core/lib/*.ini "$BIN"/ 2>/dev/null || true
+          chmod +x "$BIN"/obc "$BIN"/obr
+          "$BIN"/obc -version | head -1 || true
+          echo "dir=$BIN" >> $GITHUB_OUTPUT
+
+      - name: Run native cross-language harness
+        run: |
+          bash perf-results/cross-lang/run_native.sh \
+            "${{ steps.bindir.outputs.dir }}" /tmp/perf.csv "${{ github.event.inputs.runs || '3' }}"
+          echo "---- results ----"; cat /tmp/perf.csv
+
+      - name: Perf gate (report-only for now)
+        run: |
+          # report into the job summary; --no-fail until a CI-measured baseline is committed
+          python3 perf-results/check_perf_gate.py /tmp/perf.csv --no-fail --summary "$GITHUB_STEP_SUMMARY"
+
+      - name: Produce CI-measured baseline (for committing)
+        run: |
+          cp perf-results/perf_baseline.json /tmp/perf_baseline.prev.json 2>/dev/null || true
+          python3 perf-results/check_perf_gate.py /tmp/perf.csv --update-baseline --baseline /tmp/perf_baseline.measured.json
+
+      - name: Upload results + measured baseline
+        uses: actions/upload-artifact@v6
+        with:
+          name: perf-gate-results
+          path: |
+            /tmp/perf.csv
+            /tmp/perf_baseline.measured.json
+          retention-days: 90

--- a/perf-results/PERF_GATE.md
+++ b/perf-results/PERF_GATE.md
@@ -1,0 +1,45 @@
+# Perf Gate — native cross-language regression check
+
+Catches **relative** performance regressions (the GC-safepoint one shipped
+unnoticed because nothing compared releases head-to-head). It runs Objeck against
+the fast peer JITs — **Java (HotSpot)** and **LuaJIT** — natively on one machine
+and gates on the **Objeck-vs-peer time ratios**. Ratios on the same run cancel
+machine noise, so the check is meaningful even on a shared/variable CI runner
+where absolute times wander 2–3×.
+
+## Pieces
+
+- `cross-lang/run_native.sh <objeck_bin_dir> <out.csv> [runs] [--with-scripting]`
+  — compiles + times Objeck CLBG benchmarks and the Java/LuaJIT equivalents
+  (sources in `cross-lang/benchmarks/`), CI-scaled inputs. `--with-scripting`
+  adds Python/Ruby (slow; off by default).
+- `check_perf_gate.py RESULTS.csv` — median per (lang, benchmark) → Objeck/Java
+  and Objeck/LuaJIT ratios → compared to `perf_baseline.json`. Warns at
+  >+15%, fails at >+30% (ratio worsening). `--update-baseline` regenerates the
+  baseline; `--no-fail` reports without failing; `--summary FILE` appends a
+  Markdown table (used for the GitHub job summary).
+- `perf_baseline.json` — committed baseline ratios (lower = Objeck faster).
+- `.github/workflows/perf-gate.yml` — runs on push to `master` and on PRs that
+  touch `core/vm` / `core/compiler` / `core/shared`, plus manual dispatch.
+
+## Run locally
+
+```bash
+# build obc/obr first, then point at the bin dir:
+bash perf-results/cross-lang/run_native.sh core/release/deploy-x64/bin /tmp/perf.csv 3
+python3 perf-results/check_perf_gate.py /tmp/perf.csv
+```
+
+## Enabling hard enforcement
+
+The workflow currently runs **report-only** (`--no-fail`) because the committed
+baseline is an approximation from a dev box. To turn on hard failures:
+
+1. Trigger **Perf Gate** once (Actions → Run workflow).
+2. Download the `perf-gate-results` artifact → `perf_baseline.measured.json`.
+3. Commit it as `perf-results/perf_baseline.json`.
+4. Remove the `--no-fail` flag from the "Perf gate" step in `perf-gate.yml`.
+
+After that a relative regression beyond the threshold fails the check. Refresh
+the baseline the same way after any *intended* perf change (e.g. a new
+optimization that shifts the ratios on purpose).

--- a/perf-results/check_perf_gate.py
+++ b/perf-results/check_perf_gate.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Perf gate: compare Objeck-vs-peer ratios against a committed baseline.
+
+Reads a cross-language results CSV (language,benchmark,run,time_seconds), takes
+the median time per (language,benchmark), and computes Objeck/peer ratios
+(objeck/java, objeck/luajit). Ratios on the *same* run cancel CI machine noise,
+so they are the gate signal — a regression like the GC-safepoint one shows up as
+Objeck getting relatively slower vs Java/LuaJIT, regardless of runner speed.
+
+Usage:
+  check_perf_gate.py RESULTS.csv [--baseline perf_baseline.json]
+                                 [--warn PCT] [--fail PCT]
+                                 [--update-baseline] [--no-fail] [--summary FILE]
+
+Exit code: 0 if within tolerance (or --no-fail / --update-baseline), 1 on a
+ratio regression beyond --fail.
+"""
+import argparse, csv, json, os, statistics, sys
+
+PEERS = ["java", "luajit"]
+
+
+def load_medians(path):
+    rows = {}
+    with open(path) as f:
+        for r in csv.DictReader(f):
+            rows.setdefault((r["language"], r["benchmark"]), []).append(float(r["time_seconds"]))
+    return {k: statistics.median(v) for k, v in rows.items() if v}
+
+
+def compute_ratios(med):
+    benches = sorted({b for (lang, b) in med if lang == "objeck"})
+    ratios = {}
+    for peer in PEERS:
+        rp = {}
+        for b in benches:
+            o = med.get(("objeck", b)); p = med.get((peer, b))
+            if o and p and p > 0:
+                rp[b] = round(o / p, 4)
+        if rp:
+            ratios[f"objeck/{peer}"] = rp
+    return ratios
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("results")
+    ap.add_argument("--baseline", default=os.path.join(os.path.dirname(__file__), "perf_baseline.json"))
+    ap.add_argument("--warn", type=float, default=15.0, help="warn if ratio worsens >PCT%%")
+    ap.add_argument("--fail", type=float, default=30.0, help="fail if ratio worsens >PCT%%")
+    ap.add_argument("--update-baseline", action="store_true")
+    ap.add_argument("--no-fail", action="store_true", help="report but never exit non-zero")
+    ap.add_argument("--summary", default=os.environ.get("GITHUB_STEP_SUMMARY"))
+    args = ap.parse_args()
+
+    med = load_medians(args.results)
+    cur = compute_ratios(med)
+
+    if args.update_baseline:
+        with open(args.baseline, "w") as f:
+            json.dump({"ratios": cur, "note": "Objeck/peer median-time ratios; lower is better. Refresh on a quiet CI runner after an intended perf change."}, f, indent=2)
+            f.write("\n")
+        print(f"Wrote baseline {args.baseline}")
+        return 0
+
+    base = {}
+    if os.path.exists(args.baseline):
+        base = json.load(open(args.baseline)).get("ratios", {})
+
+    lines = ["## Perf gate - Objeck vs peer ratios (lower = Objeck faster)", ""]
+    lines.append("| Pair | Benchmark | Baseline | Current | Change | Status |")
+    lines.append("|------|-----------|----------|---------|---|--------|")
+    worst = 0.0
+    failed = []
+    have_base = bool(base)
+    for pair in sorted(cur):
+        for b in sorted(cur[pair]):
+            c = cur[pair][b]
+            bl = base.get(pair, {}).get(b)
+            if bl is None:
+                lines.append(f"| {pair} | {b} | - | {c:.3f} | - | new |")
+                continue
+            pct = (c - bl) / bl * 100.0
+            worst = max(worst, pct)
+            if pct > args.fail:
+                st = "FAIL"; failed.append(f"{pair} {b}: {bl:.3f}->{c:.3f} (+{pct:.1f}%)")
+            elif pct > args.warn:
+                st = "warn"
+            elif pct < -args.warn:
+                st = "faster"
+            else:
+                st = "ok"
+            lines.append(f"| {pair} | {b} | {bl:.3f} | {c:.3f} | {pct:+.1f}% | {st} |")
+
+    if not have_base:
+        lines += ["", "_No baseline committed yet — run with `--update-baseline` on a CI runner and commit `perf_baseline.json`._"]
+    lines += ["", f"Thresholds: warn > +{args.warn:.0f}%, fail > +{args.fail:.0f}% (ratio worsening). Worst delta: {worst:+.1f}%."]
+
+    report = "\n".join(lines)
+    print(report)
+    if args.summary:
+        with open(args.summary, "a") as f:
+            f.write(report + "\n")
+
+    if failed and have_base and not args.no_fail:
+        print("\nPERF GATE FAILED:")
+        for x in failed:
+            print("  - " + x)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/perf-results/cross-lang/run_native.sh
+++ b/perf-results/cross-lang/run_native.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Native (non-Docker) cross-language benchmark harness.
+#
+# Runs Objeck head-to-head against the fast peer JITs (Java/HotSpot, LuaJIT) on
+# the SAME machine in one pass, so the Objeck-vs-peer ratios are directly
+# comparable and machine-noise-resistant. Python/Ruby are optional (slow) and
+# off by default so this stays fast enough for CI.
+#
+# Usage:
+#   run_native.sh <objeck_bin_dir> <out_csv> [runs] [--with-scripting]
+#
+#   <objeck_bin_dir>  dir containing obc/obr (e.g. core/release/deploy-x64/bin)
+#   <out_csv>         output CSV path (language,benchmark,run,time_seconds)
+#   [runs]            runs per benchmark (default 3)
+#   --with-scripting  also run Python3 + Ruby (slow; off by default)
+#
+# Benchmarks + inputs are CI-scaled (each language stays well under ~20s/run).
+set -u
+
+BIN_DIR="${1:?objeck bin dir required}"
+OUT_CSV="${2:?output csv path required}"
+RUNS="${3:-3}"
+WITH_SCRIPTING=0
+for a in "$@"; do [ "$a" = "--with-scripting" ] && WITH_SCRIPTING=1; done
+
+OBC="$BIN_DIR/obc"
+OBR="$BIN_DIR/obr"
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_OBJ="$SELF_DIR/../../programs/tests/clbg"   # Objeck CLBG sources
+SRC_X="$SELF_DIR/benchmarks"                     # cross-language sources
+TMP="$(mktemp -d)"
+JOUT="$TMP/java"; mkdir -p "$JOUT"
+
+# benchmark -> CI-scaled input (kept small enough that even LuaJIT fannkuch and
+# the Objeck interpreter spectralnorm finish quickly on a CI runner)
+declare -A ARG=( [nbody]=50000000 [fannkuchredux]=11 [spectralnorm]=2000 [binarytrees]=15 [mandelbrot]=4000 )
+BENCHES="nbody fannkuchredux spectralnorm binarytrees mandelbrot"
+
+echo "language,benchmark,run,time_seconds" > "$OUT_CSV"
+
+echo "============================================="
+echo "  Native cross-language benchmark harness"
+echo "  Objeck: $($OBC 2>&1 | head -1)"
+command -v java  >/dev/null && echo "  Java:   $(java -version 2>&1 | head -1)"
+command -v luajit>/dev/null && echo "  LuaJIT: $(luajit -v 2>&1 | head -1)"
+echo "  Runs:   $RUNS"
+echo "============================================="
+
+# time a command, append median-friendly per-run rows to the CSV
+time_runs() { # lang name cmd...
+  local lang="$1" name="$2"; shift 2
+  echo "=== $lang: $name (${ARG[$name]}) ==="
+  for r in $(seq 1 "$RUNS"); do
+    local s e ms sec
+    s=$(date +%s%N); "$@" >/dev/null 2>&1; e=$(date +%s%N)
+    ms=$(( (e - s) / 1000000 )); sec=$(awk "BEGIN{printf \"%.3f\", $ms/1000}")
+    echo "  run $r: ${sec}s"
+    echo "$lang,$name,$r,$sec" >> "$OUT_CSV"
+  done
+}
+
+# ---- Objeck (compile once per benchmark, then time obr) ----
+for b in $BENCHES; do
+  libflag=""; [ "$b" = "binarytrees" ] && libflag="-lib gen_collect"
+  "$OBC" -src "$SRC_OBJ/$b.obs" $libflag -opt s3 -dest "$TMP/$b.obe" >/dev/null 2>&1
+  if [ -f "$TMP/$b.obe" ]; then time_runs objeck "$b" "$OBR" "$TMP/$b.obe" "${ARG[$b]}"
+  else echo "=== objeck: $b SKIP (compile failed) ==="; fi
+done
+
+# ---- Java (HotSpot): compile once, time the run (excludes javac) ----
+if command -v javac >/dev/null && command -v java >/dev/null; then
+  for b in nbody fannkuchredux spectralnorm binarytrees; do
+    [ -f "$SRC_X/$b.java" ] && javac -d "$JOUT" "$SRC_X/$b.java" 2>/dev/null
+  done
+  for b in nbody fannkuchredux spectralnorm binarytrees; do
+    [ -f "$JOUT/$b.class" ] && time_runs java "$b" java -cp "$JOUT" "$b" "${ARG[$b]}"
+  done
+fi
+
+# ---- LuaJIT ----
+if command -v luajit >/dev/null; then
+  for b in nbody fannkuchredux spectralnorm binarytrees; do
+    [ -f "$SRC_X/$b.lua" ] && time_runs luajit "$b" luajit "$SRC_X/$b.lua" "${ARG[$b]}"
+  done
+fi
+
+# ---- Python / Ruby (optional, slow) ----
+if [ "$WITH_SCRIPTING" = "1" ]; then
+  command -v python3 >/dev/null && for b in nbody fannkuchredux spectralnorm binarytrees; do
+    [ -f "$SRC_X/$b.py" ] && time_runs python3 "$b" python3 "$SRC_X/$b.py" "${ARG[$b]}"
+  done
+  command -v ruby >/dev/null && for b in nbody fannkuchredux spectralnorm binarytrees; do
+    [ -f "$SRC_X/$b.rb" ] && time_runs ruby "$b" ruby "$SRC_X/$b.rb" "${ARG[$b]}"
+  done
+fi
+
+rm -rf "$TMP"
+echo "Wrote $OUT_CSV"

--- a/perf-results/perf_baseline.json
+++ b/perf-results/perf_baseline.json
@@ -1,0 +1,17 @@
+{
+  "ratios": {
+    "objeck/java": {
+      "binarytrees": 32.4583,
+      "fannkuchredux": 1.4888,
+      "nbody": 7.6957,
+      "spectralnorm": 36.8462
+    },
+    "objeck/luajit": {
+      "binarytrees": 2.3323,
+      "fannkuchredux": 0.262,
+      "nbody": 4.1163,
+      "spectralnorm": 38.8378
+    }
+  },
+  "note": "Objeck/peer median-time ratios; lower is better. Refresh on a quiet CI runner after an intended perf change."
+}


### PR DESCRIPTION
**P3 of the speedup roadmap** — a native (non-Docker) head-to-head perf harness + automatic regression gate, so relative regressions like the GC-safepoint one are caught instead of shipping unnoticed.

## How it works
Runs Objeck against the fast peer JITs (**Java/HotSpot**, **LuaJIT**) natively on one runner and gates on the **Objeck-vs-peer time ratios**. Ratios on the same run cancel CI machine noise, so the signal holds even when absolute times wander 2–3× across runners.

## Pieces
- `perf-results/cross-lang/run_native.sh` — compiles + times Objeck CLBG + Java/LuaJIT (CI-scaled inputs; Python/Ruby optional via `--with-scripting`).
- `perf-results/check_perf_gate.py` — medians → Objeck/Java & Objeck/LuaJIT ratios vs `perf_baseline.json`; warn >+15%, fail >+30%. Validated locally: flags a simulated +60% fannkuch regression, `--no-fail`/`--update-baseline` work.
- `perf-results/perf_baseline.json` — seed ratios (dev-box approximation).
- `.github/workflows/perf-gate.yml` — runs on master push + PRs touching `core/vm`/`core/compiler`/`core/shared` + manual dispatch.

## Rollout
Ships **report-only** (`--no-fail`) since the baseline is a dev-box approximation. Each run uploads a CI-measured baseline; commit it and drop `--no-fail` to enforce hard failures (see `perf-results/PERF_GATE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)