### PR TITLE
docs(perf): refresh all numbers — unified Docker run (2026-06-21)

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -13,8 +13,9 @@
 | **CPU** | AMD Ryzen 9 7950X3D (16C/32T) |
 | **RAM** | 128 GB (62 GB visible in Docker) |
 | **OS** | Ubuntu 24.04.4 in Docker (Windows 11 host) |
-| **Compiler** | Objeck v2026.6.2 + P2 JIT work (`DYN_MTHD_CALL` auto-JIT, interpreter float fast-path, GC-safepoint fixes), built from source, `-opt s3` |
+| **Compiler** | Objeck v2026.6.2 + P2 JIT work (`DYN_MTHD_CALL` auto-JIT, interpreter float fast-path, TCO/float/shutdown correctness fixes), built from source, `-opt s3` |
 | **Methodology** | 3 runs per benchmark, median reported |
+| **Date** | 2026-06-21 (unified Docker run) |
 
 > All tables below come from a **single unified Docker run** (`perf-results/docker/Dockerfile`) on the box above, so the single-language and cross-language numbers are directly comparable. Note Docker's virtualized backend runs Objeck's **interpreter**-bound benchmarks ~30–50% slower than a native (bare-metal/WSL2) build, while JIT/`native` code is nearly unaffected — so the interpreter rows here are conservative.
 
