### PR TITLE
feat(compiler): bare lambdas + FuncRef auto-wrap (closure ergonomics 2/3)

### DIFF
--- a/core/compiler/context.cpp
+++ b/core/compiler/context.cpp
@@ -1114,6 +1114,44 @@ void ContextAnalyzer::CheckUnreferencedVariables(Method* method)
 }
 
 /****************************
+ * Auto-wraps a bare lambda `\(...) => body` into `FuncRef->New(lambda)<R>`
+ * when it appears where a FuncRef<R> is expected (assignment, return, etc.),
+ * so the lambda body's return type is inferred from R. Returns the original
+ * expression unchanged when no wrapping applies.
+ ****************************/
+Expression* ContextAnalyzer::WrapBareLambdaInFuncRef(Expression* expression, Type* expected, const int depth)
+{
+  // the expected type may carry the short ("FuncRef") or qualified
+  // ("System.FuncRef") name depending on where it was resolved
+  if(expression && expression->GetExpressionType() == LAMBDA_EXPR && expected &&
+     expected->GetType() == CLASS_TYPE &&
+     (expected->GetName() == L"System.FuncRef" || expected->GetName() == L"FuncRef")) {
+    Lambda* lambda = static_cast<Lambda*>(expression);
+    // only bare lambdas: no explicit `~ R :` signature and no alias name
+    if(!lambda->GetLambdaType() && lambda->GetName().empty()) {
+      const std::vector<Type*> generics = expected->GetGenerics();
+      if(generics.size() == 1) {
+        const std::wstring file_name = lambda->GetFileName();
+        const int line_num = lambda->GetLineNumber();
+        const int line_pos = lambda->GetLinePosition();
+
+        ExpressionList* args = TreeFactory::Instance()->MakeExpressionList();
+        args->AddExpression(lambda);
+        MethodCall* wrap = TreeFactory::Instance()->MakeMethodCall(
+          file_name, line_num, line_pos, line_num, line_pos, NEW_INST_CALL, L"FuncRef", args);
+
+        std::vector<Type*> concrete;
+        concrete.push_back(TypeFactory::Instance()->MakeType(generics[0]));
+        wrap->SetConcreteTypes(concrete);
+        return wrap;
+      }
+    }
+  }
+
+  return expression;
+}
+
+/****************************
  * Analyzes a lambda function
  ****************************/
 void ContextAnalyzer::AnalyzeLambda(Lambda* lambda, const int depth)
