### PR TITLE
ci: silence apt unsandboxed-download warning

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -93,7 +93,7 @@ jobs:
       run: |
         mkdir -p ~/apt-cache/partial
         sudo apt-get update
-        sudo apt-get install -y -o Dir::Cache::archives="$HOME/apt-cache" \
+        sudo apt-get install -y -o Dir::Cache::archives="$HOME/apt-cache" -o APT::Sandbox::User=root \
           build-essential \
           libopencv-dev \
           libmbedtls-dev \

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -170,7 +170,7 @@ jobs:
         run: |
           mkdir -p ~/apt-cache/partial
           sudo apt-get update
-          sudo apt-get install -y -o Dir::Cache::archives="$HOME/apt-cache" \
+          sudo apt-get install -y -o Dir::Cache::archives="$HOME/apt-cache" -o APT::Sandbox::User=root \
             build-essential \
             libopencv-dev \
             libmbedtls-dev \
@@ -632,7 +632,7 @@ jobs:
         run: |
           mkdir -p ~/apt-cache/partial
           sudo apt-get update
-          sudo apt-get install -y -o Dir::Cache::archives="$HOME/apt-cache" \
+          sudo apt-get install -y -o Dir::Cache::archives="$HOME/apt-cache" -o APT::Sandbox::User=root \
             build-essential \
             libopencv-dev \
             libmbedtls-dev \


### PR DESCRIPTION
Follow-up to #562. After moving to a user-owned `~/apt-cache`, apt logs a benign `W: Download is performed unsandboxed as root ... couldn't be accessed by user '_apt' (13: Permission denied)` on each Linux job. Adding `-o APT::Sandbox::User=root` makes apt download as root without the _apt sandbox — harmless on CI (already root) and clears the last 'Permission denied' line. Applied to ci-build.yml + both release-build.yml install steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)