@@ -24,13 +25,13 @@ Classic [Computer Language Benchmarks Game](https://benchmarksgame-team.pages.de
 
 | Benchmark | Input | Time (s) | Peak RSS |
 |-----------|-------|----------|----------|
-| **mandelbrot** | 4000 | 0.81 | 12 MB |
-| **nbody** | 50M | 17.70 | 10 MB |
-| **binarytrees** | 17 | 7.79 | 207 MB |
-| **fannkuchredux** | 12 | 30.67 | 12 MB |
-| **spectralnorm** | 5500 | 43.11 | 11 MB |
+| **mandelbrot** | 4000 | 0.87 | 12 MB |
+| **nbody** | 50M | 18.42 | 10 MB |
+| **binarytrees** | 17 | 8.53 | 206 MB |
+| **fannkuchredux** | 12 | 32.32 | 10 MB |
+| **spectralnorm** | 5500 | 44.86 | 11 MB |
 
-**mandelbrot** and **nbody** benefit from `native`-annotated methods that JIT-compile to x64. **binarytrees** benefits from the young-gen bump allocator and auto-JIT for methods containing `MTHD_CALL`. **fannkuchredux** is the headline gain from the new back-edge GC-safepoint work (PR #539). **spectralnorm** is a closure/function-reference kernel: its calls now auto-JIT (`DYN_MTHD_CALL`), but at the default threshold a single short run still pays JIT warmup (the ~43s above). Forcing compilation with `OBJECK_JIT_THRESHOLD=1` runs the same 5500 input in **3.5s (~14x)**, and at n=2000 it reaches **0.46s** — matching the hand-`native` kernel (0.40s). The remaining gap is JIT warmup/threshold tuning, not coverage.
+**mandelbrot** and **nbody** benefit from `native`-annotated methods that JIT-compile to x64. **binarytrees** benefits from the young-gen bump allocator and auto-JIT for methods containing `MTHD_CALL`. **fannkuchredux** is the headline gain from the new back-edge GC-safepoint work (PR #539). **spectralnorm** is a closure/function-reference kernel: its calls now auto-JIT (`DYN_MTHD_CALL`), but at the default threshold a single short run still pays JIT warmup (the ~45s above). Forcing compilation with `OBJECK_JIT_THRESHOLD=1` runs the same 5500 input in **3.3s (~14x)**, and at n=2000 it reaches **~0.46s** — approaching the hand-`native` kernel (0.37s). The remaining gap is JIT warmup/threshold tuning, not coverage.
 
 ---
 
@@ -51,25 +52,25 @@ All five languages measured in **one Docker run on identical inputs** (`perf-res
 
 | Benchmark | Input | Objeck | Python 3.12 | Ruby 3.2 | LuaJIT 2.1 | Java 21 | Best |
 |-----------|-------|--------|-------------|----------|------------|---------|------|
-| **nbody** | 50M | 17.70s | 136.91s | 201.22s | 4.30s | **2.30s** | Java |
-| **binarytrees** | 17 | 7.79s | 3.51s | 3.49s | 3.34s | **0.24s** | Java |
-| **spectralnorm** | 5500 | 43.11s | 125.74s | 85.83s | **1.11s** | 1.17s | LuaJIT |
-| **fannkuchredux** | 12 | 30.67s | 415.40s | 1166.46s | 117.07s | **20.60s** | Java |
+| **nbody** | 50M | 18.42s | 137.70s | 216.06s | 4.57s | **2.38s** | Java |
+| **binarytrees** | 17 | 8.53s | 3.72s | 3.73s | 3.86s | **0.52s** | Java |
+| **spectralnorm** | 5500 | 44.86s | 131.63s | 89.91s | **1.15s** | 1.20s | LuaJIT |
+| **fannkuchredux** | 12 | 32.32s | 432.21s | 1252.25s | 122.52s | **21.30s** | Java |
 
 ### Reading the table
 
-- **Java (HotSpot) sets the ceiling — it wins 3 of 4** (nbody, binarytrees, fannkuchredux); LuaJIT takes spectralnorm (1.11s vs Java's 1.17s). A mature tiered JIT plus escape analysis and a generational GC is the bar a younger JIT is measured against.
-- **Objeck beats both Python and Ruby on 3 of 4** — by wide margins where the JIT engages: nbody **7.7x** faster than Python / **11.4x** faster than Ruby; fannkuchredux **13.5x** / **38x**; spectralnorm **2.9x** / **2.0x** (interpreter only).
-- **Objeck beats LuaJIT on fannkuchredux** (30.67s vs 117.07s, **3.8x faster**) — the integer-array permutation/flip pattern is a poor fit for LuaJIT's tracing JIT, and Objeck's method-JIT handles it well. The new back-edge GC-safepoint work (PR #539) roughly halved Objeck's fannkuch time, closing the gap to Java to ~1.5x.
-- **binarytrees is Objeck's weak spot — slower than even the interpreters here.** Allocation/GC throughput dominates; Java's generational GC + escape analysis is **~32x** faster (0.24s vs 7.79s). This is the clearest improvement target (P1 on the roadmap).
-- **spectralnorm's 43s is a JIT-warmup artifact, not raw capability.** Its closure calls (`DYN_MTHD_CALL`) now auto-JIT; the 43s is a single short run dominated by warmup at the default threshold. With `OBJECK_JIT_THRESHOLD=1` the same 5500 run is **3.5s (~14x)** and n=2000 reaches **0.46s**, matching the hand-`native` kernel. The remaining lever is auto-JIT threshold tuning, not coverage.
+- **Java (HotSpot) sets the ceiling — it wins 3 of 4** (nbody, binarytrees, fannkuchredux); LuaJIT takes spectralnorm (1.15s vs Java's 1.20s). A mature tiered JIT plus escape analysis and a generational GC is the bar a younger JIT is measured against.
+- **Objeck beats both Python and Ruby on 3 of 4** — by wide margins where the JIT engages: nbody **7.5x** faster than Python / **11.7x** faster than Ruby; fannkuchredux **13.4x** / **38.7x**; spectralnorm **2.9x** / **2.0x** (interpreter only).
+- **Objeck beats LuaJIT on fannkuchredux** (32.32s vs 122.52s, **3.8x faster**) — the integer-array permutation/flip pattern is a poor fit for LuaJIT's tracing JIT, and Objeck's method-JIT handles it well. The back-edge GC-safepoint work (PR #539) roughly halved Objeck's fannkuch time, leaving the gap to Java at ~1.5x.
+- **binarytrees is Objeck's weak spot — slower than even the interpreters here.** Allocation/GC throughput dominates; Java's generational GC + escape analysis is **~16x** faster (0.52s vs 8.53s; Java's binarytrees has high run-to-run JIT-warmup variance). This is the clearest improvement target (P1 on the roadmap).
+- **spectralnorm's ~45s is a JIT-warmup artifact, not raw capability.** Its closure calls (`DYN_MTHD_CALL`) now auto-JIT; the 45s is a single short run dominated by warmup at the default threshold. With `OBJECK_JIT_THRESHOLD=1` the same 5500 run is **3.3s (~14x)** and n=2000 reaches **~0.46s**, approaching the hand-`native` kernel. The remaining lever is auto-JIT threshold tuning, not coverage.
 
 ### Key Takeaways
 
 1. **Against scripting peers, Objeck is decisively faster.** On JIT-friendly numeric and integer loops it leads Python and Ruby by 3–30x.
 2. **Against compiled-class JITs (Java, LuaJIT), Objeck trails on float loops but is competitive — and ahead — on the right integer workload** (fannkuchredux beats LuaJIT).
 3. **Allocation throughput is the #1 gap.** binarytrees is the one benchmark where Objeck loses to everything; escape analysis / faster young-gen allocation is the highest-leverage future work.
-4. **`DYN_MTHD_CALL` auto-JIT closed the coverage gap; warmup is the remaining lever.** Closure/function-reference calls now auto-JIT, so spectralnorm at `OBJECK_JIT_THRESHOLD=1` reaches 0.46s (n=2000), matching hand-`native`, and 3.5s at 5500 (~14x vs the default-threshold run). At the default threshold a single short run still pays warmup — the open question is auto-JIT threshold tuning, not coverage.
+4. **`DYN_MTHD_CALL` auto-JIT closed the coverage gap; warmup is the remaining lever.** Closure/function-reference calls now auto-JIT, so spectralnorm at `OBJECK_JIT_THRESHOLD=1` reaches ~0.46s (n=2000), near hand-`native`, and 3.3s at 5500 (~14x vs the default-threshold run). At the default threshold a single short run still pays warmup — the open question is auto-JIT threshold tuning, not coverage.
 5. **Measurement environment matters.** Objeck's interpreter is more sensitive to virtualization than its JIT; native (non-Docker) numbers would be meaningfully better than the Docker numbers shown here.
 
 ---
@@ -80,10 +81,9 @@ Methods marked `native` are JIT-compiled to x64 or ARM64 machine code. All other
 
 | spectralnorm | Input | Time | Notes |
 |-------------|-------|------|-------|
-| Interpreter (JIT disabled) | 5500 | 43.11s | baseline |
-| Auto-JIT, default threshold | 5500 | ~43s | single short run — JIT warmup dominates |
-| Auto-JIT, `OBJECK_JIT_THRESHOLD=1` | 5500 | **3.5s** | ~14x; closures auto-JIT (`DYN_MTHD_CALL`) |
-| Auto-JIT `THRESHOLD=1` / `native` | 2000 | **0.46 / 0.40s** | auto-JIT now matches hand-`native` |
+| Auto-JIT, default threshold | 5500 | 44.86s | single short run — JIT warmup dominates |
+| Auto-JIT, `OBJECK_JIT_THRESHOLD=1` | 5500 | **3.3s** | ~14x; closures auto-JIT (`DYN_MTHD_CALL`) |
+| Auto-JIT `THRESHOLD=1` / `native` | 2000 | **0.46 / 0.37s** | auto-JIT approaches hand-`native` |
 
 Methods marked `native` that contain `MTHD_CALL` are JIT-compiled via `ProcessStackCallback`. Auto-JIT also compiles hot methods automatically (default: after 10 calls). Closure/function-reference calls (`DYN_MTHD_CALL`) are **now auto-JIT'd** as well, so closure-heavy kernels like spectralnorm reach native-level speed once compiled — the lever is no longer coverage but the auto-JIT threshold (warmup), tunable via `OBJECK_JIT_THRESHOLD` (a single short run at the default threshold doesn't amortize compilation).
 


### PR DESCRIPTION
## Summary
Re-ran the **full unified Docker benchmark** (Objeck + Python/Ruby/LuaJIT/Java, median of 3) on the Ryzen 9 7950X3D after the P2 JIT correctness work, and refreshed every measured table in `docs/performance.md` from that one coherent run.

## CLBG (Objeck)
| | mandelbrot | nbody | binarytrees | fannkuchredux | spectralnorm |
|---|---|---|---|---|---|
| new | 0.87 | 18.42 | 8.53 | 32.32 | 44.86 |
| prior | 0.81 | 17.70 | 7.79 | 30.67 | 43.11 |

~4–9% higher: the **long-running CLBG sustain at lower boost** than the prior measurement, while the **short micro-benchmarks hit full boost and are unchanged** (so the micro table is left as-is — it still matches exactly).

## Cross-language (all five re-measured in the same run → ratios stay comparable)
nbody Objeck 18.42 / Py 137.70 / Ruby 216.06 / LuaJIT 4.57 / **Java 2.38**; binarytrees 8.53 / 3.72 / 3.73 / 3.86 / **0.52**; spectralnorm 44.86 / 131.63 / 89.91 / **1.15** / 1.20; fannkuchredux 32.32 / 432.21 / 1252.25 / 122.52 / **21.30**. Updated the reading ratios (nbody 7.5x/11.7x, fannkuch 13.4x/38.7x & 3.8x vs LuaJIT, binarytrees now ~16x vs Java — Java's binarytrees has high JIT-warmup variance this run).

## spectralnorm / DYN_MTHD_CALL
Default ~45s, `OBJECK_JIT_THRESHOLD=1` = **3.3s (~14x)**, n=2000 ~0.46s approaching hand-`native` 0.37s — coverage gap stays closed. Added the unified-run date row.

Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)