### PR TITLE
perf(jit): auto-JIT DYN_MTHD_CALL (function-reference/closure calls) on AMD64

### DIFF
--- a/core/compiler/intermediate.cpp
+++ b/core/compiler/intermediate.cpp
@@ -1348,33 +1348,58 @@ void IntermediateEmitter::EmitMethodCallStatement(MethodCall* method_call)
     }      
     imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, LOAD_FUNC_VAR, entry->GetId(), mem_context));
 
-    // emit dynamic call
-    switch(method_call->GetRougeReturn()) {
-    case instructions::INT_TYPE:
-      imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, DYN_MTHD_CALL, entry->GetType()->GetFunctionParameterCount(), instructions::INT_TYPE));
-      if(!method_call->GetMethodCall()) {
-        imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, POP_INT));
+    // Determine the func-ref's ACTUAL return type for the DYN_MTHD_CALL operand2.
+    // GetRougeReturn() is only set for standalone calls (it stays NIL in
+    // assignment / return / expression context), but the JIT relies on operand2
+    // to marshal the call result; a wrong NIL there underflows the JIT working
+    // stack. The interpreter ignores operand2, so this is safe for it. The POP
+    // (result-discard) logic below stays keyed on GetRougeReturn() unchanged.
+    instructions::MemoryType dyn_rtrn = instructions::NIL_TYPE;
+    Type* dyn_fret = entry->GetType() ? entry->GetType()->GetFunctionReturn() : nullptr;
+    if(dyn_fret && dyn_fret->GetType() != frontend::NIL_TYPE) {
+      if(dyn_fret->GetDimension() > 0) {
+        dyn_rtrn = instructions::INT_TYPE;
       }
-      break;
-  
-    case instructions::FLOAT_TYPE:
-      imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, DYN_MTHD_CALL, entry->GetType()->GetFunctionParameterCount(), instructions::FLOAT_TYPE));
-      if(!method_call->GetMethodCall()) {
+      else {
+        switch(dyn_fret->GetType()) {
+        case frontend::BOOLEAN_TYPE:
+        case frontend::BYTE_TYPE:
+        case frontend::CHAR_TYPE:
+        case frontend::INT_TYPE:
+        case frontend::CLASS_TYPE:
+          dyn_rtrn = instructions::INT_TYPE;
+          break;
+        case frontend::FLOAT_TYPE:
+          dyn_rtrn = instructions::FLOAT_TYPE;
+          break;
+        case frontend::FUNC_TYPE:
+          dyn_rtrn = instructions::FUNC_TYPE;
+          break;
+        default:
+          break;
+        }
+      }
+    }
+
+    // emit dynamic call (operand2 = real return type so the JIT can marshal it)
+    imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, DYN_MTHD_CALL, entry->GetType()->GetFunctionParameterCount(), dyn_rtrn));
+
+    // discard the result for standalone calls (rogue return is only set then)
+    if(!method_call->GetMethodCall()) {
+      switch(method_call->GetRougeReturn()) {
+      case instructions::INT_TYPE:
+        imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, POP_INT));
+        break;
+      case instructions::FLOAT_TYPE:
         imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, POP_FLOAT));
-      }
-      break;
-  
-    case instructions::FUNC_TYPE:
-      imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, DYN_MTHD_CALL, entry->GetType()->GetFunctionParameterCount(), instructions::FUNC_TYPE));
-      if(!method_call->GetMethodCall()) {
+        break;
+      case instructions::FUNC_TYPE:
         imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, POP_INT));
-        imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, POP_INT));  
+        imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, POP_INT));
+        break;
+      default:
+        break;
       }
-      break;
-  
-    default:
-      imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, DYN_MTHD_CALL, entry->GetType()->GetFunctionParameterCount(), instructions::NIL_TYPE));
-      break;
     }
 
     // check nesting
@@ -4060,34 +4085,56 @@ void IntermediateEmitter::EmitMethodCallExpression(MethodCall* method_call, bool
     }      
     imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(current_statement, static_cast<Expression*>(method_call), cur_line_num, LOAD_FUNC_VAR, entry->GetId(), mem_context));
     
