### PR TITLE
fix(vm): quiesce worker threads before program teardown

### DIFF
--- a/core/vm/interpreter.h
+++ b/core/vm/interpreter.h
@@ -35,6 +35,7 @@
 #include <random>
 #include <string.h>
 #include <thread>
+#include <chrono>
 
 #ifdef _WIN32
 #include "arch/memory.h"
@@ -524,7 +525,62 @@ namespace Runtime {
     void Halt() {
       halt = true;
     }
-    
+
+    // Halt every registered interpreter EXCEPT `self`. Used at program teardown
+    // so other VM threads (e.g. web-server request workers) stop before the
+    // Loader frees the program — otherwise a worker can auto-JIT (PatchCallSites
+    // walks the class tables) while ~StackProgram frees them => use-after-free.
+    // Never halts `self` (the thread running teardown), so it stays usable.
+    static void HaltAllExcept(StackInterpreter* self) {
+#ifdef _WIN32
+      EnterCriticalSection(&intpr_threads_cs);
+#else
+      pthread_mutex_lock(&intpr_threads_mutex);
+#endif
+      for(std::set<StackInterpreter*>::iterator iter = intpr_threads.begin(); iter != intpr_threads.end(); ++iter) {
+        if(*iter != self) {
+          (*iter)->Halt();
+        }
+      }
+#ifdef _WIN32
+      LeaveCriticalSection(&intpr_threads_cs);
+#else
+      pthread_mutex_unlock(&intpr_threads_mutex);
+#endif
+    }
+
+    // Wait (bounded) until only `self` (or nothing) remains registered, i.e.
+    // every other thread has unwound and deregistered (RemoveThread). Returns
+    // true if drained, false on timeout (a worker blocked in a syscall may not
+    // observe Halt; the caller proceeds anyway). Pair with HaltAllExcept.
+    static bool WaitForThreadsToDrain(StackInterpreter* self, long timeout_ms) {
+      long waited_ms = 0;
+      while(waited_ms < timeout_ms) {
+        size_t remaining;
+#ifdef _WIN32
+        EnterCriticalSection(&intpr_threads_cs);
+#else
+        pthread_mutex_lock(&intpr_threads_mutex);
+#endif
+        remaining = intpr_threads.size();
+        // self stays registered during Release teardown (RemoveThread is only in
+        // the _SANITIZE path), so <= 1 means no other threads remain.
+        const bool only_self = (remaining <= 1);
+        (void)self;
+#ifdef _WIN32
+        LeaveCriticalSection(&intpr_threads_cs);
+#else
+        pthread_mutex_unlock(&intpr_threads_mutex);
+#endif
+        if(only_self) {
+          return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        waited_ms++;
+      }
+      return false;
+    }
+
     // free static resources
     static void Clear() {
       while(!cached_frames.empty()) {

--- a/core/vm/vm.cpp
+++ b/core/vm/vm.cpp
@@ -97,7 +97,15 @@ int Execute(int argc, const char* argv[], size_t gc_threshold)
       CleanUpCommandLine(argc, commands);
       return USAGE_ERROR;
     }
-    
+
+    // Quiesce any still-running VM threads (e.g. web-server request workers)
+    // before `loader` destructs and frees the program. Otherwise a worker can be
+    // mid auto-JIT (PatchCallSites walking the class tables) while ~StackProgram
+    // frees them -> use-after-free crash at exit. Halt the others (not `intpr`,
+    // which is this thread) and wait briefly for them to unwind and deregister.
+    Runtime::StackInterpreter::HaltAllExcept(intpr);
+    Runtime::StackInterpreter::WaitForThreadsToDrain(intpr, 2000);
+
 #ifdef _DEBUG
     std::wcout << L"# final std::stack: pos=" << (*stack_pos) << L" #" << std::endl;
     if((*stack_pos) > 0) {


### PR DESCRIPTION
## Summary
Fixes a **use-after-free at process exit** in multi-threaded programs (the `Web.HTTP` server / mcp tests). At exit the main thread runs `~Loader → delete program` (frees every class/method/`NativeCode`), but a still-running worker thread can be mid auto-JIT — `JitCompiler::PatchCallSites` walks `program->GetClasses()` while `~StackProgram` frees them → SIGSEGV.

Root-caused with **gdb + llvm-symbolizer**: the crashing worker (Thread 5) was in `PatchCallSites` (`TryAutoJitCompile` ← `CheckAutoJit` ← `ProcessMethodCall` ← a JIT callback); another thread (Thread 1) was in `~StackProgram → ~StackClass → ~NativeCode` (`VirtualFree`).

The race is latent at any threshold, but a low `OBJECK_JIT_THRESHOLD` widens the window dramatically (far more methods compile lazily during shutdown) — it surfaced as `mcp_debug_test` crashing only at `OBJECK_JIT_THRESHOLD=1`.

## Fix
After `Execute()` returns in the VM main, before `loader` destructs:
- `StackInterpreter::HaltAllExcept(intpr)` — halt every **other** interpreter (never the calling thread).
- `StackInterpreter::WaitForThreadsToDrain(intpr, 2000)` — wait (bounded 2s) for them to unwind and deregister.

Single-threaded programs see **no overhead** (only `self` is registered → returns immediately). A worker blocked in a syscall may not observe the halt within the timeout; the caller then proceeds best-effort (the common case — a worker finishing its current method after halt — drains promptly).

## Validation (AMD64)
- `mcp_debug_test` **3/3 clean** at `OBJECK_JIT_THRESHOLD=1` (was a deterministic segfault).
- Full regression **160/161 at BOTH default and `OBJECK_JIT_THRESHOLD=1`** (only pre-existing `core_opencv`) — i.e. **THRESHOLD=1 is now fully green on x64**.
- `interpreter.h` is shared; ARM64 cross-compiles clean (MSVC `amd64_arm64`).

## Note on the alternative (graceful library `Stop()` join)
A library-level `thread->Join()` in the web server was considered (option C) but is unsafe with the current server threading model: one reused `Thread` object + per-client async spawn, and `THREAD_JOIN` `exit(1)`s on a stale/finished/null handle. This VM-level quiesce is robust for **all** threaded programs and doesn't require a server redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)