### PR TITLE
feat(compiler): auto-wrap bare lambda passed as a FuncRef<R> argument

### DIFF
--- a/core/compiler/context.cpp
+++ b/core/compiler/context.cpp
@@ -1249,13 +1249,59 @@ Type* ContextAnalyzer::ResolveAlias(const std::wstring& name, const std::wstring
   return alias_type;
 }
 
+/****************************
+ * Wraps the deferred bare-lambda argument of a method call into
+ * FuncRef->New(lambda)<R>, replaces it in the call's parameters, and analyzes
+ * the wrap (which builds the lambda via the normal FuncRef->New(...)<R> path).
+ * Returns true when the argument was wrapped.
+ ****************************/
+bool ContextAnalyzer::DerivedFuncRefLambdaArg(MethodCall* lambda_inferred_call, Type* resolved_param)
+{
+  Expression* bare_lambda = static_cast<Expression*>(lambda_inferred.first);
+  Expression* wrap = WrapBareLambdaInFuncRef(bare_lambda, resolved_param, 0);
+  if(wrap == bare_lambda) {
+    return false;
+  }
+
+  ExpressionList* call_params = lambda_inferred_call->GetCallingParameters();
+  if(!call_params) {
+    return false;
+  }
+
+  const std::vector<Expression*> exprs = call_params->GetExpressions();
+  for(size_t i = 0; i < exprs.size(); ++i) {
+    if(exprs[i] == bare_lambda) {
+      call_params->SetExpression(wrap, i);
+      // re-analyzing the wrap re-enters the inferred-lambda machinery for the
+      // FuncRef->New(...) call, which builds the lambda from its `<R>` generic
+      AnalyzeExpression(wrap, 0);
+      return true;
+    }
+  }
+
+  return false;
+}
+
 Method* ContextAnalyzer::DerivedLambdaFunction(std::vector<Method*>& alt_mthds)
 {
   if(lambda_inferred.first && lambda_inferred.second && alt_mthds.size() == 1) {
     MethodCall* lambda_inferred_call = lambda_inferred.second;
     Method* alt_mthd = alt_mthds[0];
     std::vector<Declaration*> alt_mthd_types = alt_mthd->GetDeclarations()->GetDeclarations();
-    if(alt_mthd_types.size() == 1 && alt_mthd_types[0]->GetEntry() && 
+    // a bare lambda passed where the sole parameter resolves to FuncRef<R>
+    // auto-wraps into FuncRef->New(lambda)<R> (mirrors the assign/return wrap).
+    // Resolve generics first -- a collection element type is often a generic
+    // placeholder (`@T`) that resolves to FuncRef<R>.
+    if(alt_mthd_types.size() == 1 && alt_mthd_types[0]->GetEntry()) {
+      Type* resolved_param = ResolveGenericType(alt_mthd_types[0]->GetEntry()->GetType(), lambda_inferred_call, alt_mthd->GetClass(), nullptr);
+      if(resolved_param && resolved_param->GetType() == CLASS_TYPE &&
+         (resolved_param->GetName() == L"System.FuncRef" || resolved_param->GetName() == L"FuncRef")) {
+        if(DerivedFuncRefLambdaArg(lambda_inferred_call, resolved_param)) {
+          return alt_mthd;
+        }
+      }
+    }
+    if(alt_mthd_types.size() == 1 && alt_mthd_types[0]->GetEntry() &&
        alt_mthd_types[0]->GetEntry()->GetType()->GetType() == FUNC_TYPE) {
       // set parameters
       std::vector<Type*> inferred_type_params;
@@ -1286,6 +1332,18 @@ LibraryMethod* ContextAnalyzer::DerivedLambdaFunction(std::vector<LibraryMethod*
     MethodCall* lambda_inferred_call = lambda_inferred.second;
     LibraryMethod* alt_mthd = alt_mthds[0];
     std::vector<frontend::Type*> alt_mthd_types = alt_mthd->GetDeclarationTypes();
+    // bare lambda passed where the sole parameter resolves to FuncRef<R>
+    // auto-wraps (resolve generics first -- collection element types are often
+    // a generic placeholder `@T` that resolves to FuncRef<R>)
+    if(alt_mthd_types.size() == 1) {
+      Type* resolved_param = ResolveGenericType(alt_mthd_types[0], lambda_inferred_call, nullptr, alt_mthd->GetLibraryClass());
+      if(resolved_param && resolved_param->GetType() == CLASS_TYPE &&
+         (resolved_param->GetName() == L"System.FuncRef" || resolved_param->GetName() == L"FuncRef")) {
+        if(DerivedFuncRefLambdaArg(lambda_inferred_call, resolved_param)) {
+          return alt_mthd;
+        }
+      }
+    }
     if(alt_mthd_types.size() == 1 && alt_mthd_types[0]->GetType() == FUNC_TYPE) {
       // set parameters
       std::vector<Type*> inferred_type_params;

--- a/core/compiler/context.h
+++ b/core/compiler/context.h
@@ -538,6 +538,7 @@ class ContextAnalyzer {
   void AnalyzeExpression(Expression* expression, const int depth);
   void AnalyzeLambda(Lambda* param1, const int depth);
   Expression* WrapBareLambdaInFuncRef(Expression* expression, Type* expected, const int depth);
+  bool DerivedFuncRefLambdaArg(MethodCall* lambda_inferred_call, Type* resolved_param);
   Type* ResolveAlias(const std::wstring& name, const std::wstring& fn, int ln, int lp);
   Type* ResolveAlias(const std::wstring& name, ParseNode* node) {
     return ResolveAlias(name, node->GetFileName(), node->GetLineNumber(), node->GetLinePosition());

--- a/programs/regression/closure_bare_lambda.obs
+++ b/programs/regression/closure_bare_lambda.obs
@@ -39,6 +39,17 @@ class ClosureBareLambda {
     vr := v();
     if(vr->Get() <> 3) { pass := false; };
 
+    # bare lambda passed directly as a method argument typed FuncRef<R>
+    if(CallIt(\() => x) <> 5) { pass := false; };
+
+    # bare lambda passed to a generic collection element typed FuncRef<R>
+    vec := Vector->New()<FuncRef<IntRef>>;
+    y := IntRef->New(11);
+    vec->AddBack(\() => y);
+    ve := vec->Get(0);
+    vr2 := ve();
+    if(vr2->Get() <> 11) { pass := false; };
+
     if(pass) {
       "PASS: bare lambda auto-wrap"->PrintLine();
     }
@@ -46,6 +57,12 @@ class ClosureBareLambda {
       "FAIL: bare lambda auto-wrap"->PrintLine();
       Runtime->Exit(1);
     };
+  }
+
+  # bare lambda passed as a FuncRef<R> method argument auto-wraps
+  function : CallIt(fr : FuncRef<IntRef>) ~ Int {
+    r := fr();
+    return r->Get();
   }
 
   # bare lambda returned, auto-wrapped into FuncRef<IntRef>


### PR DESCRIPTION
Completes the bare-lambda follow-up noted in #572: a bare lambda passed **directly as a method/function argument** whose parameter resolves to `FuncRef<R>` now auto-wraps into `FuncRef->New(lambda)<R>`.

```objeck
Use(\() => x);            // function parameter : FuncRef<IntRef>
vec->AddBack(\() => x);   // Vector<FuncRef<IntRef>> element
```

## How
A bare-lambda argument defers (same as the existing higher-order inference) and reaches `DerivedLambdaFunction` when exact overload matching fails. Both overloads (program-method + library-method) were extended: when the sole parameter **resolves** to `FuncRef<R>` (generics included — a collection element is usually a generic `@T`), the new `DerivedFuncRefLambdaArg` helper wraps the deferred lambda via `WrapBareLambdaInFuncRef`, swaps it into the call's parameters, and re-analyzes it through the normal `FuncRef->New(...)<R>` path.

The pre-existing `() ~ R` higher-order inference (`Map`/`Filter`/`Reduce`) is **unchanged** — a `FUNC_TYPE` parameter skips the FuncRef branch.

## Validation
- Extended `programs/regression/closure_bare_lambda.obs` with method-argument and `Vector->AddBack` cases.
- Full x64 regression **168/0** at default and `OBJECK_JIT_THRESHOLD=1`; interpreter + both JIT modes agree.
- No new opcodes, no `jit_arm_a64.cpp`/`jit_amd_lp64.cpp` change — front-end only, emitting existing bytecode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)