-    switch(method_call->GetRougeReturn()) {
-    case instructions::INT_TYPE:
-      imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(current_statement, static_cast<Expression*>(method_call), cur_line_num, DYN_MTHD_CALL, entry->GetType()->GetFunctionParameterCount(), instructions::INT_TYPE));
-      if(!method_call->GetMethodCall()) {
-        imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, POP_INT));
+    // operand2 = the func-ref's ACTUAL return type (GetRougeReturn() is NIL in
+    // assignment/expression context, but the JIT needs the real type to marshal
+    // the result; the interpreter ignores operand2). POP-discard logic below
+    // stays keyed on GetRougeReturn() unchanged. Mirrors the fix at the other
+    // functional-call emission site.
+    instructions::MemoryType dyn_rtrn = instructions::NIL_TYPE;
+    Type* dyn_fret = entry->GetType() ? entry->GetType()->GetFunctionReturn() : nullptr;
+    if(dyn_fret && dyn_fret->GetType() != frontend::NIL_TYPE) {
+      if(dyn_fret->GetDimension() > 0) {
+        dyn_rtrn = instructions::INT_TYPE;
       }
-      break;
-  
-    case instructions::FLOAT_TYPE:
-      imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(current_statement, static_cast<Expression*>(method_call), cur_line_num, DYN_MTHD_CALL, entry->GetType()->GetFunctionParameterCount(), instructions::FLOAT_TYPE));
-      if(!method_call->GetMethodCall()) {
-        imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, POP_FLOAT));
+      else {
+        switch(dyn_fret->GetType()) {
+        case frontend::BOOLEAN_TYPE:
+        case frontend::BYTE_TYPE:
+        case frontend::CHAR_TYPE:
+        case frontend::INT_TYPE:
+        case frontend::CLASS_TYPE:
+          dyn_rtrn = instructions::INT_TYPE;
+          break;
+        case frontend::FLOAT_TYPE:
+          dyn_rtrn = instructions::FLOAT_TYPE;
+          break;
+        case frontend::FUNC_TYPE:
+          dyn_rtrn = instructions::FUNC_TYPE;
+          break;
+        default:
+          break;
+        }
       }
-      break;
-
-    case instructions::FUNC_TYPE:
-      imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(current_statement, static_cast<Expression*>(method_call), cur_line_num, DYN_MTHD_CALL, entry->GetType()->GetFunctionParameterCount(), instructions::FUNC_TYPE));
-      if(!method_call->GetMethodCall()) {
-        imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, POP_INT));
-        imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, POP_INT));
-      }
-      break;
-      
-    default:
-      imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(current_statement, static_cast<Expression*>(method_call), cur_line_num, DYN_MTHD_CALL, entry->GetType()->GetFunctionParameterCount(), instructions::NIL_TYPE));
-      break;
     }
-      
+
+    imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(current_statement, static_cast<Expression*>(method_call), cur_line_num, DYN_MTHD_CALL, entry->GetType()->GetFunctionParameterCount(), dyn_rtrn));
+    if(!method_call->GetMethodCall()) {
+      switch(method_call->GetRougeReturn()) {
+      case instructions::INT_TYPE:
+        imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, POP_INT));
+        break;
+      case instructions::FLOAT_TYPE:
+        imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, POP_FLOAT));
+        break;
+      case instructions::FUNC_TYPE:
+        imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, POP_INT));
+        imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, POP_INT));
+        break;
+      default:
+        break;
+      }
+    }
+
     // emit nested calls
     bool is_nested = false; // function call
     method_call = method_call->GetMethodCall();

