### PR TITLE
fix(jit): correct two latent DYN_MTHD_CALL miscompiles

### DIFF
--- a/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
+++ b/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
@@ -246,9 +246,17 @@ void JitAmd64::ProcessParameters(long params) {
     RegisterHolder* stack_pos_holder = GetRegister();
     move_mem_reg(STACK_POS, RBP, stack_pos_holder->GetRegister());
     
-    if(instr->GetType() == STOR_LOCL_INT_VAR || instr->GetType() == STOR_CLS_INST_INT_VAR) {
+    // A parameter may arrive as STOR_* (pop into slot) or, when the optimizer
+    // keeps the incoming arg on the stack to reuse it directly (e.g. forwarding
+    // a param straight into a call: `f(x)` with x a param), as COPY_* (store to
+    // slot AND leave on the working stack). COPY_* must be routed to ProcessCopy,
+    // not ProcessStore, or it leaves the stack unbalanced. Crucially, an int
+    // COPY_LOCL_INT_VAR param must be classified as int here, not fall through
+    // to the float else-branch (which would read it into an XMM reg and crash).
+    if(instr->GetType() == STOR_LOCL_INT_VAR || instr->GetType() == STOR_CLS_INST_INT_VAR ||
+       instr->GetType() == COPY_LOCL_INT_VAR || instr->GetType() == COPY_CLS_INST_INT_VAR) {
       dec_mem(0, stack_pos_holder->GetRegister());
-#ifdef _WIN64    
+#ifdef _WIN64
       move_mem_reg32(0, stack_pos_holder->GetRegister(), stack_pos_holder->GetRegister());
 #else
       move_mem_reg(0, stack_pos_holder->GetRegister(), stack_pos_holder->GetRegister());
@@ -258,8 +266,13 @@ void JitAmd64::ProcessParameters(long params) {
       RegisterHolder* dest_holder = GetRegister();
       move_mem_reg(0, op_stack_holder->GetRegister(), dest_holder->GetRegister());
       working_stack.push_front(new RegInstr(dest_holder));
-      // store int
-      ProcessStore(instr);
+      // store int (COPY keeps the value on the working stack for later use)
+      if(instr->GetType() == COPY_LOCL_INT_VAR || instr->GetType() == COPY_CLS_INST_INT_VAR) {
+        ProcessCopy(instr);
+      }
+      else {
+        ProcessStore(instr);
+      }
     }
     else if(instr->GetType() == STOR_FUNC_VAR) {
       dec_mem(0, stack_pos_holder->GetRegister());  
@@ -295,12 +308,17 @@ void JitAmd64::ProcessParameters(long params) {
       move_mem_reg(0, stack_pos_holder->GetRegister(), stack_pos_holder->GetRegister());
 #endif    
       shl_imm_reg(3, stack_pos_holder->GetRegister());
-      add_reg_reg(stack_pos_holder->GetRegister(), op_stack_holder->GetRegister()); 
+      add_reg_reg(stack_pos_holder->GetRegister(), op_stack_holder->GetRegister());
       move_mem_xreg(0, op_stack_holder->GetRegister(), dest_holder->GetRegister());
       working_stack.push_front(new RegInstr(dest_holder));
 
-      // store float
-      ProcessStore(instr);
+      // store float (COPY keeps the value on the working stack for later use)
+      if(instr->GetType() == COPY_FLOAT_VAR) {
+        ProcessCopy(instr);
+      }
+      else {
+        ProcessStore(instr);
+      }
     }
     ReleaseRegister(op_stack_holder);
     ReleaseRegister(stack_pos_holder);
@@ -6009,6 +6027,20 @@ bool JitAmd64::Compile(StackMethod* cm)
     for(long i = 0; i < method->GetInstructionCount(); ++i) {
       StackInstr* scan_instr = method->GetInstruction(i);
       if(!CanJitInstruction(scan_instr->GetType())) {
+        return false;
+      }
+      // DYN_MTHD_CALL return marshalling (ProcessReturnParameters) is driven by
+      // operand2 (the func-ref's return MemoryType). For a generic func-ref
+      // (`(H)~H`) compiled in library mode the return type collapses to NIL_TYPE
+      // — indistinguishable from a genuinely void func-ref (`(H)~Nil`). If we
+      // JIT such a call and the result IS consumed (e.g. `a[i] := f(x)` in
+      // Collection.Map/Filter/Reduce), no value is marshalled back and the next
+      // instruction underflows the working stack -> crash. Reject these methods
+      // so they run in the interpreter (which marshals results dynamically and
+      // handles them correctly). Concrete-return func-refs (e.g. spectralnorm's
+      // `~Float` closures) keep a non-NIL operand2 and still JIT.
+      if((scan_instr->GetType() == DYN_MTHD_CALL || scan_instr->GetType() == DYN_MTHD_CALL_JIT) &&
+         scan_instr->GetOperand2() == instructions::MemoryType::NIL_TYPE) {
         return false;
       }
       // detect loops via backward jumps (a JMP operand is the target instruction

--- a/core/vm/arch/jit/arm64/jit_arm_a64.cpp
+++ b/core/vm/arch/jit/arm64/jit_arm_a64.cpp
@@ -254,7 +254,15 @@ void JitArm64::ProcessParameters(long params) {
     RegisterHolder* stack_pos_holder = GetRegister();
     move_mem_reg(OP_STACK_POS, SP, stack_pos_holder->GetRegister());
       
-    if(instr->GetType() == STOR_LOCL_INT_VAR || instr->GetType() == STOR_CLS_INST_INT_VAR) {
+    // A parameter may arrive as STOR_* (pop into slot) or, when the optimizer
+    // keeps the incoming arg on the stack to reuse it directly (e.g. forwarding
+    // a param into a call: `f(x)` with x a param), as COPY_* (store to slot AND
+    // leave on the working stack). COPY_* must route to ProcessCopy, not
+    // ProcessStore. An int COPY_LOCL_INT_VAR param must also be classified as
+    // int here, not fall through to the float else-branch (which would read it
+    // into an FP reg and crash). Mirrors the AMD64 fix.
+    if(instr->GetType() == STOR_LOCL_INT_VAR || instr->GetType() == STOR_CLS_INST_INT_VAR ||
+       instr->GetType() == COPY_LOCL_INT_VAR || instr->GetType() == COPY_CLS_INST_INT_VAR) {
       RegisterHolder* dest_holder = GetRegister();
       dec_mem(0, stack_pos_holder->GetRegister());
       move_mem_reg(0, stack_pos_holder->GetRegister(), stack_pos_holder->GetRegister());
@@ -262,8 +270,13 @@ void JitArm64::ProcessParameters(long params) {
       add_reg_reg(stack_pos_holder->GetRegister(), op_stack_holder->GetRegister());
       move_mem_reg(0, op_stack_holder->GetRegister(), dest_holder->GetRegister());
       working_stack.push_front(new RegInstr(dest_holder));
-      // store int
-      ProcessStore(instr);
+      // store int (COPY keeps the value on the working stack for later use)
+      if(instr->GetType() == COPY_LOCL_INT_VAR || instr->GetType() == COPY_CLS_INST_INT_VAR) {
+        ProcessCopy(instr);
+      }
+      else {
+        ProcessStore(instr);
+      }
     }
     else if(instr->GetType() == STOR_FUNC_VAR) {
       RegisterHolder* dest_holder = GetRegister();
@@ -294,8 +307,13 @@ void JitArm64::ProcessParameters(long params) {
       add_reg_reg(stack_pos_holder->GetRegister(), op_stack_holder->GetRegister());
       move_mem_freg(0, op_stack_holder->GetRegister(), dest_holder->GetRegister());
       working_stack.push_front(new RegInstr(dest_holder));
-      // store float
-      ProcessStore(instr);
+      // store float (COPY keeps the value on the working stack for later use)
+      if(instr->GetType() == COPY_FLOAT_VAR) {
+        ProcessCopy(instr);
+      }
+      else {
+        ProcessStore(instr);
+      }
     }
     ReleaseRegister(op_stack_holder);
     ReleaseRegister(stack_pos_holder);
@@ -4979,6 +4997,18 @@ bool JitArm64::Compile(StackMethod* cm)
     for(long i = 0; i < method->GetInstructionCount(); ++i) {
       StackInstr* scan_instr = method->GetInstruction(i);
       if(!CanJitInstruction(scan_instr->GetType())) {
+        return false;
+      }
+      // DYN_MTHD_CALL return marshalling is driven by operand2 (the func-ref's
+      // return MemoryType). A generic func-ref (`(H)~H`) compiled in library
+      // mode collapses to NIL_TYPE — indistinguishable from a genuinely void
+      // func-ref. JIT'ing such a call when the result IS consumed (e.g.
+      // `a[i] := f(x)` in Collection.Map/Filter/Reduce) marshals no value and
+      // underflows the working stack -> crash. Reject -> run in the interpreter.
+      // Concrete-return func-refs keep a non-NIL operand2 and still JIT. Mirrors
+      // the AMD64 guard.
+      if((scan_instr->GetType() == DYN_MTHD_CALL || scan_instr->GetType() == DYN_MTHD_CALL_JIT) &&
+         scan_instr->GetOperand2() == instructions::MemoryType::NIL_TYPE) {
         return false;
       }
       // detect loops via backward jumps. On ARM64 a JMP operand is the target

--- a/core/vm/arch/jit/jit_common.h
+++ b/core/vm/arch/jit/jit_common.h
@@ -45,6 +45,14 @@
 // Auto-JIT: methods called more than threshold times are JIT compiled.
 // Pre-scan validation (CanJitInstruction) runs before resource allocation,
 // so unsupported instructions cause immediate return false with no corruption.
+//
+// NOTE: lowering this default to 1 yields a large win on closure/numeric code
+// (spectralnorm 2000: 0.44s vs 7.0s at 10, 16x — only threshold=1 JITs the
+// outermost hot method before its single huge first call). It is NOT safe to
+// do yet: threshold=1 compiles many rarely-exercised methods and surfaces
+// several latent JIT miscompiles (chained transcendental float calls produce
+// NaN, string-interpolation paths, etc.). Those must be fixed first. See the
+// DYN_MTHD_CALL fixes in this change set for two such bugs already addressed.
 // Tunables:
 //   OBJECK_JIT_DISABLE=1   — turn auto-JIT off entirely
 //   OBJECK_JIT_THRESHOLD=N — call-count threshold (must be positive)

--- a/programs/regression/jit_func_ref_hot.obs
+++ b/programs/regression/jit_func_ref_hot.obs
@@ -1,0 +1,68 @@
+use Collection;
+
+# Exercises two latent DYN_MTHD_CALL JIT miscompiles that only surface once the
+# containing method gets hot enough to auto-JIT (default threshold). Each pattern
+# is driven >15 times so the method compiles and the JIT path runs. On the
+# pre-fix VM both segfault; they must produce correct results here.
+#
+#   1. Calling a function-reference PARAMETER directly (`f(x)` with x also a
+#      parameter) — the optimizer emits COPY_LOCL_INT_VAR for the forwarded
+#      param, which the JIT parameter marshaller misclassified as a float.
+#   2. A generic higher-order library method (Collection.CompareVector.Map),
+#      whose `(H)~H` func-ref return collapses to NIL in library mode, so the
+#      JIT marshalled no result and underflowed the working stack.
+class JitFuncRefHot {
+    function : Main(args : String[]) ~ Nil {
+        "Testing hot function-reference JIT paths..."->PrintLine();
+        pass := true;
+
+        # Pattern 1: func-ref parameter forwarded into a direct call, run hot.
+        total := 0;
+        for(i := 0; i < 50; i += 1;) {
+            total += Apply(i, Double(Int) ~ Int);
+        };
+        # sum of 2*i for i in 0..49 = 2 * (49*50/2) = 2450
+        if(total <> 2450) {
+            pass := false;
+            "  FAIL: func-ref param total = {$total}, expected 2450"->PrintLine();
+        };
+
+        # Pattern 1b: float func-ref parameter forwarded (COPY_FLOAT_VAR path).
+        ftotal := 0.0;
+        for(i := 0; i < 50; i += 1;) {
+            ftotal += ApplyF(2.0, Half(Float) ~ Float);
+        };
+        if(ftotal < 49.999 | ftotal > 50.001) {
+            pass := false;
+            "  FAIL: float func-ref total = {$ftotal}, expected 50"->PrintLine();
+        };
+
+        # Pattern 2: generic higher-order library method (Map), run hot.
+        cv := CompareVector->New()<IntRef>;
+        each(i : 5) { cv->AddBack(IntRef->New(i)); };
+        last_sum := 0;
+        for(j := 0; j < 30; j += 1;) {
+            mapped := cv->Map(Triple(IntRef) ~ IntRef);
+            s := 0;
+            each(v in mapped) { s += v->Get(); };
+            last_sum := s;
+        };
+        # 3*(0+1+2+3+4) = 30
+        if(last_sum <> 30) {
+            pass := false;
+            "  FAIL: Map sum = {$last_sum}, expected 30"->PrintLine();
+        };
+
+        if(pass) {
+            "PASS: hot function-reference JIT paths"->PrintLine();
+        } else {
+            "FAIL: hot function-reference JIT paths"->PrintLine();
+        };
+    }
+
+    function : Apply(x : Int, f : (Int) ~ Int) ~ Int { return f(x); }
+    function : ApplyF(x : Float, f : (Float) ~ Float) ~ Float { return f(x); }
+    function : Double(v : Int) ~ Int { return v * 2; }
+    function : Half(v : Float) ~ Float { return v / 2.0; }
+    function : Triple(v : IntRef) ~ IntRef { return IntRef->New(v->Get() * 3); }
+}


### PR DESCRIPTION
## Summary
Fixes **two latent JIT miscompiles in `DYN_MTHD_CALL`** (function-reference/closure calls). Both are **live crashes on master**: a method using these patterns segfaults once it gets hot enough to auto-JIT (≥ the default threshold of 10 calls). They were masked only because the regression suite never calls the affected methods often enough to trigger compilation. Found while measuring a lower auto-JIT threshold, which surfaced them immediately.

## Bug 1 — function-reference parameter called directly
`f(x)` where both `f` and `x` are parameters (e.g. `Apply(x, f) { return f(x); }`). The optimizer emits `COPY_LOCL_INT_VAR` for the forwarded arg (store to slot **and** keep on stack). `ProcessParameters` only classified `STOR_LOCL_INT_VAR`/`STOR_CLS_INST_INT_VAR` as int params, so the `COPY` fell through to the **float else-branch** — reading the int arg into an FP register and unbalancing the stack → crash.

**Fix:** classify the `COPY_*` int forms as int params, and route COPY-typed params through `ProcessCopy` (keeps the value on the working stack) instead of `ProcessStore`. Float params get the same `COPY_FLOAT_VAR` handling. (AMD64 + ARM64.)

## Bug 2 — generic higher-order library methods
`Collection.CompareVector` `Map`/`Filter`/`Reduce`. A generic func-ref return `(H)~H` collapses to `NIL_TYPE` when the library is compiled with `-tar lib` — indistinguishable from a genuinely void `(H)~Nil`. The `DYN_MTHD_CALL` then carries `operand2 == NIL`, so the JIT marshalled **no** return value while the following bytecode (`a[i] := f(x)`) consumed one → working-stack underflow → crash.

**Fix:** reject JIT compilation of any method containing a `DYN_MTHD_CALL` whose return type is ambiguous (`operand2 == NIL_TYPE`); it runs in the interpreter (which marshals results dynamically and is correct). Concrete-return func-refs (e.g. spectralnorm's `~Float` closures) keep a non-NIL `operand2` and still JIT. Restores pre-#543 behavior only for the ambiguous-return case.

## Test
`programs/regression/jit_func_ref_hot.obs` drives all three patterns (int/float func-ref param forwarding + generic `Map`) past the JIT threshold. **Segfaults pre-fix; passes now** at the default threshold and `OBJECK_JIT_THRESHOLD=1`.

## Validation (x64)
- Full regression **159/160** (only pre-existing `core_opencv`).
- spectralnorm output and perf unchanged.
- ARM64 mirrors both fixes — cross-compiled clean (`vcvarsall amd64_arm64`); on-device validation pending.

## Note on the auto-JIT threshold
Lowering the default threshold from 10 to 1 is a **~16x win** on closure/numeric code (spectralnorm 2000: 0.44s vs 7.0s — only threshold=1 JITs the outermost hot method before its single huge first call). It is **not done here**: threshold=1 surfaces further latent JIT bugs (chained transcendental float calls produce NaN; string-interpolation paths) that must be fixed first. Documented in `jit_common.h` for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)