### PR TITLE
perf(interp): inline float fast-path in interpreter dispatch (P2)

### DIFF
--- a/core/vm/interpreter.cpp
+++ b/core/vm/interpreter.cpp
@@ -315,6 +315,69 @@ void StackInterpreter::Execute(size_t* op_stack, size_t* stack_pos, long i, Stac
       continue;
     }
 
+    // float arithmetic (operands bit-stored in op_stack slots; left=sp-1, right=sp-2,
+    // matching AddFloat/SubFloat/MulFloat). DIV_FLOAT is NOT inlined — its
+    // divide-by-zero path needs the recovery check below, same as DIV_INT/MOD_INT.
+    case ADD_FLOAT: {
+      const size_t sp = *stack_pos;
+      *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 2]) =
+        *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 1]) + *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 2]);
+      *stack_pos = sp - 1;
+      continue;
+    }
+    case SUB_FLOAT: {
+      const size_t sp = *stack_pos;
+      *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 2]) =
+        *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 1]) - *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 2]);
+      *stack_pos = sp - 1;
+      continue;
+    }
+    case MUL_FLOAT: {
+      const size_t sp = *stack_pos;
+      *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 2]) =
+        *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 1]) * *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 2]);
+      *stack_pos = sp - 1;
+      continue;
+    }
+
+    // float comparisons (pop 2, push 0/1)
+    case LES_FLOAT: {
+      const size_t sp = *stack_pos;
+      op_stack[sp - 2] = *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 1]) < *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 2]);
+      *stack_pos = sp - 1;
+      continue;
+    }
+    case GTR_FLOAT: {
+      const size_t sp = *stack_pos;
+      op_stack[sp - 2] = *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 1]) > *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 2]);
+      *stack_pos = sp - 1;
+      continue;
+    }
+    case LES_EQL_FLOAT: {
+      const size_t sp = *stack_pos;
+      op_stack[sp - 2] = *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 1]) <= *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 2]);
+      *stack_pos = sp - 1;
+      continue;
+    }
+    case GTR_EQL_FLOAT: {
+      const size_t sp = *stack_pos;
+      op_stack[sp - 2] = *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 1]) >= *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 2]);
+      *stack_pos = sp - 1;
+      continue;
+    }
+    case EQL_FLOAT: {
+      const size_t sp = *stack_pos;
+      op_stack[sp - 2] = *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 1]) == *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 2]);
+      *stack_pos = sp - 1;
+      continue;
+    }
+    case NEQL_FLOAT: {
+      const size_t sp = *stack_pos;
+      op_stack[sp - 2] = *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 1]) != *reinterpret_cast<FLOAT_VALUE*>(&op_stack[sp - 2]);
+      *stack_pos = sp - 1;
+      continue;
+    }
+
     case LBL:
       continue;
 