--- a/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
+++ b/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
@@ -624,11 +624,10 @@ void JitAmd64::ProcessInstructions() {
       break;
 
     case DYN_MTHD_CALL: {
-#ifdef _DEBUG_JIT
-      std::wcout << L"DYN_MTHD_CALL: regs=" << aval_regs.size() << L"," << aux_regs.size() << std::endl;
-#endif  
-      // passing instance variable
-      ProcessStackCallback(DYN_MTHD_CALL, instr, instr_index, instr->GetOperand() + 3);
+      // Working stack at the call = [args..., func-ref word2 (instance), func-ref
+      // word1 (packed cls<<16|mthd)] = operand + 2 entries. (Was +3, over-counting
+      // by one -> ProcessStackCallback marshalled past the stack -> crash.)
+      ProcessStackCallback(DYN_MTHD_CALL, instr, instr_index, instr->GetOperand() + 2);
       ProcessReturnParameters((MemoryType)instr->GetOperand2());
     }
       break;
@@ -5926,8 +5925,8 @@ static bool CanJitInstruction(InstructionType type) {
     // control flow
   case MTHD_CALL:
   case MTHD_CALL_JIT:
-    // DYN_MTHD_CALL: function-reference calls need further investigation
-    // before whitelisting (prgm70/71 segfaults with closure patterns)
+  case DYN_MTHD_CALL:        // P2: function-reference / closure call JIT
+  case DYN_MTHD_CALL_JIT:
   case JMP:
   case LBL:
   case RTRN:

--- a/core/vm/arch/jit/jit_common.cpp
+++ b/core/vm/arch/jit/jit_common.cpp
@@ -65,16 +65,7 @@ bool JitCompiler::TryAutoJitCompile(StackMethod* callee)
     return true;
   }
 
-  // Auto-JIT: skip methods containing DYN_MTHD_CALL (closure parameter
-  // handling issues — prgm70/71 segfault with certain closure patterns).
-  // MTHD_CALL is now allowed: uses ProcessStackCallback the same way
-  // explicit 'native' methods do, which is already proven correct.
-  for(long i = 0; i < callee->GetInstructionCount(); ++i) {
-    if(callee->GetInstruction(i)->GetType() == DYN_MTHD_CALL) {
-      callee->SetJitAttempted();
-      return false;
-    }
-  }
+  // P2: DYN_MTHD_CALL auto-JIT enabled (function-reference/closure calls).
 
 #if defined(_M_ARM64)
   Runtime::JitArm64 jit_compiler;
@@ -154,7 +145,16 @@ void JitCompiler::JitStackCallback(const long instr_id, StackInstr* instr, const
   switch(instr_id) {
   case MTHD_CALL:
   case DYN_MTHD_CALL: {
-    StackMethod* callee = program->GetClass(instr->GetOperand())->GetMethod(instr->GetOperand2());
+    // For DYN_MTHD_CALL the target is the packed func-ref word on the op stack
+    // (cls<<16|mthd), NOT the instr operands (param-count/return-type).
+    StackMethod* callee;
+    if(instr_id == DYN_MTHD_CALL) {
+      const size_t fref = op_stack[(*stack_pos) - 1];
+      callee = program->GetClass((long)((fref >> 16) & 0xFFFF))->GetMethod((long)(fref & 0xFFFF));
+    }
+    else {
+      callee = program->GetClass(instr->GetOperand())->GetMethod(instr->GetOperand2());
+    }
 
 #ifndef _NO_JIT
     // Auto-JIT: compile hot callees from JIT code (no counting overhead)
@@ -166,6 +166,7 @@ void JitCompiler::JitStackCallback(const long instr_id, StackInstr* instr, const
     // without going through the interpreter as a trampoline. This eliminates
     // frame creation + instruction dispatch + MTHD_CALL handler overhead.
     if(callee->GetNativeCode()) {
+      if(instr_id == DYN_MTHD_CALL) { --(*stack_pos); }   // discard func-ref word; instance below
       // Pop instance from op_stack (same as ProcessMethodCall)
       size_t* callee_inst = (size_t*)op_stack[--(*stack_pos)];
 


### PR DESCRIPTION
**P2, sub-item 1** of the JIT speedup roadmap — the gating, deliberately-deferred item. Enables JIT for methods that call through **function references / closures** (`DYN_MTHD_CALL`).

## Headline
**spectralnorm 2000: 43s (interpreter) → 0.52s (JIT)** — closure-heavy float code now JITs.

## Three root causes (all fixed)
1. **Wrong callee in `JitStackCallback`.** The shared `MTHD_CALL`/`DYN_MTHD_CALL` case derived the callee from `instr` operands — but for `DYN_MTHD_CALL` those are param-count/return-type, not class/method ids → garbage pointer → SIGSEGV. The target is the packed func-ref word on the op stack (`cls<<16|mthd`); peek it (don't pop — the deopt fallback needs the stack intact) and discard it before popping the instance. Mirrors `StackInterpreter::ProcessDynamicMethodCall`.
2. **Off-by-one stack marshalling.** Codegen passed `ProcessStackCallback` params `= operand+3`; a func-ref call's working stack is `[args…, func-ref word2 (instance), func-ref word1 (packed)] = operand+2`. The extra count marshalled past the stack → compile-time crash. Now `+2`.
3. **NIL return type.** The compiler set `DYN_MTHD_CALL`'s `operand2` (the JIT's return-type for result marshalling) from `RogueReturn()`, which is NIL in assignment/return/expression context. So `r := f(13)` got a NIL return type → `ProcessReturnParameters(NIL)` pushed no result → JIT working-stack underflow → compile-time crash. Now `operand2` comes from the func-ref's actual return type at both emission sites; the POP-discard logic is unchanged. The interpreter ignores `operand2`, so it's unaffected.

Also removes the auto-JIT exclusion for `DYN_MTHD_CALL` methods and whitelists it in the AMD64 `CanJitInstruction`.

## Validation (x64)
- **157/158 regression** (only the pre-existing `core_opencv`).
- `jit_native_func_ref.obs` **PASS** at default *and* `OBJECK_JIT_THRESHOLD=1`.
- Field / returned / static func-ref repros correct; loop-DYN inside a JIT'd method correct under volume (20M calls); spectralnorm output identical to baseline.

## Scope
AMD64 only. ARM64 is unchanged and safe (its `CanJitInstruction` still excludes `DYN_MTHD_CALL`, so it keeps using the interpreter callback). The compiler fix (#3) is arch-independent and already benefits ARM64 once enabled there; enabling ARM64 + on-device validation is a follow-up. Default auto-JIT threshold leaves spectralnorm at ~10s (warmup); lowering it is a separate tuning question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)