### PR TITLE
ci: fix broken APT package cache (libopencv .deb permission-denied)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -73,12 +73,17 @@ jobs:
     # Dependency Installation
     # ============================================
 
-    # Linux dependencies with caching
+    # Linux dependencies with caching. Cache a USER-OWNED archive dir (~/apt-cache)
+    # rather than the root-owned /var/cache/apt/archives -- restoring the latter as
+    # the unprivileged runner fails with "tar: ...deb: Permission denied" (it can't
+    # overwrite the root-owned .debs), which silently disabled the cache and spammed
+    # the log with libopencv-*.deb errors. apt downloads into ~/apt-cache via
+    # Dir::Cache::archives, so a cache hit skips re-downloading.
     - name: Cache APT packages (Linux)
       if: runner.os == 'Linux'
       uses: actions/cache@v5
       with:
-        path: /var/cache/apt/archives
+        path: ~/apt-cache
         key: ${{ runner.os }}-${{ matrix.arch }}-apt-${{ hashFiles('.github/workflows/**') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.arch }}-apt-
@@ -86,8 +91,9 @@ jobs:
     - name: Install Linux dependencies
       if: runner.os == 'Linux'
       run: |
+        mkdir -p ~/apt-cache/partial
         sudo apt-get update
-        sudo apt-get install -y \
+        sudo apt-get install -y -o Dir::Cache::archives="$HOME/apt-cache" \
           build-essential \
           libopencv-dev \
           libmbedtls-dev \
@@ -107,7 +113,9 @@ jobs:
           libmp3lame-dev \
           ccache \
           expect
-        sudo chmod -R a+r /var/cache/apt/archives
+        # apt writes the .debs as root; make them runner-owned so the cache-save
+        # step (which runs unprivileged) can read them without permission errors.
+        sudo chown -R "$(id -u):$(id -g)" ~/apt-cache
 
     - name: Configure ODBC test DSN (Linux)
       if: runner.os == 'Linux'

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -154,11 +154,13 @@ jobs:
       # Install Dependencies (Same as CI)
       # ============================================
 
+      # Cache a USER-OWNED archive dir; restoring root-owned /var/cache/apt/archives
+      # as the unprivileged runner fails with "tar: ...deb: Permission denied".
       - name: Cache APT packages (Linux)
         if: runner.os == 'Linux'
         uses: actions/cache@v5
         with:
-          path: /var/cache/apt/archives
+          path: ~/apt-cache
           key: ${{ runner.os }}-${{ matrix.arch }}-apt-release
           restore-keys: |
             ${{ runner.os }}-${{ matrix.arch }}-apt-
@@ -166,8 +168,9 @@ jobs:
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
+          mkdir -p ~/apt-cache/partial
           sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get install -y -o Dir::Cache::archives="$HOME/apt-cache" \
             build-essential \
             libopencv-dev \
             libmbedtls-dev \
@@ -184,6 +187,7 @@ jobs:
             libreadline-dev \
             libeigen3-dev \
             libmp3lame-dev
+          sudo chown -R "$(id -u):$(id -g)" ~/apt-cache
 
       - name: Cache Homebrew (macOS)
         if: runner.os == 'macOS'
@@ -614,18 +618,21 @@ jobs:
           name: version-metadata
           path: core/shared/
 
+      # Cache a USER-OWNED archive dir; restoring root-owned /var/cache/apt/archives
+      # as the unprivileged runner fails with "tar: ...deb: Permission denied".
       - name: Cache APT packages
         uses: actions/cache@v5
         with:
-          path: /var/cache/apt/archives
+          path: ~/apt-cache
           key: ${{ runner.os }}-x64-apt-release
           restore-keys: |
             ${{ runner.os }}-x64-apt-
 
       - name: Install Linux dependencies
         run: |
+          mkdir -p ~/apt-cache/partial
           sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get install -y -o Dir::Cache::archives="$HOME/apt-cache" \
             build-essential \
             libopencv-dev \
             libmbedtls-dev \
@@ -642,6 +649,7 @@ jobs:
             libreadline-dev \
             libeigen3-dev \
             libmp3lame-dev
+          sudo chown -R "$(id -u):$(id -g)" ~/apt-cache
 
       - name: Build Linux x64 toolchain
         working-directory: ./core/release


### PR DESCRIPTION
## Problem
The Linux CI/release jobs cached **`/var/cache/apt/archives`**, which is **root-owned**. On restore, `actions/cache` runs `tar` as the unprivileged runner and can't overwrite the root-owned `.deb`s, so every run logged:

```
tar: .../libopencv-imgproc406t64_4.6.0+dfsg-...deb: Cannot open: Permission denied
##[warning]Failed to restore: "/usr/bin/tar" failed with error: exit code 2
```

(The `libopencv-*.deb` lines are the loudest because OpenCV pulls in the most packages — which is why it reads as an "OpenCV CI issue.") Net effect: the APT cache was **silently dead** (apt re-downloaded every run) and the logs were full of errors. The old `sudo chmod -R a+r` only granted *read*, not the write/ownership a restore needs.

## Fix
Cache a **user-owned** directory (`~/apt-cache`) and point apt's archive cache at it:
```yaml
- uses: actions/cache@v5
  with: { path: ~/apt-cache, ... }
- run: |
    mkdir -p ~/apt-cache/partial
    sudo apt-get update
    sudo apt-get install -y -o Dir::Cache::archives="$HOME/apt-cache" <pkgs>
    sudo chown -R "$(id -u):$(id -g)" ~/apt-cache   # apt writes .debs as root
```
- Restore extracts into a runner-owned dir → **no permission errors**.
- A cache hit reuses the `.debs` (apt skips re-downloading).
- `chown` after install lets the unprivileged cache-save read the root-written `.debs`.

Applied to `ci-build.yml` and **both** Linux dependency steps in `release-build.yml`.

## Notes
- Not a build break (jobs still passed via re-download) — this restores the cache's speedup and removes the error spam.
- No effect on macOS/Windows (separate caches) or on the build output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)