--- a/programs/regression/interp_float_fastpath.obs
+++ b/programs/regression/interp_float_fastpath.obs
@@ -1,0 +1,63 @@
+# JIT_DISABLE
+# Exercises the interpreter's inlined float fast-path (ADD/SUB/MUL_FLOAT and the
+# six float comparisons added in P2). JIT is disabled so every float op goes
+# through the interpreter dispatch loop, not native code. Values are accumulated
+# in loops so they are not constant-folded — the inlined ops must run for real.
+class InterpFloatFastPath {
+    function : Main(args : String[]) ~ Nil {
+        "Testing interpreter float fast-path..."->PrintLine();
+        pass := true;
+
+        # ADD_FLOAT in a loop: sum 0.5 a thousand times -> 500.0
+        sum := 0.0;
+        for(i := 0; i < 1000; i += 1;) { sum += 0.5; };
+        if(sum < 499.999 | sum > 500.001) { pass := false; "  FAIL: ADD loop = {$sum}"->PrintLine(); };
+
+        # SUB_FLOAT operand order (non-commutative): start high, subtract down
+        diff := 1000.0;
+        for(i := 0; i < 1000; i += 1;) { diff -= 0.25; };
+        if(diff < 749.999 | diff > 750.001) { pass := false; "  FAIL: SUB loop = {$diff}"->PrintLine(); };
+        # direct order check: 10.0 - 3.0 = 7.0 (not -7.0)
+        a := 10.0; b := 3.0;
+        if(a - b <> 7.0) { pass := false; "  FAIL: SUB order 10-3"->PrintLine(); };
+
+        # MUL_FLOAT: repeated doubling 2^10 = 1024.0
+        prod := 1.0;
+        for(i := 0; i < 10; i += 1;) { prod *= 2.0; };
+        if(prod < 1023.999 | prod > 1024.001) { pass := false; "  FAIL: MUL loop = {$prod}"->PrintLine(); };
+
+        # All six float comparisons (results 0/1 pushed by inlined ops)
+        x := 2.5; y := 4.0;
+        if(<>(x < y))   { pass := false; "  FAIL: LES_FLOAT"->PrintLine(); };
+        if(x > y)       { pass := false; "  FAIL: GTR_FLOAT false"->PrintLine(); };
+        if(<>(y > x))   { pass := false; "  FAIL: GTR_FLOAT true"->PrintLine(); };
+        if(<>(x <= 2.5)){ pass := false; "  FAIL: LES_EQL_FLOAT"->PrintLine(); };
+        if(<>(y >= 4.0)){ pass := false; "  FAIL: GTR_EQL_FLOAT"->PrintLine(); };
+        if(<>(x = 2.5)) { pass := false; "  FAIL: EQL_FLOAT"->PrintLine(); };
+        if(x <> 2.5)    { pass := false; "  FAIL: NEQL_FLOAT (should be equal)"->PrintLine(); };
+        if(<>(x <> y))  { pass := false; "  FAIL: NEQL_FLOAT (should differ)"->PrintLine(); };
+
+        # Negative operands through the fast path
+        neg := -8.0;
+        if(neg + 3.0 <> -5.0)  { pass := false; "  FAIL: neg ADD"->PrintLine(); };
+        if(neg - 2.0 <> -10.0) { pass := false; "  FAIL: neg SUB"->PrintLine(); };
+        if(neg * -0.5 <> 4.0)  { pass := false; "  FAIL: neg MUL"->PrintLine(); };
+
+        # Comparison driving control flow inside a counting loop. Threshold 4.95
+        # sits between the 4.9 and 5.0 accumulation grid points, so tiny 0.1
+        # rounding drift can't flip the count: t exceeds it for i=49..99 -> 51.
+        count := 0;
+        t := 0.0;
+        for(i := 0; i < 100; i += 1;) {
+            t += 0.1;
+            if(t > 4.95) { count += 1; };
+        };
+        if(count <> 51) { pass := false; "  FAIL: compare-in-loop count = {$count}"->PrintLine(); };
+
+        if(pass) {
+            "PASS: interpreter float fast-path"->PrintLine();
+        } else {
+            "FAIL: interpreter float fast-path"->PrintLine();
+        };
+    }
+}


### PR DESCRIPTION
## Summary
P2 sub-item 3. Adds an inline float fast-path to the interpreter dispatch loop, mirroring the integer fast-path from v2026.6.0. The hot float opcodes are handled inline at the top of the loop with a `continue`, skipping both the function-pointer dispatch table and the per-op error-recovery check. Non-JIT'd float code (cold methods, JIT-disabled runs) stops paying indirect-call overhead per float op. **Architecture-independent.**

## Changes (`core/vm/interpreter.cpp`)
Inlined into the dispatch `switch`:
- `ADD_FLOAT`, `SUB_FLOAT`, `MUL_FLOAT`
- the six float comparisons: `LES`/`GTR`/`LES_EQL`/`GTR_EQL`/`EQL`/`NEQL_FLOAT`

Semantics copied exactly from the existing `AddFloat`…`LesFloat` handlers (operands bit-stored in the `size_t` op_stack slots; left=`sp-1`, right=`sp-2`).

**`DIV_FLOAT` is deliberately not inlined** — its divide-by-zero path needs the recovery check below the switch, the same reason `DIV_INT`/`MOD_INT` aren't inlined.

## Test
New `programs/regression/interp_float_fastpath.obs` (`# JIT_DISABLE` forces the interpreter path) exercises every inlined op: loop-accumulated ADD/SUB/MUL (so values aren't constant-folded), non-commutative SUB operand order, all six comparisons, negative operands, and compare-driven control flow.

## Validation (x64)
- New test **passes** JIT-disabled, default, and `OBJECK_JIT_THRESHOLD=1`.
- Full regression **158/159** (only the known pre-existing `core_opencv`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)