### PR TITLE
fix(jit): bounds-check float-constant pool; fix arm64 heap corruption

### DIFF
--- a/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
+++ b/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
@@ -428,9 +428,17 @@ void JitAmd64::ProcessInstructions() {
       // float literal
     case LOAD_FLOAT_LIT:
 #ifdef _DEBUG_JIT
-      std::wcout << L"LOAD_FLOAT_LIT: value=" << instr->GetFloatOperand() 
+      std::wcout << L"LOAD_FLOAT_LIT: value=" << instr->GetFloatOperand()
             << L"; regs=" << aval_regs.size() << L"," << aux_regs.size() << std::endl;
 #endif
+      // Bounds-check the per-method float-constant pool. Overrunning float_consts
+      // writes the literal's bit pattern past the array end and trashes an adjacent
+      // heap block; bail to the interpreter instead. (MAX_DBLS is larger here than
+      // on arm64, so this is latent on x64, but guard it for parity.)
+      if(floats_index >= MAX_DBLS) {
+        compile_success = false;
+        break;
+      }
       float_consts[floats_index] = instr->GetFloatOperand();
       working_stack.push_front(new RegInstr(&float_consts[floats_index++]));
       break;

--- a/core/vm/arch/jit/arm64/jit_arm_a64.cpp
+++ b/core/vm/arch/jit/arm64/jit_arm_a64.cpp
@@ -414,6 +414,14 @@ void JitArm64::ProcessInstructions() {
       std::wcout << L"LOAD_FLOAT_LIT: value=" << instr->GetFloatOperand()
             << L"; regs=" << aval_regs.size() << endl;
 #endif
+      // Bounds-check the per-method float-constant pool. Overrunning float_consts
+      // writes the literal's bit pattern (e.g. 0.02 -> 0x3F94...) past the array
+      // end and trashes an adjacent heap block, corrupting the heap and crashing
+      // late and non-deterministically. Bail to the interpreter instead.
+      if(floats_index >= MAX_DBLS) {
+        compile_success = false;
+        break;
+      }
       float_consts[floats_index] = instr->GetFloatOperand();
       working_stack.push_front(new RegInstr(&float_consts[floats_index++]));
       break;

--- a/core/vm/arch/jit/arm64/jit_arm_a64.h
+++ b/core/vm/arch/jit/arm64/jit_arm_a64.h
@@ -75,7 +75,7 @@ namespace Runtime {
 
   // buffer sizes
 #define MAX_INTS 128
-#define MAX_DBLS 64
+#define MAX_DBLS 256
 #define BUFFER_SIZE 512
 #define PAGE_SIZE 4096
 


### PR DESCRIPTION
## Problem
JIT-compiled SDL games crash on **arm64 only** (macOS + Windows arm64) with non-deterministic heap corruption — a wild PC, or a crash inside a later `JitArm64::Compile` (`code[index]`). x64 (Linux + Windows) is unaffected.

## Root cause
`ProcessInstructions` writes every `LOAD_FLOAT_LIT` into a fixed `double[MAX_DBLS]` pool with **no bounds check**:
```cpp
float_consts[floats_index] = instr->GetFloatOperand();
working_stack.push_front(new RegInstr(&float_consts[floats_index++]));
```
arm64 set `MAX_DBLS = 64`; amd64 set it to `256`. A method with more float literals than the pool (e.g. `2d_game_13.obs`'s `DrawBackground`, ~92 literals) overruns `float_consts` and writes the literal's bit pattern (`0.02` → `0x3F94…`, `0.012` → `0x3F8E…`) past the array end, trashing an adjacent heap block's header. Corruption surfaces late and non-deterministically.

It's arm64-specific purely because of the smaller pool — x64's 256-slot buffer was big enough that the game never overran it. Distinct from the register-cache-clobber fix in `bea137939` (that fix is correct; the headless `DrawStar`/`DrawGem` repro is clean).

## Fix
- arm64 `MAX_DBLS` 64 → 256 (parity with amd64) so large draw methods still JIT.
- Bounds-check `floats_index` in `LOAD_FLOAT_LIT` on **both** arches; on overflow set `compile_success = false` and bail to the interpreter instead of corrupting the heap. amd64 was latently vulnerable too (>256 literals) — guarded for parity.

## Validation (Apple Silicon)
Caught at the exact faulting store with macOS **Guard Malloc** (`libgmalloc`), which faulted instantly at `float_consts[floats_index]` before the fix and is clean after.

| Test | before | after |
|---|---|---|
| Game under Guard Malloc | instant fault at overrun | clean, no overflow |
| Game, default JIT | crash 5/5 | clean 5/5 |
| Game, forced JIT (threshold=1) | crash | clean 3/3 |
| Headless `jit_repro.obs` | clean | clean |

Total: **0/8 → 8/8 clean**; clean with JIT disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)