### PR TITLE
fix(compiler): closure captures use closure-local ids (multi-lambda heap corruption)

### DIFF
--- a/core/compiler/context.cpp
+++ b/core/compiler/context.cpp
@@ -2270,6 +2270,7 @@ void ContextAnalyzer::AnalyzeVariable(Variable* variable, SymbolEntry* entry, co
       else {
         const std::wstring var_scope_name = current_method->GetName() + L':' + variable->GetName();
         SymbolEntry* copy_entry = TreeFactory::Instance()->MakeSymbolEntry(var_scope_name, capture_entry->GetType(), false, false);
+        copy_entry->SetClosureEntry();
         symbol_table->GetSymbolTable(current_class->GetName())->AddEntry(copy_entry, true);
 
         variable->SetTypes(copy_entry->GetType());

--- a/core/compiler/intermediate.cpp
+++ b/core/compiler/intermediate.cpp
@@ -846,6 +846,14 @@ void IntermediateEmitter::EmitLambda(Lambda* lambda)
   long closure_space = 0;
   IntermediateDeclarations* closure_dclrs = new IntermediateDeclarations;
   std::vector<std::pair<SymbolEntry*, SymbolEntry*> > closure_copies = lambda->GetClosures();
+  // Closure captures are stored at closure-LOCAL offsets (0-based per lambda),
+  // matching the positional GC closure-declaration scan. They were excluded from
+  // class-instance numbering, so assign their ids here. Without this, a second
+  // capturing lambda inherits class-global ids and its stores overflow the
+  // per-lambda closure allocation (heap corruption).
+  for(size_t i = 0; i < closure_copies.size(); ++i) {
+    closure_copies[i].first->SetId((int)i);
+  }
   for(size_t i = 0; i < closure_copies.size(); ++i) {
     SymbolEntry* entry = closure_copies[i].second;
     switch(entry->GetType()->GetType()) {
@@ -6495,6 +6503,9 @@ int IntermediateEmitter::CalculateEntrySpace(SymbolTable* table, int &index, Int
         
     for(size_t i = 0; i < entries.size(); ++i) {
       SymbolEntry* entry = entries[i];
+      if(entry->IsClosureEntry()) {
+        continue;
+      }
       if(!entry->IsSelf() && entry->IsStatic() == is_static) {
         switch(entry->GetType()->GetType()) {
         case frontend::BOOLEAN_TYPE:

--- a/core/compiler/tree.h
+++ b/core/compiler/tree.h
@@ -119,8 +119,9 @@ namespace frontend {
     bool is_self;
     bool is_param;
     bool is_loaded;
+    bool is_closure;
 
-  SymbolEntry(const std::wstring &file_name, const int line_num, const int line_pos, const std::wstring &n, Type* t, 
+  SymbolEntry(const std::wstring &file_name, const int line_num, const int line_pos, const std::wstring &n, Type* t,
         bool s, bool c, bool e = false) : ParseNode(file_name, line_num, line_pos) {
       name = n;
       id = -1;
@@ -129,6 +130,7 @@ namespace frontend {
       is_local = c;
       is_self = e;
       is_param = is_loaded = false;
+      is_closure = false;
     }
 
     ~SymbolEntry() {
@@ -149,6 +151,14 @@ namespace frontend {
 
     bool IsLoaded() {
       return is_loaded;
+    }
+
+    void SetClosureEntry() {
+      is_closure = true;
+    }
+
+    bool IsClosureEntry() {
+      return is_closure;
     }
 
     void SetType(Type* t) {

--- a/programs/regression/closure_multi_capture.obs
+++ b/programs/regression/closure_multi_capture.obs
@@ -1,0 +1,43 @@
+# Regression for multiple capturing lambdas in one class.
+#
+# Each lambda's captured variables live in per-lambda closure memory at
+# CLOSURE-LOCAL offsets. They were being numbered with class-global instance
+# ids, so a second capturing lambda's capture got a higher id and its closure
+# store wrote past the (per-lambda-sized) closure allocation -> intermittent
+# heap corruption under GC. The fix assigns closure-local (0-based per lambda)
+# ids at emit time. This test defines several capturing lambdas and exercises
+# them under heavy GC churn; it exits non-zero on any wrong value.
+use Collection;
+
+class ClosureMultiCapture {
+  function : Main(args : String[]) ~ Nil {
+    bad := 0;
+    for(j := 0; j < 4000; j += 1;) {
+      a := MkA(j);       ar := a();  if(ar->Get() <> j) { bad += 1; };
+      b := MkB(j + 1);   br := b();  if(br->Get() <> j + 1) { bad += 1; };
+      c := MkC(j, j*2);  cr := c();  if(cr->Get() <> j * 3) { bad += 1; };
+      junk := Int->New[32];   # GC pressure
+    };
+    if(bad = 0) {
+      "PASS: multi-capture closures"->PrintLine();
+    }
+    else {
+      "FAIL: multi-capture closures"->PrintLine();
+      Runtime->Exit(1);
+    };
+  }
+
+  function : MkA(n : Int) ~ FuncRef<IntRef> {
+    x := IntRef->New(n);
+    return FuncRef->New(\() ~ IntRef : () => x)<IntRef>;
+  }
+  function : MkB(n : Int) ~ FuncRef<IntRef> {
+    y := IntRef->New(n);
+    return FuncRef->New(\() ~ IntRef : () => y)<IntRef>;
+  }
+  # a third distinct capturing lambda
+  function : MkC(p : Int, q : Int) ~ FuncRef<IntRef> {
+    r := IntRef->New(p + q);
+    return FuncRef->New(\() ~ IntRef : () => r)<IntRef>;
+  }
+}


### PR DESCRIPTION
## Bug
Two (or more) capturing lambdas in the **same class** caused **intermittent heap corruption under GC** (and a mis-scan of the enclosing class instance). Minimal repro — two closures each capturing a value, exercised under GC churn — corrupts nondeterministically.

## Root cause
A lambda's captured variables live in **per-lambda closure memory** at **closure-local offsets**, but `CalculateEntrySpace` numbered them with **class-global instance ids**. With one capturing lambda the ids are 0-based and it works; a second capturing lambda inherited higher ids, so its capture store `STOR_INT_VAR <id>, INST` wrote **past** its per-lambda closure allocation (`NEW_FUNC_INST`, sized for that lambda's captures only).

IR evidence (two single-capture lambdas):
- before: 2nd lambda → `NEW_FUNC_INST mem_size=8` (1 slot) but `STOR id=1, INST` → **offset 1, out of bounds**
- after: both → `STOR id=0, INST`

## Fix
- Flag closure-capture entries (`SymbolEntry::is_closure`).
- Exclude them from class-instance numbering in `CalculateEntrySpace`.
- Assign **closure-local (0-based per lambda)** ids in `EmitLambda` — matching the **positional** GC closure-declaration scan (`MemoryManager::CheckMemory`) and the per-lambda closure layout.

Assigning at **emit time** (not during context analysis) is required — setting the id during analysis is read by the lambda body and breaks single-lambda closures.

## Validation
- New test `programs/regression/closure_multi_capture.obs` (several capturing lambdas under GC churn).
- Full x64 regression **165/0** at default and `OBJECK_JIT_THRESHOLD=1`; interpreter + both JIT modes agree.
- Compiler-side bytecode fix (capture offsets); no native-codegen change — ARM64 consumes the same corrected bytecode. On-device ARM64 validation pending per workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)