### PR TITLE
fix(jit/compiler): two JIT crashes in SDL games — int-compare opcode + libc-call cache clobber (malloc corruption)

### DIFF
--- a/core/compiler/intermediate.cpp
+++ b/core/compiler/intermediate.cpp
@@ -5186,11 +5186,34 @@ void IntermediateEmitter::EmitAndOr(CalculatedExpression* expression)
  ****************************/
 static bool IsScalarFloat(frontend::Expression* e)
 {
-  if(!e->GetEvalType() || e->GetEvalType()->GetType() != frontend::FLOAT_TYPE) {
+  // Effective stack type of the operand. A trailing cast/method-call changes the
+  // value actually pushed -- e.g. `(12.0 + x)->As(Int)` pushes an Int even though
+  // the sub-expression's own eval type is Float. The comparison opcode must match
+  // the post-cast type (mirrors EmitCalculation, which emits the operand then its
+  // method-call + cast); otherwise an integer compare gets a FLOAT opcode, which
+  // bit-compares ints and feeds mismatched operands to the JIT (crash/corruption).
+  frontend::Type* type = e->GetEvalType();
+  frontend::MethodCall* mc = e->GetMethodCall();
+  if(mc) {
+    while(mc->GetMethodCall()) {
+      mc = mc->GetMethodCall();
+    }
+    if(mc->GetCastType()) {
+      type = mc->GetCastType();
+    }
+    else if(mc->GetEvalType()) {
+      type = mc->GetEvalType();
+    }
+  }
+  else if(e->GetCastType()) {
+    type = e->GetCastType();
+  }
+
+  if(!type || type->GetType() != frontend::FLOAT_TYPE) {
     return false;
   }
 
-  if(e->GetEvalType()->GetDimension() < 1) {
+  if(type->GetDimension() < 1) {
     return true;
   }
 
@@ -5292,8 +5315,7 @@ void IntermediateEmitter::EmitCalculation(CalculatedExpression* expression)
     break;
 
   case LES_EXPR:
-    if(left->GetEvalType()->GetType() == frontend::FLOAT_TYPE ||
-       right->GetEvalType()->GetType() == frontend::FLOAT_TYPE) {
+    if(IsScalarFloat(left) || IsScalarFloat(right)) {
       imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(current_statement, expression, cur_line_num, LES_FLOAT));
     } else {
       imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(current_statement, expression, cur_line_num, LES_INT));
@@ -5302,8 +5324,7 @@ void IntermediateEmitter::EmitCalculation(CalculatedExpression* expression)
     break;
 
   case GTR_EXPR:
-    if(left->GetEvalType()->GetType() == frontend::FLOAT_TYPE ||
-       right->GetEvalType()->GetType() == frontend::FLOAT_TYPE) {
+    if(IsScalarFloat(left) || IsScalarFloat(right)) {
       imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(current_statement, expression, cur_line_num, GTR_FLOAT));
     } else {
       imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(current_statement, expression, cur_line_num, GTR_INT));
@@ -5312,8 +5333,7 @@ void IntermediateEmitter::EmitCalculation(CalculatedExpression* expression)
     break;
 
   case LES_EQL_EXPR:
-    if(left->GetEvalType()->GetType() == frontend::FLOAT_TYPE ||
-       right->GetEvalType()->GetType() == frontend::FLOAT_TYPE) {
+    if(IsScalarFloat(left) || IsScalarFloat(right)) {
       imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(current_statement, expression, cur_line_num, LES_EQL_FLOAT));
     } else {
       imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(current_statement, expression, cur_line_num, LES_EQL_INT));
@@ -5322,8 +5342,7 @@ void IntermediateEmitter::EmitCalculation(CalculatedExpression* expression)
     break;
 
   case GTR_EQL_EXPR:
-    if(left->GetEvalType()->GetType() == frontend::FLOAT_TYPE ||
-       right->GetEvalType()->GetType() == frontend::FLOAT_TYPE) {
+    if(IsScalarFloat(left) || IsScalarFloat(right)) {
       imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(current_statement, expression, cur_line_num, GTR_EQL_FLOAT));
     } else {
       imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(current_statement, expression, cur_line_num, GTR_EQL_INT));

--- a/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
+++ b/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
@@ -592,6 +592,13 @@ void JitAmd64::ProcessInstructions() {
             << aux_regs.size() << std::endl;
 #endif
       ProcessFloatCalculation(instr);
+      // ProcessFloatCalculation pops both operands; on an unexpected operand
+      // kind it sets compile_success=false and pushes nothing back. Honor that
+      // here before touching working_stack, or front()/pop_front() underflow
+      // the (now-empty) deque and dereference a garbage RegInstr.
+      if(!compile_success) {
+        break;
+      }
 
       RegInstr* left = working_stack.front();
       working_stack.pop_front(); // pop invalid xmm register
@@ -3286,6 +3293,15 @@ void JitAmd64::loop(long offset)
 
 RegisterHolder* JitAmd64::call_xfunc(double(*func_ptr)(double), RegInstr* left)
 {
+  // The libc call below clobbers caller-saved GP/XMM registers. Any local
+  // variable still held in the register cache (e.g. an object 'self'/param
+  // loaded before a Float->Sin) would be destroyed, and ProcessLoad's
+  // cache-hit path would then hand back the clobbered register -- a wild
+  // (often float-bit) pointer that corrupts the heap on the next store.
+  // Stores are write-through, so flushing just drops the cached registers;
+  // later loads reload from memory.
+  FlushLocalCache();
+
   move_xreg_mem(XMM0, TMP_XMM_0, RBP);
   if(left->GetType() == REG_FLOAT) {
     if(left->GetRegister()->GetRegister() != XMM0) {
@@ -3321,6 +3337,9 @@ RegisterHolder* JitAmd64::call_xfunc2(double(*func_ptr)(double, double), RegInst
 {
   RegInstr* right = working_stack.front();
   working_stack.pop_front();
+
+  // See call_xfunc: drop cached locals across the clobbering libc call.
+  FlushLocalCache();
 
 #ifdef _DEBUG_JIT
   assert(right->GetType() == MEM_FLOAT);

--- a/core/vm/arch/jit/arm64/jit_arm_a64.cpp
+++ b/core/vm/arch/jit/arm64/jit_arm_a64.cpp
@@ -4254,6 +4254,15 @@ void JitArm64::ProcessFloatOperation(StackInstr* instruction)
   assert(left->GetType() == MEM_FLOAT || left->GetType() == REG_FLOAT);
 #endif
 
+  // Drop cached locals across the clobbering libc call. A local var held in the
+  // register cache (e.g. an object 'self'/param loaded before a Float->Sin) lives
+  // in a caller-saved reg the libc blr destroys; ProcessLoad's cache-hit path
+  // would then return the clobbered reg -- a wild (often float-bit) pointer that
+  // corrupts the heap on the next store. Stores are write-through, so flushing
+  // just drops the cached registers; later loads reload from memory. (The
+  // working-stack spill below only covers in-flight temps, not the local cache.)
+  FlushLocalCache();
+
   // Preserve caller-saved working-stack registers across the libc call below (see
   // ProcessFloatOperation2 for the rationale): spill int temps to TMP_X1..TMP_X5,
   // fall back to the interpreter for cases that do not fit.
@@ -4489,6 +4498,9 @@ void JitArm64::ProcessFloatOperation2(StackInstr* instruction)
 #ifdef _DEBUG_JIT_JIT
   assert(left->GetType() == MEM_FLOAT || left->GetType() == REG_FLOAT);
 #endif
+
+  // Drop cached locals across the clobbering libc call (see ProcessFloatOperation).
+  FlushLocalCache();
 
   // Preserve caller-saved working-stack registers across the libc call below. The
   // call clobbers x0-x17/d0-d7, but any pending working-stack temp (e.g. an earlier


### PR DESCRIPTION
Fixes two distinct JIT-related crashes in JIT-compiled SDL games (repro: `programs/deploy/2d_game_13.obs`). Together they take the game from crashing within seconds to fully stable. Both are backend-independent (AMD64 + ARM64); neither reproduces with JIT disabled.

## Bug #1 — compiler emitted a FLOAT comparison opcode for an INT comparison
`type_roll < (12.0 + difficulty * 20.0)->As(Int)` compiled to `F2I; LOAD_INT_VAR; LES_FLOAT` — two Int operands fed to a FLOAT opcode. The relational cases (`< > <= >=`) picked the opcode from the sub-expression's `GetEvalType()` (Float) and ignored the trailing `->As(Int)` cast. Consequences: the AMD64 JIT corrupts its compile-time stack model and **segfaults during compilation**; ARM64 bails to the interpreter; and the comparison is semantically wrong everywhere (bit-compares ints as doubles).

Fix: `IsScalarFloat()` now uses the operand's effective post-cast type and the relational ops route through it like `==`/`<>` already did.

## Bug #2 — JIT local-register cache clobbered across float-transcendental libc calls
Resolves the open `investigate/jit-malloc-corruption` ("BUG IN CLIENT OF LIBMALLOC: memory corruption of free block" / float-bit value used as a pointer).

The JIT local-variable register cache was never invalidated across the libc call emitted for `Float->Sin/Cos/Tan/Exp/...`. A local still held in the cache (e.g. an object `self`/param loaded before a trig call) lives in a caller-saved register the libc call clobbers — often with float bit patterns (hence the `0x3F94...` = `double 0.02` fault PC). `ProcessLoad`'s cache-hit path then returned the clobbered register as a live object pointer, and the next store through it smashed an unrelated heap block (detected late, in the SDL/malloc activity after the corrupting write).

Manifested in `2d_game_13.obs` as a nil/garbage `renderer` in `GamePlatform:DrawStar`/`DrawMushroom` (many `Float->Sin/Cos` before the first `renderer->` use).

Fix: `FlushLocalCache()` before the libc call (AMD64 `call_xfunc`/`call_xfunc2`; ARM64 `ProcessFloatOperation`/`ProcessFloatOperation2`). Stores are write-through, so flushing only drops the cached registers; later loads reload from memory. (ARM64 already spilled working-stack temps per #548, but not the local cache — this closes that gap.)

## Validation
- **x64 (Windows + Linux):** `2d_game_13` went 6/6 fail → 6/6 clean (normal settings) and 5/5 clean under forced-JIT + 32 KB-GC stress.
- **Regression suite:** green — the only failures are unrelated missing-native-`.so` load errors in the test sandbox (crypto/ml/opencv/odbc/diags).
- **ARM64/macOS:** the bug #2 change mirrors the AMD64 fix and the investigation doc, but is **pending on-device validation** (headless repro: `YOUNG_REGION_SIZE = 32KB` + `OBJECK_JIT_THRESHOLD=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