@@ -5052,6 +5090,12 @@ void ContextAnalyzer::AnalyzeReturn(Return* rtrn, const int depth)
   Type* mthd_type = current_method->GetReturn();
   Expression* expression = rtrn->GetExpression();
   if(expression) {
+    // auto-wrap a bare lambda when the return type is FuncRef<R>
+    Expression* wrapped = WrapBareLambdaInFuncRef(expression, mthd_type, depth);
+    if(wrapped != expression) {
+      rtrn->SetExpression(wrapped);
+      expression = wrapped;
+    }
     AnalyzeExpression(expression, depth + 1);
     // Handle string concatenation: replace ADD_EXPR with STR_CONCAT_EXPR
     if(expression->GetPreviousExpression() && expression->GetPreviousExpression()->GetExpressionType() == STR_CONCAT_EXPR) {
@@ -5209,6 +5253,14 @@ void ContextAnalyzer::AnalyzeAssignment(Assignment* assignment, StatementType ty
   // get last expression for assignment
   Expression* expression = assignment->GetExpression();
   if(expression) {
+    // auto-wrap a bare lambda when the assignment target is FuncRef<R>
+    if(variable && variable->GetEvalType()) {
+      Expression* wrapped = WrapBareLambdaInFuncRef(expression, variable->GetEvalType(), depth);
+      if(wrapped != expression) {
+        assignment->SetExpression(wrapped);
+        expression = wrapped;
+      }
+    }
     AnalyzeExpression(expression, depth + 1);
     if(expression->GetPreviousExpression() && expression->GetPreviousExpression()->GetExpressionType() == STR_CONCAT_EXPR) {
       expression = expression->GetPreviousExpression();

--- a/core/compiler/context.h
+++ b/core/compiler/context.h
@@ -537,6 +537,7 @@ class ContextAnalyzer {
   void AnalyzeExpressions(ExpressionList* parameters, const int depth);
   void AnalyzeExpression(Expression* expression, const int depth);
   void AnalyzeLambda(Lambda* param1, const int depth);
+  Expression* WrapBareLambdaInFuncRef(Expression* expression, Type* expected, const int depth);
   Type* ResolveAlias(const std::wstring& name, const std::wstring& fn, int ln, int lp);
   Type* ResolveAlias(const std::wstring& name, ParseNode* node) {
     return ResolveAlias(name, node->GetFileName(), node->GetLineNumber(), node->GetLinePosition());

--- a/core/compiler/parser.cpp
+++ b/core/compiler/parser.cpp
@@ -1349,16 +1349,37 @@ Lambda* Parser::ParseLambda(int depth) {
   current_method = method;
   symbol_table->NewParseScope();
 
-  // parse derived, alias, or types 
+  // parse derived, alias, or types
   Type* type = nullptr;
   std::wstring alias_name;
   if(Match(TOKEN_OPEN_PAREN)) {
-    type = ParseType(depth + 1);
-
-    if(!Match(TOKEN_COLON)) {
-      ProcessError(TOKEN_COLON);
+    // Disambiguate the explicit-type form `\(<sig>) ~ R : (<params>) => body`
+    // from the bare form `\(<params>) => body` (type inferred from context).
+    // Both start with `(...)`; in the typed form the matching `)` is followed
+    // by `~` (the function type's return marker), in the bare form it is not.
+    int scan = 1;
+    int paren_depth = 1;
+    while(paren_depth > 0 && !Match(TOKEN_END_OF_STREAM, scan)) {
+      if(Match(TOKEN_OPEN_PAREN, scan)) {
+        paren_depth++;
+      }
+      else if(Match(TOKEN_CLOSED_PAREN, scan)) {
+        paren_depth--;
+      }
+      scan++;
     }
-    NextToken();
+
+    if(Match(TOKEN_TILDE, scan)) {
+      // explicit function-type signature
+      type = ParseType(depth + 1);
+
+      if(!Match(TOKEN_COLON)) {
+        ProcessError(TOKEN_COLON);
+      }
+      NextToken();
+    }
+    // else: bare lambda -- the `(...)` is the parameter list, type is inferred
+    // from context; fall through to parameter parsing below with type == nullptr
   }
   else if(Match(TOKEN_HAT)) {
     NextToken();

--- a/programs/regression/closure_bare_lambda.obs
+++ b/programs/regression/closure_bare_lambda.obs
@@ -1,0 +1,77 @@
+# Regression for bare lambdas `\(...) => body` with the return type inferred
+# from context, auto-wrapping into FuncRef<R>:
+#
+#   FuncRef->New(\() => x)<IntRef>        # explicit New, annotation dropped
+#   f : FuncRef<IntRef> := \() => x       # assignment target -> auto-wrap
+#   return \() => x                       # return type FuncRef<IntRef> -> auto-wrap
+#
+# The verbose form `\() ~ IntRef : () => x` is unchanged. Block bodies and
+# params work with the bare form too.
+use Collection;
+
+class ClosureBareLambda {
+  function : Main(args : String[]) ~ Nil {
+    pass := true;
+
+    # bare lambda as an assignment target typed FuncRef<R>
+    x := IntRef->New(5);
+    f : FuncRef<IntRef> := \() => x;
+    r := f();
+    if(r->Get() <> 5) { pass := false; };
+
+    # bare lambda returned where the method returns FuncRef<R>
+    g := Mk(7);
+    gr := g();
+    if(gr->Get() <> 7) { pass := false; };
+
+    # bare lambda inside explicit FuncRef->New (annotation dropped)
+    h := MkNew(9);
+    hr := h();
+    if(hr->Get() <> 9) { pass := false; };
+
+    # bare lambda with a block body, auto-wrapped on return
+    s := SumTo(5);
+    sr := s();
+    if(sr->Get() <> 10) { pass := false; };
+
+    # the verbose form still works
+    v := MkVerbose(3);
+    vr := v();
+    if(vr->Get() <> 3) { pass := false; };
+
+    if(pass) {
+      "PASS: bare lambda auto-wrap"->PrintLine();
+    }
+    else {
+      "FAIL: bare lambda auto-wrap"->PrintLine();
+      Runtime->Exit(1);
+    };
+  }
+
+  # bare lambda returned, auto-wrapped into FuncRef<IntRef>
+  function : Mk(n : Int) ~ FuncRef<IntRef> {
+    x := IntRef->New(n);
+    return \() => x;
+  }
+
+  # bare lambda inside an explicit FuncRef->New (the `~ IntRef :` is dropped)
+  function : MkNew(n : Int) ~ FuncRef<IntRef> {
+    x := IntRef->New(n);
+    return FuncRef->New(\() => x)<IntRef>;
+  }
+
+  # bare lambda with a block body
+  function : SumTo(n : Int) ~ FuncRef<IntRef> {
+    return \() => {
+      acc := IntRef->New(0);
+      for(k := 0; k < n; k += 1;) { acc->Set(acc->Get() + k); };
+      return acc;
+    };
+  }
+
+  # verbose form, unchanged
+  function : MkVerbose(n : Int) ~ FuncRef<IntRef> {
+    x := IntRef->New(n);
+    return FuncRef->New(\() ~ IntRef : () => x)<IntRef>;
+  }
+}


### PR DESCRIPTION
**Stacked on #571 → #570.** Base is the block-body branch so this diff shows only the bare-lambda changes; retarget down the stack as each lands.

## Feature
Write `\(params) => body` (no `~ RetType :`); the return type is inferred from context. A bare lambda where a `FuncRef<R>` is expected **auto-wraps** into `FuncRef->New(lambda)<R>`:

```objeck
f : FuncRef<IntRef> := \() => x;     # assignment target
return \() => x;                     # method returns FuncRef<IntRef>
FuncRef->New(\() => x)<IntRef>       # explicit New, annotation dropped
```

`ParseLambda` disambiguates `\(<sig>) ~ R : (<p>) => e` from `\(<p>) => e` by lookahead (after the first `(...)`, `~` ⇒ type signature, else ⇒ params). `WrapBareLambdaInFuncRef` synthesizes `FuncRef->New(lambda)<R>` and is hooked into **return** and **assignment** analysis. This emits the **same bytecode** the explicit form would — no new opcodes, no VM/JIT change.

## Known gap (follow-up)
A bare lambda passed **directly as a method argument** where the param is `FuncRef<R>` (e.g. `coll->AddBack(\() => x)`) isn't auto-wrapped yet — that needs the overload-resolution / `DerivedLambdaFunction` path. Workaround: bind to a `FuncRef<R>` local first.

## Validation
- New test `programs/regression/closure_bare_lambda.obs` (assignment, return, explicit New, block-body bare lambda, verbose form).
- Full x64 regression **168/0** at default and `OBJECK_JIT_THRESHOLD=1`; interpreter + both JIT modes agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)