### PR TITLE
fix(jit-arm64): emit LDUR for negative loads; fix func-value SIGSEGV

### DIFF
--- a/core/vm/arch/jit/arm64/jit_arm_a64.cpp
+++ b/core/vm/arch/jit/arm64/jit_arm_a64.cpp
@@ -287,8 +287,11 @@ void JitArm64::ProcessParameters(long params) {
       move_mem_reg(0, op_stack_holder->GetRegister(), dest_holder->GetRegister());
       
       RegisterHolder* dest_holder2 = GetRegister();
+      // The func value's second word sits one slot BELOW op_stack[pos]; move_mem_reg
+      // now emits a signed LDUR for the negative displacement (it previously abs()'d
+      // it and read the wrong word above the base).
       move_mem_reg(-(long)(sizeof(size_t)), op_stack_holder->GetRegister(), dest_holder2->GetRegister());
-      
+
       move_mem_reg(OP_STACK_POS, SP, stack_pos_holder->GetRegister());
       dec_mem(0, stack_pos_holder->GetRegister());
       
@@ -363,8 +366,13 @@ void JitArm64::ProcessFunctionCallParameter() {
   
   move_mem_reg(0, op_stack_holder->GetRegister(), op_stack_holder->GetRegister());
   working_stack.push_front(new RegInstr(op_stack_holder));
-  
-  move_mem_reg(4, holder->GetRegister(), holder->GetRegister());
+
+  // Second word of the returned 2-word func value {block_ptr, mthd_cls_id}.
+  // move_mem_reg scales the byte offset by /sizeof(size_t) to build the LDR imm12,
+  // so a literal 4 collapses to imm12=0 and re-reads word 0 -- duplicating block_ptr
+  // and dropping mthd_cls_id, which later lands the method-id in the closure-block
+  // slot and SIGSEGVs on invoke. sizeof(size_t) encodes imm12=1 -> [base,#8].
+  move_mem_reg(sizeof(size_t), holder->GetRegister(), holder->GetRegister());
   working_stack.push_front(new RegInstr(holder));
   
   ReleaseRegister(stack_pos_holder);
@@ -2459,18 +2467,27 @@ void JitArm64::move_reg_mem16(Register src, long offset, Register dest) {
 void JitArm64::move_mem_reg(long offset, Register src, Register dest) {
 #ifdef _DEBUG_JIT_JIT
     std::wcout << L"  " << (++instr_count) << L": [ldr " << GetRegisterName(dest) << L", (" << GetRegisterName(src) << L", #" << offset << L")]" << std::endl;
-    assert(offset > -1);
 #endif
-  
-  uint32_t op_code = 0xF9400000;
-  uint32_t op_src = src << 5;
-  op_code |= op_src;
-  
-  uint32_t op_dest = dest;
-  op_code |= op_dest;
-  
-  uint32_t op_offset = static_cast<uint32_t>(abs(offset) / sizeof(size_t));
-  op_code |= op_offset << 10;
+
+  uint32_t op_code;
+  if(offset < 0) {
+    // LDUR (unscaled, signed 9-bit byte offset) for negative displacements. The
+    // scaled LDR below takes an UNSIGNED imm12 (offset/8) and cannot encode a
+    // negative offset at all -- the old code abs()'d it and read the wrong word
+    // above the base (e.g. op_stack[pos+1] instead of op_stack[pos-1]).
+    assert(offset >= -256);
+    op_code = 0xF8400000;
+    op_code |= (uint32_t)(src) << 5;
+    op_code |= (uint32_t)dest;
+    op_code |= ((uint32_t)(offset & 0x1FF)) << 12;
+  }
+  else {
+    // LDR (unsigned, offset scaled by 8 for a 64-bit load)
+    op_code = 0xF9400000;
+    op_code |= (uint32_t)(src) << 5;
+    op_code |= (uint32_t)dest;
+    op_code |= static_cast<uint32_t>((size_t)offset / sizeof(size_t)) << 10;
+  }
 
   // encode
   AddMachineCode(op_code);


### PR DESCRIPTION
## Problem
Invoking a captured closure retrieved from a collection (`Vector<FuncRef>` → `Get()` → invoke) **SIGSEGVs on ARM64** (macOS + Windows ARM64) once `FuncRef:New`/`Get` get JIT-compiled. x64 (Linux + Windows) is fine; the interpreter is always correct. Surfaced by the `jit_closure_gc_fixup` regression test (not actually a GC bug — crashes with N=5, no GC pressure, under forced JIT; passes JIT-disabled).

## Root cause: the opcode was wrong
`JitArm64::move_mem_reg` only ever emitted a **scaled, unsigned** `LDR` (`imm12 = abs(offset)/8`). It literally cannot encode a **negative** displacement — it `abs()`'d the offset and read the word **above** the base instead of below (the debug `assert(offset > -1)` even documented that negatives were unsupported).

`ProcessParameters` loads the **second word** of a 2-word func value `{block_ptr, mthd_cls_id}` at `op_stack[pos-1]` via `move_mem_reg(-sizeof(size_t), …)`. The `abs()` turned that into `op_stack[pos+1]`, so JIT'd `FuncRef:New` stored a **garbage block pointer** into the FuncRef. A later read returned it, the lambda used it as `self`, and dereferencing the captured slot faulted (`cls_inst_mem` == the method-id word, e.g. `0x140002`).

## Fix the opcode, not the call site
- `move_mem_reg` now emits **`LDUR`** (unscaled, signed 9-bit byte offset) for negative offsets, and the scaled `LDR` for non-negative ones — **byte-identical to before for every existing caller**. The parameter load reverts to the natural `move_mem_reg(-sizeof(size_t))`.
- Latent twin fixed: `ProcessFunctionCallParameter` loaded a returned func value's second word at byte offset **4** (scaled `4/8 → imm12=0`, re-reading word 0 and dropping `mthd_cls_id`); corrected to `sizeof(size_t)`, matching amd64's offset-8.

## Why ARM64-only / why the JIT threshold matters
- Both defects live only in the ARM64 backend; amd64's signed raw-byte `move_mem_reg` reads the right words.
- The corruption appears exactly when `FuncRef:New`/`Get` cross the JIT threshold (verified: threshold=5 → crash on call 5, =10 → call 10, =20 → call 20, =60 → pass). No GC involved (instrumented `CollectMinor`/`CollectMajor` — never fire).

## Validation (Apple Silicon)
- `programs/regression/jit_closure_gc_fixup`: was SIGSEGV (exit 139) → **passes** at every JIT threshold and JIT-disabled.
- Minimal repros (capturing closure via `Vector<FuncRef>`, direct invoke, JIT-New + interp-Get, threshold sweep) all pass.
- **Full POSIX regression suite: 163/163.**
- amd64 backend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)