### PR TITLE
feat(compiler): lambda block bodies (closure ergonomics 3/3)

### DIFF
--- a/core/compiler/context.cpp
+++ b/core/compiler/context.cpp
@@ -2279,6 +2279,20 @@ void ContextAnalyzer::AnalyzeVariable(Variable* variable, SymbolEntry* entry, co
         capture_lambda->AddClosure(copy_entry, capture_entry);
       }
     }
+    else {
+      // not a capture -- a new type-inferred local declared inside the lambda
+      // body (e.g. `a := ...` in a `{ }` block body). Create it in the lambda's
+      // own scope, mirroring the normal type-inferred-variable path below.
+      const std::wstring scope_name = current_method->GetName() + L':' + variable->GetName();
+      SymbolEntry* var_entry = TreeFactory::Instance()->MakeSymbolEntry(scope_name, TypeFactory::Instance()->MakeType(VAR_TYPE), false, true);
+      current_table->AddEntry(var_entry, true);
+      if(variable->IsAlt()) {
+        var_entry->WasLoaded();
+      }
+      variable->SetTypes(var_entry->GetType());
+      variable->SetEntry(var_entry);
+      var_entry->AddVariable(variable);
+    }
   }
   // type inferred variable
   else if(current_method) {

--- a/core/compiler/parser.cpp
+++ b/core/compiler/parser.cpp
@@ -1406,28 +1406,16 @@ Lambda* Parser::ParseLambda(int depth) {
   }
   NextToken();
 
-  // parse statement
-  StatementList * statements = TreeFactory::Instance()->MakeStatementList();
+  // parse body
+  StatementList* statements;
+  // block body: `\(...) => { stmt; ...; return expr; }` -- arbitrary statements,
+  // the caller supplies the return (previously restricted to a single if/select)
   if(Match(TOKEN_OPEN_BRACE)) {
-    NextToken();
-
-    Statement* statement = ParseStatement(depth + 1);
-    if(!statement) {
-      return nullptr;
-    }
-
-    if(statement->GetStatementType() != IF_STMT && statement->GetStatementType() != SELECT_STMT) {
-      ProcessError(L"Expected 'if' or 'select' statement", TOKEN_SEMI_COLON);
-    }
-    statements->AddStatement(statement);
-
-    if(!Match(TOKEN_CLOSED_BRACE)) {
-      ProcessError(L"Expected '}'", TOKEN_CLOSED_BRACE);
-    }
-    NextToken();
+    statements = ParseStatementList(depth + 1);
   }
-  // parse expression
+  // expression body: `\(...) => expr` -- sugar for `{ return expr; }`
   else {
+    statements = TreeFactory::Instance()->MakeStatementList();
     Expression* expression = ParseExpression(depth + 1);
     Statement* rtrn_stmt = TreeFactory::Instance()->MakeReturn(file_name, line_num, line_pos, GetLineNumber(), GetLinePosition(), expression);
     statements->AddStatement(rtrn_stmt);

--- a/programs/regression/closure_block_body.obs
+++ b/programs/regression/closure_block_body.obs
@@ -1,0 +1,73 @@
+# Regression for lambda block bodies: `\(...) ~ R : () => { ...; return e; }`.
+# Previously a `{ }` lambda body accepted only a single if/select statement;
+# now it accepts an arbitrary statement list (with the caller's own return),
+# including type-inferred (`:=`) locals declared inside the lambda. The
+# single-expression body `=> e` is unchanged (sugar for `{ return e; }`).
+#
+# Defines several block-body lambdas (which create multiple capturing closures)
+# and exercises them under GC churn -- this also depends on the closure-local
+# capture-id fix to avoid heap corruption across multiple lambdas.
+use Collection;
+
+class ClosureBlockBody {
+  function : Main(args : String[]) ~ Nil {
+    pass := true;
+    for(j := 0; j < 3000; j += 1;) {
+      # block body with a := local and a loop: sum 0..n-1
+      s := SumTo(5);
+      r := s();
+      if(r->Get() <> 10) { pass := false; };          # 0+1+2+3+4
+
+      # block body with control flow (early return)
+      c := Clamp(7);
+      cr := c();
+      if(cr->Get() <> 5) { pass := false; };          # min(7,5) capped at 5
+
+      cz := Clamp(2);
+      czr := cz();
+      if(czr->Get() <> 2) { pass := false; };
+
+      # the classic single-expression body still works
+      e := Identity(42);
+      er := e();
+      if(er->Get() <> 42) { pass := false; };
+
+      junk := Int->New[32];   # GC pressure
+    };
+
+    if(pass) {
+      "PASS: lambda block body"->PrintLine();
+    }
+    else {
+      "FAIL: lambda block body"->PrintLine();
+      Runtime->Exit(1);
+    };
+  }
+
+  # block body: inferred local + for loop + explicit return
+  function : SumTo(n : Int) ~ FuncRef<IntRef> {
+    return FuncRef->New(\() ~ IntRef : () => {
+      acc := IntRef->New(0);
+      for(k := 0; k < n; k += 1;) {
+        acc->Set(acc->Get() + k);
+      };
+      return acc;
+    })<IntRef>;
+  }
+
+  # block body: control flow with early return
+  function : Clamp(v : Int) ~ FuncRef<IntRef> {
+    return FuncRef->New(\() ~ IntRef : () => {
+      if(v > 5) {
+        return IntRef->New(5);
+      };
+      return IntRef->New(v);
+    })<IntRef>;
+  }
+
+  # single-expression body (unchanged)
+  function : Identity(v : Int) ~ FuncRef<IntRef> {
+    x := IntRef->New(v);
+    return FuncRef->New(\() ~ IntRef : () => x)<IntRef>;
+  }
+}


### PR DESCRIPTION
**Stacked on #570** (the closure-local capture-id fix). Base is the #570 branch so this diff shows only the block-body changes; retarget to `master` once #570 lands.

## Feature
A lambda body may now be a full statement block:

```objeck
\() ~ IntRef : () => {
  acc := IntRef->New(0);
  for(k := 0; k < n; k += 1;) { acc->Set(acc->Get() + k); };
  return acc;
}
```

`ParseLambda` now parses an arbitrary statement list (the caller supplies the `return`), instead of only a single `if`/`select`. The single-expression form `=> expr` is unchanged (sugar for `{ return expr; }`).

Also fixes type-inferred (`:=`) locals **inside** a lambda body: the lambda variable-analysis path only handled captures, so a new local fell through unresolved. Non-captures now create a local in the lambda's own scope.

## Why it depends on #570
Block bodies naturally produce several capturing lambdas in one class, which is exactly what surfaced the pre-existing multi-lambda closure-corruption bug fixed in #570. Without it, this feature heap-corrupts under GC.

## Validation
- New test `programs/regression/closure_block_body.obs` (block bodies with inferred locals, loops, control flow, across multiple lambdas under GC churn) — deterministic across reruns.
- Edge cases verified: capture+local, while/for loops, nested if, local mutation.
- Full x64 regression **167/0** at default and `OBJECK_JIT_THRESHOLD=1`; interpreter + both JIT modes agree.
- No native-codegen change; on-device ARM64 validation pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)