### PR TITLE
fix(jit): AMD64 materialize deferred local loads before overwriting store (TCO)

### DIFF
--- a/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
+++ b/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
@@ -1680,6 +1680,31 @@ void JitAmd64::ProcessStore(StackInstr* instr) {
         ReleaseXmmRegister(xreg_it->second);
         local_xreg_cache.erase(xreg_it);
       }
+
+      // Materialize any pending working-stack value that defers to this slot
+      // BEFORE it is overwritten. A deferred LOAD of this local (a MEM_INT/
+      // MEM_FLOAT still pointing at the slot) would otherwise read the post-store
+      // value. This is what breaks TCO'd self-recursive tail calls where a bare
+      // local is forwarded as an argument: e.g. `return Gcd(b, a%b)` compiles to
+      // LOAD b; ...; STOR b (:=a%b); STOR a (:= the deferred b) -- without this,
+      // the second store reads b's slot, which now holds a%b, so a := a%b instead
+      // of the old b. (Mirrors the ARM64 fix.)
+      const long stor_slot = instr->GetOperand3();
+      for(size_t wi = 0; wi < working_stack.size(); ++wi) {
+        RegInstr* pend = working_stack[wi];
+        if(pend->GetType() == MEM_INT && (long)pend->GetOperand() == stor_slot) {
+          RegisterHolder* mh = GetRegister();
+          move_mem_reg(stor_slot, RBP, mh->GetRegister());
+          delete pend;
+          working_stack[wi] = new RegInstr(mh);
+        }
+        else if(pend->GetType() == MEM_FLOAT && (long)pend->GetOperand() == stor_slot) {
+          RegisterHolder* mh = GetXmmRegister();
+          move_mem_xreg(stor_slot, RBP, mh->GetRegister());
+          delete pend;
+          working_stack[wi] = new RegInstr(mh);
+        }
+      }
     }
   }
   // class or instance memory

--- a/programs/regression/jit_tco_bare_local.obs
+++ b/programs/regression/jit_tco_bare_local.obs
@@ -1,0 +1,33 @@
+# Regression for the TCO deferred-local-load miscompile (both arches).
+# A self-recursive tail call that forwards a BARE LOCAL as an argument
+# (`return Gcd(b, a%b)` — param 0 is just `b`) is TCO-rewritten to stores into
+# the parameter slots. The JIT defers the bare `b` load as a pointer to b's
+# slot; the `b := a%b` store then overwrites that slot before the deferred load
+# is consumed, so the other parameter reads a%b instead of the old b.
+# Gcd is called >10 times so it auto-JITs at the DEFAULT threshold (the bug
+# otherwise only shows at OBJECK_JIT_THRESHOLD=1, where Gcd JITs on first call).
+use System;
+
+class JitTcoBareLocal {
+    function : Main(args : String[]) ~ Nil {
+        pass := true;
+        for(i := 0; i < 25; i += 1;) {
+            if(Gcd(48, 18) <> 6)     { pass := false; "  FAIL: Gcd(48,18)"->PrintLine(); };
+            if(Gcd(1071, 462) <> 21) { pass := false; "  FAIL: Gcd(1071,462)"->PrintLine(); };
+            if(Gcd(17, 5) <> 1)      { pass := false; "  FAIL: Gcd(17,5)"->PrintLine(); };
+            if(Gcd(100, 0) <> 100)   { pass := false; "  FAIL: Gcd(100,0)"->PrintLine(); };
+        };
+        if(pass) {
+            "PASS: TCO bare-local tail-call arg"->PrintLine();
+        }
+        else {
+            "FAIL: TCO bare-local tail-call arg"->PrintLine();
+            Runtime->Exit(1);
+        };
+    }
+
+    function : Gcd(a : Int, b : Int) ~ Int {
+        if(b = 0) { return a; };
+        return Gcd(b, a % b);
+    }
+}


### PR DESCRIPTION
## Summary
Ports the ARM64 fix `cea4d1ea5` to AMD64 — **the TCO deferred-local-load bug is present on both arches**, not just ARM64. You asked me to determine whether the macOS/ARM64 fixes apply to AMD64; this one does.

A TCO'd self-recursive tail call that forwards a **bare local** as an argument (`return Gcd(b, a%b)`, where param 0 is just `b`) is rewritten to stores into the parameter slots. The JIT defers the bare `b` load as a `MEM_INT` pointing at b's slot; `ProcessStore` then overwrites that slot (`b := a%b`) **before** the deferred load is consumed, so the next store reads `a%b` instead of the old `b`. **`GCD(48,18)` returns 0 instead of 6** once `Gcd` auto-JITs (`OBJECK_JIT_THRESHOLD=1`, or any hot bare-local-forwarding tail call at the default threshold).

**Fix:** before overwriting a local slot, scan the working stack and materialize any pending `MEM_INT`/`MEM_FLOAT` that defers to the same slot into a register first. (`ProcessStore` previously only invalidated the *register cache*, not deferred working-stack loads.) `working_stack` is a `std::deque` on both arches, so the ARM64 fix ports directly.

## Audit of the other recent ARM64 fixes — none apply to AMD64
| ARM64 fix | AMD64? | Verified |
|---|---|---|
| `139427c5d` unary float-op arg via `move_freg_freg` GP-bridge | **N/A** — AMD64 moves floats XMM↔XMM | `Sig(2.0)=0.881` correct at `THRESHOLD=1` |
| `5ad7adbae` `imm19` sign-extension in `b.cond` backpatch | **N/A** — AMD64 writes `rel32` via `memcpy` | early-return-then-divide correct, no SIGILL |
| `4d638ef60` `Int->MinSize()` | arch-independent (lang.obl) | already in master |
| `cea4d1ea5` TCO deferred load | **APPLIES** (this PR) | `GCD` 0→6 |

## Benchmarks
`bench_tco` is **not** affected — its `Sum(n-1, acc+n)` args are *expressions* (materialized), so no bare-local load is deferred. Confirmed `500000500000` before and after.

## Validation (AMD64)
- New `programs/regression/jit_tco_bare_local.obs` (bare-local `Gcd` called >10× → auto-JITs at the **default** threshold): returns 0 pre-fix, passes now at default **and** `THRESHOLD=1`.
- Full regression **160/161 at both thresholds** (only pre-existing `core_opencv`). x64 is now fully green at `THRESHOLD=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)