### PR TITLE
ci(windows): retry NuGet restore on transient nuget.org failures

### DIFF
--- a/core/release/deploy_windows.cmd
+++ b/core/release/deploy_windows.cmd
@@ -547,14 +547,26 @@ if "%NUGET_EXE%"=="" (
 	echo ============================================================
 	exit /b 1
 )
+REM Retry the restore: nuget.org intermittently returns transient errors
+REM (HTTP 502 Bad Gateway, dropped connections) on package downloads such as
+REM Microsoft.AI.DirectML, which would otherwise abort an entire release build.
+set NUGET_MAX_ATTEMPTS=5
+set NUGET_ATTEMPT=0
+:nuget_restore_retry
+set /a NUGET_ATTEMPT+=1
 "%NUGET_EXE%" restore onnx.sln
-if errorlevel 1 (
+if not errorlevel 1 goto nuget_restore_ok
+if %NUGET_ATTEMPT% geq %NUGET_MAX_ATTEMPTS% (
 	echo.
 	echo ============================================================
-	echo  ERROR: NuGet restore failed - aborting deploy
+	echo  ERROR: NuGet restore failed after %NUGET_MAX_ATTEMPTS% attempts - aborting deploy
 	echo ============================================================
 	exit /b 1
 )
+echo NuGet restore attempt %NUGET_ATTEMPT% of %NUGET_MAX_ATTEMPTS% failed ^(transient nuget.org error?^) - retrying in 15s...
+powershell -Command "Start-Sleep -Seconds 15" >nul 2>&1
+goto nuget_restore_retry
+:nuget_restore_ok
 
 if [%1] == [arm64] (
 	devenv onnx.sln /rebuild "Release-QNN|ARM64"


### PR DESCRIPTION
## Problem

The Windows release build's ONNX NuGet restore (`core/release/deploy_windows.cmd`) had **no retry**, so a single transient nuget.org error aborted the entire release.

The **v2026.6.2** release build failed exactly this way on **windows-arm64**: nuget.org returned `502 Bad Gateway` / dropped the connection while fetching `Microsoft.AI.DirectML.1.15.4` (a transitive dependency of `Microsoft.ML.OnnxRuntime.DirectML`). The compile had already succeeded and every other platform packaged fine — purely a transient infra hiccup.

```
WARNING: Error downloading 'Microsoft.AI.DirectML.1.15.4' ...
Unable to read data from the transport connection: The connection was closed.
  BadGateway ... 502 (Bad Gateway)
ERROR: NuGet restore failed - aborting deploy
```

## Fix

Wrap `nuget restore onnx.sln` in a **5-attempt loop with a 15s backoff**:

- `nuget restore` is idempotent — already-cached packages aren't re-downloaded, so a retry only re-fetches the package that failed.
- Plain `%VAR%` expansion via a goto-label loop (the script has no `setlocal enabledelayedexpansion`, so a parenthesized `!VAR!` loop wouldn't work).
- `powershell Start-Sleep` rather than `timeout /t`, which needs a console input handle and throws in non-interactive CI.

Build-script only — does not change any shipped artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)