### PR TITLE
feat(compiler): direct FuncRef callability `v()` + functional-chaining fix (closure ergonomics 1/3)

### DIFF
--- a/core/compiler/context.cpp
+++ b/core/compiler/context.cpp
@@ -4178,28 +4178,40 @@ void ContextAnalyzer::AnalyzeVariableFunctionCall(MethodCall* method_call, const
   // functional-call path on that temp -- reusing the existing
   // STOR/LOAD_FUNC_VAR + DYN_MTHD_CALL lowering (no VM/JIT change).
   if(entry && entry->GetType() && entry->GetType()->GetType() == CLASS_TYPE &&
-     entry->GetType()->GetName() == L"System.FuncRef" && !method_call->GetFuncRefUnwrap()) {
-    Statement* mc_stmt = static_cast<Statement*>(method_call);
-    const std::wstring mc_file = mc_stmt->GetFileName();
-    const int mc_ln = mc_stmt->GetLineNumber();
-    const int mc_lp = mc_stmt->GetLinePosition();
-    ExpressionList* no_args = TreeFactory::Instance()->MakeExpressionList();
-    MethodCall* unwrap = TreeFactory::Instance()->MakeMethodCall(
-      mc_file, mc_ln, mc_lp,
-      method_call->GetMidLineNumber(), method_call->GetMidLinePosition(),
-      mc_stmt->GetEndLineNumber(), mc_stmt->GetEndLinePosition(),
-      method_call->GetMethodName(), L"Get", no_args);
-    AnalyzeMethodCall(unwrap, depth + 1);
+     entry->GetType()->GetName() == L"System.FuncRef") {
+    if(method_call->GetFuncRefUnwrap()) {
+      // Already desugared on an earlier pass (binary-op operands are analyzed
+      // more than once). Reuse the functional temp established the first time
+      // instead of re-synthesizing, otherwise `entry` stays the raw FuncRef and
+      // the call is wrongly rejected as undefined.
+      entry = method_call->GetFunctionalEntry();
+    }
+    else {
+      Statement* mc_stmt = static_cast<Statement*>(method_call);
+      const std::wstring mc_file = mc_stmt->GetFileName();
+      const int mc_ln = mc_stmt->GetLineNumber();
+      const int mc_lp = mc_stmt->GetLinePosition();
+      ExpressionList* no_args = TreeFactory::Instance()->MakeExpressionList();
+      MethodCall* unwrap = TreeFactory::Instance()->MakeMethodCall(
+        mc_file, mc_ln, mc_lp,
+        method_call->GetMidLineNumber(), method_call->GetMidLinePosition(),
+        mc_stmt->GetEndLineNumber(), mc_stmt->GetEndLinePosition(),
+        method_call->GetMethodName(), L"Get", no_args);
+      AnalyzeMethodCall(unwrap, depth + 1);
 
-    Type* unwrap_type = unwrap->GetEvalType();
-    if(unwrap_type && unwrap_type->GetType() == FUNC_TYPE) {
-      const std::wstring tmp_name = current_method->GetName() + L":#funcref_tmp#" +
-        std::to_wstring(mc_ln) + L'#' + std::to_wstring(mc_lp);
-      SymbolEntry* tmp = TreeFactory::Instance()->MakeSymbolEntry(tmp_name, unwrap_type, false, true);
-      current_table->AddEntry(tmp, true);
-      tmp->WasLoaded();
-      method_call->SetFuncRefUnwrap(unwrap);
-      entry = tmp;  // continue as a functional call on the unwrapped temp
+      Type* unwrap_type = unwrap->GetEvalType();
+      if(unwrap_type && unwrap_type->GetType() == FUNC_TYPE) {
+        // unique per desugar site -- two `v()` on one line share a line/position,
+        // so a counter (not line:pos) is required to avoid temp-name collisions
+        static int func_ref_tmp_id = 0;
+        const std::wstring tmp_name = current_method->GetName() + L":#funcref_tmp#" +
+          std::to_wstring(func_ref_tmp_id++);
+        SymbolEntry* tmp = TreeFactory::Instance()->MakeSymbolEntry(tmp_name, unwrap_type, false, true);
+        current_table->AddEntry(tmp, true);
+        tmp->WasLoaded();
+        method_call->SetFuncRefUnwrap(unwrap);
+        entry = tmp;  // continue as a functional call on the unwrapped temp
+      }
     }
   }
 

--- a/core/compiler/context.cpp
+++ b/core/compiler/context.cpp
@@ -4170,6 +4170,39 @@ void ContextAnalyzer::AnalyzeVariableFunctionCall(MethodCall* method_call, const
 {
   // dynamic function call that is not bound to a class/function until runtime
   SymbolEntry* entry = GetEntry(method_call->GetMethodName());
+
+  // Direct call of a FuncRef<R> instance: `v()` desugars to `(v->Get())()`.
+  // FuncRef only wraps a nullary `() ~ R`, so the call is always zero-arg.
+  // Synthesize and resolve the `v->Get()` unwrap, materialize its `() ~ R`
+  // result into a hidden local temp, then fall through to the ordinary
+  // functional-call path on that temp -- reusing the existing
+  // STOR/LOAD_FUNC_VAR + DYN_MTHD_CALL lowering (no VM/JIT change).
+  if(entry && entry->GetType() && entry->GetType()->GetType() == CLASS_TYPE &&
+     entry->GetType()->GetName() == L"System.FuncRef" && !method_call->GetFuncRefUnwrap()) {
+    Statement* mc_stmt = static_cast<Statement*>(method_call);
+    const std::wstring mc_file = mc_stmt->GetFileName();
+    const int mc_ln = mc_stmt->GetLineNumber();
+    const int mc_lp = mc_stmt->GetLinePosition();
+    ExpressionList* no_args = TreeFactory::Instance()->MakeExpressionList();
+    MethodCall* unwrap = TreeFactory::Instance()->MakeMethodCall(
+      mc_file, mc_ln, mc_lp,
+      method_call->GetMidLineNumber(), method_call->GetMidLinePosition(),
+      mc_stmt->GetEndLineNumber(), mc_stmt->GetEndLinePosition(),
+      method_call->GetMethodName(), L"Get", no_args);
+    AnalyzeMethodCall(unwrap, depth + 1);
+
+    Type* unwrap_type = unwrap->GetEvalType();
+    if(unwrap_type && unwrap_type->GetType() == FUNC_TYPE) {
+      const std::wstring tmp_name = current_method->GetName() + L":#funcref_tmp#" +
+        std::to_wstring(mc_ln) + L'#' + std::to_wstring(mc_lp);
+      SymbolEntry* tmp = TreeFactory::Instance()->MakeSymbolEntry(tmp_name, unwrap_type, false, true);
+      current_table->AddEntry(tmp, true);
+      tmp->WasLoaded();
+      method_call->SetFuncRefUnwrap(unwrap);
+      entry = tmp;  // continue as a functional call on the unwrapped temp
+    }
+  }
+
   if(entry && entry->GetType() && entry->GetType()->GetType() == FUNC_TYPE) {
     entry->WasLoaded();
 

--- a/core/compiler/intermediate.cpp
+++ b/core/compiler/intermediate.cpp
@@ -4155,8 +4155,16 @@ void IntermediateEmitter::EmitMethodCallExpression(MethodCall* method_call, bool
       }
     }
 
-    // emit nested calls
-    bool is_nested = false; // function call
+    // emit nested calls -- after a functional call (DYN_MTHD_CALL) the result
+    // is left on the stack, so the first chained call is nested when the
+    // function returns an object. Mirrors the statement-emission site; without
+    // this, `fn()->Method()` in expression context loaded `self` as the
+    // receiver instead of the call result (pre-existing functional-chaining bug).
+    Type* nested_type = entry->GetType();
+    if(nested_type->GetType() == frontend::FUNC_TYPE) {
+      nested_type = nested_type->GetFunctionReturn();
+    }
+    bool is_nested = method_call->GetMethodCall() && nested_type->GetType() == CLASS_TYPE;
     method_call = method_call->GetMethodCall();
     while(method_call) {
       EmitMethodCall(method_call, is_nested);

--- a/core/compiler/intermediate.cpp
+++ b/core/compiler/intermediate.cpp
@@ -1326,6 +1326,16 @@ void IntermediateEmitter::EmitMethodCallStatement(MethodCall* method_call)
       temp = static_cast<MethodCall*>(temp->GetPreviousExpression());
     }
 
+    // Desugared direct FuncRef call `v()`: compute `v->Get()` (leaving the
+    // `() ~ R` func value on the stack) and materialize it into the functional
+    // temp, so the LOAD_FUNC_VAR + DYN_MTHD_CALL below work unchanged.
+    MethodCall* func_ref_unwrap = method_call->GetFuncRefUnwrap();
+    if(func_ref_unwrap) {
+      EmitMethodCall(func_ref_unwrap, true);
+      SymbolEntry* tmp_entry = method_call->GetFunctionalEntry();
+      imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, STOR_FUNC_VAR, tmp_entry->GetId(), LOCL));
+    }
+
     // emit function variable
     MemoryContext mem_context;
     SymbolEntry* entry = method_call->GetFunctionalEntry();
@@ -4061,6 +4071,16 @@ void IntermediateEmitter::EmitMethodCallExpression(MethodCall* method_call, bool
       EmitMethodCallParameters(temp);
       // update
       temp = static_cast<MethodCall*>(temp->GetPreviousExpression());
+    }
+
+    // Desugared direct FuncRef call `v()`: compute `v->Get()` (leaving the
+    // `() ~ R` func value on the stack) and materialize it into the functional
+    // temp, so the LOAD_FUNC_VAR + DYN_MTHD_CALL below work unchanged.
+    MethodCall* func_ref_unwrap = method_call->GetFuncRefUnwrap();
+    if(func_ref_unwrap) {
+      EmitMethodCall(func_ref_unwrap, true);
+      SymbolEntry* tmp_entry = method_call->GetFunctionalEntry();
+      imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(static_cast<Statement*>(method_call), cur_line_num, STOR_FUNC_VAR, tmp_entry->GetId(), LOCL));
     }
 
     // emit function variable

--- a/core/compiler/tree.h
+++ b/core/compiler/tree.h
@@ -2863,6 +2863,7 @@ namespace frontend {
     bool is_dyn_func_call;
     instructions::MemoryType is_rouge_return;
     SymbolEntry* dyn_func_entry;
+    MethodCall* func_ref_unwrap;
     std::vector<Type*> concrete_types;
     int mid_line_num;
     int mid_line_pos;
@@ -2892,6 +2893,7 @@ namespace frontend {
       original_klass = nullptr;
       original_lib_klass = nullptr;
       is_enum_call = is_func_def = is_dyn_func_call = false;
+      func_ref_unwrap = nullptr;
       is_rouge_return = instructions::NIL_TYPE;
       func_rtrn = nullptr;
       anonymous_klass = nullptr;
@@ -2916,6 +2918,7 @@ namespace frontend {
       original_klass = nullptr;
       original_lib_klass = nullptr;
       is_enum_call = is_func_def = is_dyn_func_call = false;
+      func_ref_unwrap = nullptr;
       is_rouge_return = instructions::NIL_TYPE;
       func_rtrn = nullptr;
       anonymous_klass = nullptr;
@@ -2938,6 +2941,7 @@ namespace frontend {
       original_klass = nullptr;
       original_lib_klass = nullptr;
       is_enum_call = is_func_def = is_dyn_func_call = false;
+      func_ref_unwrap = nullptr;
       is_rouge_return = instructions::NIL_TYPE;
       func_rtrn = nullptr;
       anonymous_klass = nullptr;
@@ -2963,6 +2967,7 @@ namespace frontend {
       original_klass = nullptr;
       original_lib_klass = nullptr;
       is_enum_call = is_func_def = is_dyn_func_call = false;
+      func_ref_unwrap = nullptr;
       func_rtrn = nullptr;
       is_rouge_return = instructions::NIL_TYPE;
       anonymous_klass = nullptr;
@@ -3015,6 +3020,17 @@ namespace frontend {
 
     SymbolEntry* GetFunctionalEntry() {
       return dyn_func_entry;
+    }
+
+    // For a desugared direct FuncRef call `v(args)`: the synthesized `v->Get()`
+    // unwrap whose result is materialized into the functional-entry temp before
+    // the DYN_MTHD_CALL. Null for ordinary `fn()` functional calls.
+    void SetFuncRefUnwrap(MethodCall* m) {
+      func_ref_unwrap = m;
+    }
+
+    MethodCall* GetFuncRefUnwrap() {
+      return func_ref_unwrap;
     }
 
     void SetEnumCall(bool e) {

--- a/programs/regression/closure_direct_call.obs
+++ b/programs/regression/closure_direct_call.obs
@@ -1,0 +1,58 @@
+# Regression for direct FuncRef callability: `v()` where v is a FuncRef<R>
+# instance. The compiler desugars v() to (v->Get())() via a hidden temp,
+# reusing the existing DYN_MTHD_CALL lowering. Exercises expression-RHS,
+# bound-collection-element, and standalone-statement positions, and confirms
+# the classic two-step still works. Exits non-zero on any mismatch so the suite
+# catches a regression in every JIT mode.
+#
+# NOTE: results are bound to a variable before calling ->Get(); chaining a
+# method directly on a functional-call result (`v()->Get()`) hits a separate,
+# pre-existing functional-call-chaining bug and is intentionally avoided here.
+use Collection;
+
+class ClosureDirectCall {
+  function : Main(args : String[]) ~ Nil {
+    pass := true;
+
+    # direct call, expression RHS
+    v := Mk(7);
+    r := v();
+    if(r->Get() <> 7) { pass := false; };
+
+    # direct call again on the same FuncRef (pure capture, stable)
+    r2 := v();
+    if(r2->Get() <> 7) { pass := false; };
+
+    # direct call on a FuncRef pulled from a collection (bound to a variable)
+    fns := Vector->New()<FuncRef<IntRef>>;
+    for(i := 0; i < 5; i += 1;) { fns->AddBack(Mk(i * 7)); };
+    idx := 0;
+    each(i : fns) {
+      f := fns->Get(i);
+      fr := f();
+      if(fr->Get() <> idx * 7) { pass := false; };
+      idx += 1;
+    };
+
+    # standalone statement (result discarded) must not crash
+    v();
+
+    # the classic two-step must still work unchanged
+    fn := v->Get();
+    tr := fn();
+    if(tr->Get() <> 7) { pass := false; };
+
+    if(pass) {
+      "PASS: direct FuncRef call"->PrintLine();
+    }
+    else {
+      "FAIL: direct FuncRef call"->PrintLine();
+      Runtime->Exit(1);
+    };
+  }
+
+  function : Mk(n : Int) ~ FuncRef<IntRef> {
+    x := IntRef->New(n);
+    return FuncRef->New(\() ~ IntRef : () => x)<IntRef>;
+  }
+}

--- a/programs/regression/closure_direct_call.obs
+++ b/programs/regression/closure_direct_call.obs
@@ -1,46 +1,46 @@
-# Regression for direct FuncRef callability: `v()` where v is a FuncRef<R>
-# instance. The compiler desugars v() to (v->Get())() via a hidden temp,
-# reusing the existing DYN_MTHD_CALL lowering. Exercises expression-RHS,
-# bound-collection-element, and standalone-statement positions, and confirms
-# the classic two-step still works. Exits non-zero on any mismatch so the suite
-# catches a regression in every JIT mode.
+# Regression for direct FuncRef callability `v()` and functional-call result
+# chaining `v()->Method()` / `fn()->Method()` in expression context.
 #
-# NOTE: results are bound to a variable before calling ->Get(); chaining a
-# method directly on a functional-call result (`v()->Get()`) hits a separate,
-# pre-existing functional-call-chaining bug and is intentionally avoided here.
+# - `v()` (v is a FuncRef<R>) desugars to (v->Get())() via a hidden temp,
+#   reusing the existing DYN_MTHD_CALL lowering (no VM/JIT change).
+# - chaining a method on a functional-call result in expression context
+#   (`v()->Get()`, `fn()->Get()`) previously loaded `self` as the receiver
+#   instead of the call result; now fixed to mirror statement context.
+#
+# Exits non-zero on any mismatch so the suite catches a regression in every
+# JIT mode.
 use Collection;
 
 class ClosureDirectCall {
   function : Main(args : String[]) ~ Nil {
     pass := true;
 
-    # direct call, expression RHS
+    # direct call, result bound
     v := Mk(7);
     r := v();
     if(r->Get() <> 7) { pass := false; };
 
-    # direct call again on the same FuncRef (pure capture, stable)
-    r2 := v();
-    if(r2->Get() <> 7) { pass := false; };
+    # direct call with inline ->Get() chaining (expression position)
+    if(v()->Get() <> 7) { pass := false; };
+    sum := v()->Get() + v()->Get();
+    if(sum <> 14) { pass := false; };
 
-    # direct call on a FuncRef pulled from a collection (bound to a variable)
+    # direct call on a FuncRef pulled from a collection, inline chaining
     fns := Vector->New()<FuncRef<IntRef>>;
     for(i := 0; i < 5; i += 1;) { fns->AddBack(Mk(i * 7)); };
     idx := 0;
     each(i : fns) {
       f := fns->Get(i);
-      fr := f();
-      if(fr->Get() <> idx * 7) { pass := false; };
+      if(f()->Get() <> idx * 7) { pass := false; };
       idx += 1;
     };
 
     # standalone statement (result discarded) must not crash
     v();
 
-    # the classic two-step must still work unchanged
+    # classic two-step, with inline chaining on the call result
     fn := v->Get();
-    tr := fn();
-    if(tr->Get() <> 7) { pass := false; };
+    if(fn()->Get() <> 7) { pass := false; };
 
     if(pass) {
       "PASS: direct FuncRef call"->PrintLine();


### PR DESCRIPTION
First of the three closure-ergonomics changes: a `FuncRef<R>` value can be **called directly** as `v()` (and `v()->Get()`) instead of the two-step `fn := v->Get(); fn()`.

## Commits
1. **Direct callability `v()`** — the context analyzer desugars `v()` into `(v->Get())()`: synthesize+resolve the `v->Get()` unwrap, materialize its `() ~ R` result into a hidden local temp, then use the normal functional-call path on that temp. The emitter STOR_FUNC_VARs the unwrap into the temp before the existing `LOAD_FUNC_VAR` + `DYN_MTHD_CALL`, at both the statement and expression sites. FuncRef only wraps a nullary `() ~ R`, so the call is always zero-arg. **No VM/JIT codegen change.**
2. **Functional-call result chaining fix** (pre-existing bug) — `fn()->Method()` / `v()->Method()` in expression context emitted the chained call as non-nested, loading `self` instead of the stack result → nil deref. Mirrored the statement-site nesting logic. Fixes the old two-step `fn()->Get()` too.
3. **Robustness** — handle re-analyzed calls (binary-op operands analyze twice) and uniquely-name the temp (two `v()` on one line).

## Works
`v()`, inline `v()->Get()`, two calls in one expression (`v()->Get() + v()->Get()`), bound collection elements, standalone statements, and the classic two-step — all in interpreter / default-JIT / forced-JIT.

## Still deferred
Calling a method-call *result* with no binding via a literal `expr()` (e.g. `fns->Get(i)()`) needs a parser change — that's the Option B / general `expr()` follow-up.

## Validation
- New/expanded test `programs/regression/closure_direct_call.obs`.
- Full x64 regression **165/0** at default and `OBJECK_JIT_THRESHOLD=1`.
- ARM64 on-device validation pending (no codegen change → expected safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)