### PR TITLE
test(debugger): fix flaky macOS 'help' test (capture race on '>' in help text)

### DIFF
--- a/programs/regression/run_debugger_tests.sh
+++ b/programs/regression/run_debugger_tests.sh
@@ -119,6 +119,7 @@ run_test() {
 run_test "help" '
     expect ">"
     send "h\r"
+    expect "q, quit"
     expect ">"
     send "q\r"
     expect eof


### PR DESCRIPTION
## What was failing
CI's `Build macos-arm64` job failed on the debugger suite (`run_debugger_tests.sh`):
```
Running: help... Missing expected output: 'n, next'   →  23 passed, 1 failed  →  exit 1
```
(The "CI Status" failure is just the aggregator reflecting it.)

## It was a flake, not a regression
- **macos-arm64 only** — linux-arm64 ran the *same* suite green (**24/0**).
- It began "failing" on a **docs-only** master merge (#554) whose debugger binary is byte-identical to the passing prior commit → non-deterministic.
- The help source genuinely contains `n, next` (debugger.cpp:2789), color-wrapped *identically* to `s, step` (2788) which matched fine — so it was a dropped line, not missing content.
- The real build + the 162-test main regression pass on all 5 platforms. PR #555 fails the *same* test for the same reason (unrelated to its code).

## Root cause
The `help` test sent `h` then did `expect ">"` intending the prompt — but the help output contains `>` near the **top** (`b, break <file>:<line> [if <expr>]`), so `expect` matched there, mid-output, and immediately quit. The rest of the help (incl. `n, next`) only landed in the captured buffer if it flushed before `expect eof` closed the pipe — a timing race that bit the slower macOS runner.

## Fix
Anchor on the **end** of the help before quitting:
```
send "h\r"
expect "q, quit"   # last help line (line 2800), contains no '>'
expect ">"         # now unambiguously the prompt
send "q\r"
```
The full help is guaranteed captured before the pattern checks → deterministic. Only the `help` test is affected (it's the only command whose output contains the prompt character). Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)