### PR TITLE
fix(compiler): don't warn 'unreferenced' for closure-captured variables

### DIFF
--- a/core/compiler/context.cpp
+++ b/core/compiler/context.cpp
@@ -2258,6 +2258,9 @@ void ContextAnalyzer::AnalyzeVariable(Variable* variable, SymbolEntry* entry, co
     const std::wstring capture_scope_name = capture_method->GetName() + L':' + variable->GetName();
     SymbolEntry* capture_entry = capture_table->GetEntry(capture_scope_name);
     if(capture_entry) {
+      // capturing a variable in a closure is a use of it; mark the enclosing
+      // entry loaded so it isn't reported as unreferenced (see CheckUnreferencedVariables)
+      capture_entry->WasLoaded();
       if(capture_lambda->HasClosure(capture_entry)) {
         SymbolEntry* copy_entry = capture_lambda->GetClosure(capture_entry);
         variable->SetTypes(copy_entry->GetType());


### PR DESCRIPTION
## Problem

A local variable used **only** by being captured in a closure was reported as unreferenced:

```
x := IntRef->New(n);
return FuncRef->New(\() ~ IntRef : () => x)<IntRef>;
//   -> Warning: Variable 'x' is unreferenced
```

The capture path in `AnalyzeVariable` (lambda branch) builds a closure *copy* entry but never marks the enclosing entry as loaded, so `CheckUnreferencedVariables` flagged the original local.

## Fix

Mark the captured outer `capture_entry->WasLoaded()` at capture time — capturing a variable in a closure is a use of it. One line.

- Genuinely-unused locals still warn (verified).
- The closure copy entry is created with `is_local=false`, so it was never subject to the check anyway.

## Verification

- `closure_min` and `jit_closure_gc_fixup` compile **warning-free** and **PASS** in interpreter / default-JIT / forced-JIT.
- A mixed program (captured `x` + a real unused `unused := 99`) warns only on `unused`.
- Full x64 regression: **163/1** (only pre-existing `core_opencv`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)