### PR TITLE
ci: capture WER minidump when obr.exe crashes on windows-x64

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -601,6 +601,27 @@ jobs:
     # Regression Tests
     # ============================================
 
+    - name: Enable WER crash dumps for obr.exe (Windows x64)
+      if: runner.os == 'Windows' && matrix.platform != 'windows-arm64'
+      shell: pwsh
+      run: |
+        # Capture a full user-mode minidump if obr.exe faults during the tests below
+        # (target: the intermittent core_thread_gc_stress 0xC0000005 that reproduces
+        # only on this Intel runner, never on local AMD). obr.exe installs no default
+        # SIGSEGV handler unless an Objeck program registers one, so the access
+        # violation propagates to Windows Error Reporting and a dump is written.
+        $dumpDir = Join-Path $env:GITHUB_WORKSPACE 'crashdumps'
+        New-Item -ItemType Directory -Force -Path $dumpDir | Out-Null
+        $base = 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting'
+        $key  = Join-Path $base 'LocalDumps\obr.exe'
+        New-Item -Path $key -Force | Out-Null
+        New-ItemProperty -Path $key -Name 'DumpFolder' -Value $dumpDir -PropertyType ExpandString -Force | Out-Null
+        New-ItemProperty -Path $key -Name 'DumpType'   -Value 2        -PropertyType DWord       -Force | Out-Null
+        New-ItemProperty -Path $key -Name 'DumpCount'  -Value 10       -PropertyType DWord       -Force | Out-Null
+        # Suppress the "app has stopped working" dialog so a crash can't hang the runner.
+        New-ItemProperty -Path $base -Name 'DontShowUI' -Value 1 -PropertyType DWord -Force | Out-Null
+        Write-Host "WER LocalDumps enabled for obr.exe (full dump) -> $dumpDir"
+
     - name: Run regression tests (POSIX)
       if: runner.os != 'Windows' && matrix.platform != 'windows-arm64'
       working-directory: ./programs/regression
@@ -657,6 +678,23 @@ jobs:
         set BIN=..\..\core\release\deploy-${{ matrix.arch }}\bin
         if not exist "%BIN%" set BIN=..\..\core\release\deploy\bin
         python run_dap_tests.py "%BIN%"
+
+    - name: Upload obr.exe crash dump on failure (Windows x64)
+      # Runs whenever an earlier step in this job failed. The dump only exists if
+      # obr.exe actually faulted; if-no-files-found:warn keeps this non-fatal when a
+      # failure was unrelated (e.g. a compile error rather than a crash). The matching
+      # obr.exe (and obr.pdb if the build emitted one) is bundled so the dump can be
+      # symbolized against the exact binary that crashed.
+      if: failure() && runner.os == 'Windows' && matrix.platform != 'windows-arm64'
+      uses: actions/upload-artifact@v6
+      with:
+        name: obr-crashdump-${{ matrix.platform }}
+        path: |
+          crashdumps/*.dmp
+          core/release/deploy-${{ matrix.arch }}/bin/obr.exe
+          core/release/deploy-${{ matrix.arch }}/bin/obr.pdb
+        if-no-files-found: warn
+        retention-days: 14
 
     # ============================================
     # Network Tests (quarantined / non-gating)

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -601,27 +601,6 @@ jobs:
     # Regression Tests
     # ============================================
 
-    - name: Enable WER crash dumps for obr.exe (Windows x64)
-      if: runner.os == 'Windows' && matrix.platform != 'windows-arm64'
-      shell: pwsh
-      run: |
-        # Capture a full user-mode minidump if obr.exe faults during the tests below
-        # (target: the intermittent core_thread_gc_stress 0xC0000005 that reproduces
-        # only on this Intel runner, never on local AMD). obr.exe installs no default
-        # SIGSEGV handler unless an Objeck program registers one, so the access
-        # violation propagates to Windows Error Reporting and a dump is written.
-        $dumpDir = Join-Path $env:GITHUB_WORKSPACE 'crashdumps'
-        New-Item -ItemType Directory -Force -Path $dumpDir | Out-Null
-        $base = 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting'
-        $key  = Join-Path $base 'LocalDumps\obr.exe'
-        New-Item -Path $key -Force | Out-Null
-        New-ItemProperty -Path $key -Name 'DumpFolder' -Value $dumpDir -PropertyType ExpandString -Force | Out-Null
-        New-ItemProperty -Path $key -Name 'DumpType'   -Value 2        -PropertyType DWord       -Force | Out-Null
-        New-ItemProperty -Path $key -Name 'DumpCount'  -Value 10       -PropertyType DWord       -Force | Out-Null
-        # Suppress the "app has stopped working" dialog so a crash can't hang the runner.
-        New-ItemProperty -Path $base -Name 'DontShowUI' -Value 1 -PropertyType DWord -Force | Out-Null
-        Write-Host "WER LocalDumps enabled for obr.exe (full dump) -> $dumpDir"
-
     - name: Run regression tests (POSIX)
       if: runner.os != 'Windows' && matrix.platform != 'windows-arm64'
       working-directory: ./programs/regression
@@ -644,6 +623,45 @@ jobs:
       env:
         OBJECK_DIAG_GENERICS: "1"
       run: run_regression.cmd ${{ matrix.arch }}
+
+    - name: Capture GC-stress crash dump (ProcDump, Windows x64)
+      # Diagnostic (temporary): core_thread_gc_stress segfaults intermittently
+      # (~1 in 3 runs) only on this Intel runner. WER LocalDumps did NOT write a dump
+      # on the crash here (WER pipeline appears disabled on hosted runners), so run the
+      # test in a loop under ProcDump, which captures the full dump itself on the access
+      # violation. continue-on-error keeps this off the job's pass/fail; the regression
+      # step above stays the gate. Detect a capture by a new *.dmp appearing, not exit code.
+      if: always() && runner.os == 'Windows' && matrix.platform != 'windows-arm64'
+      continue-on-error: true
+      working-directory: ./programs/regression
+      shell: pwsh
+      run: |
+        $dumpDir = Join-Path $env:GITHUB_WORKSPACE 'crashdumps'
+        New-Item -ItemType Directory -Force -Path $dumpDir | Out-Null
+        $max = 3
+        for($i=1; $i -le $max; $i++){
+          try { Invoke-WebRequest -Uri 'https://download.sysinternals.com/files/Procdump.zip' -OutFile procdump.zip; break }
+          catch { if($i -eq $max){ throw }; Start-Sleep 10 }
+        }
+        Expand-Archive procdump.zip -DestinationPath procdump -Force
+        $pd  = Join-Path (Resolve-Path procdump) 'procdump64.exe'
+        $bin = Resolve-Path "..\..\core\release\deploy-x64\bin"
+        $obr = Join-Path $bin 'obr.exe'
+        $env:OBJECK_LIB_PATH = (Resolve-Path "$bin\..\lib").Path
+        if(-not (Test-Path 'core_thread_gc_stress.obe')){
+          & "$bin\obc.exe" -src core_thread_gc_stress.obs -opt s3 -dest core_thread_gc_stress.obe
+        }
+        $obe = (Resolve-Path 'core_thread_gc_stress.obe').Path
+        $before = @(Get-ChildItem $dumpDir -Filter *.dmp -ErrorAction SilentlyContinue).Count
+        $caught = $false
+        for($i=1; $i -le 30; $i++){
+          Write-Host "=== gc_stress attempt $i/30 under ProcDump ==="
+          & $pd -accepteula -ma -e -x $dumpDir $obr $obe
+          $now = @(Get-ChildItem $dumpDir -Filter *.dmp -ErrorAction SilentlyContinue).Count
+          if($now -gt $before){ Write-Host "CRASH dump captured on attempt $i"; $caught=$true; break }
+        }
+        Write-Host "Dumps in ${dumpDir}:"; Get-ChildItem $dumpDir -ErrorAction SilentlyContinue | Format-Table Name,Length -AutoSize
+        if(-not $caught){ Write-Host "No crash captured in 30 attempts (test is intermittent)." }
 
     - name: Run debugger tests (POSIX)
       if: runner.os != 'Windows' && matrix.platform != 'windows-arm64'
@@ -679,13 +697,13 @@ jobs:
         if not exist "%BIN%" set BIN=..\..\core\release\deploy\bin
         python run_dap_tests.py "%BIN%"
 
-    - name: Upload obr.exe crash dump on failure (Windows x64)
-      # Runs whenever an earlier step in this job failed. The dump only exists if
-      # obr.exe actually faulted; if-no-files-found:warn keeps this non-fatal when a
-      # failure was unrelated (e.g. a compile error rather than a crash). The matching
-      # obr.exe (and obr.pdb if the build emitted one) is bundled so the dump can be
-      # symbolized against the exact binary that crashed.
-      if: failure() && runner.os == 'Windows' && matrix.platform != 'windows-arm64'
+    - name: Upload obr.exe crash dump (Windows x64)
+      # always() so the dump uploads whether the gate failed or the ProcDump step
+      # caught the crash on a run where the gate happened to pass. The dump only exists
+      # if obr.exe actually faulted; if-no-files-found:warn keeps this non-fatal. The
+      # matching obr.exe (and obr.pdb if the build emitted one) is bundled so the dump
+      # can be symbolized against the exact binary that crashed.
+      if: always() && runner.os == 'Windows' && matrix.platform != 'windows-arm64'
       uses: actions/upload-artifact@v6
       with:
         name: obr-crashdump-${{ matrix.platform }}

--- a/core/vm/arch/memory.cpp
+++ b/core/vm/arch/memory.cpp
@@ -1965,7 +1965,7 @@ void MemoryManager::FixupObject(size_t* mem)
 // not a real object start (interior/garbage self pointer).
 // Prints ONLY on the bad path (rate-limited): no per-object overhead, no timing perturb.
 // REMOVE once the forwarding gap is fixed.
-void MemoryManager::DiagNotForwarded(size_t* self, size_t fwd, const wchar_t* site)
+void MemoryManager::DiagNotForwarded(size_t* self, size_t fwd, const wchar_t* site, StackMethod* method)
 {
   if(old_generation.count((size_t*)fwd)) {
     return;  // genuine forwarded old-gen address — healthy
@@ -1985,6 +1985,8 @@ void MemoryManager::DiagNotForwarded(size_t* self, size_t fwd, const wchar_t* si
                << L" in_range=" << in_range
                << L" type=" << self[TYPE]
                << L" cls=" << (cls ? cls->GetName() : L"<n/a>")
+               << L" method=" << (method ? method->GetName() : L"<null>")
+               << L" lambda=" << (method ? (int)method->IsLambda() : -1)
                << L" minor=" << minor_gc_mode.load(std::memory_order_acquire) << std::endl;
   }
 }
@@ -2044,7 +2046,7 @@ void MemoryManager::FixupRoots(size_t* op_stack, size_t stack_pos)
             size_t fwd = self[MARKED_FLAG];
             if(fwd) {
               *mem = fwd;
-              DiagNotForwarded(self, fwd, L"pda_frames");  // [GC-DIAG] log-only, no behavior change
+              DiagNotForwarded(self, fwd, L"pda_frames", method);  // [GC-DIAG] log-only, no behavior change
             }
           }
         }
@@ -2089,7 +2091,7 @@ void MemoryManager::FixupRoots(size_t* op_stack, size_t stack_pos)
               size_t fwd = self[MARKED_FLAG];
               if(fwd) {
                 *mem = fwd;
-                DiagNotForwarded(self, fwd, L"cur_frame");  // [GC-DIAG] log-only
+                DiagNotForwarded(self, fwd, L"cur_frame", method);  // [GC-DIAG] log-only
               }
             }
           }
@@ -2115,7 +2117,7 @@ void MemoryManager::FixupRoots(size_t* op_stack, size_t stack_pos)
                 size_t fwd = self[MARKED_FLAG];
                 if(fwd) {
                   *mem = fwd;
-                  DiagNotForwarded(self, fwd, L"call_stack");  // [GC-DIAG] log-only
+                  DiagNotForwarded(self, fwd, L"call_stack", method);  // [GC-DIAG] log-only
                 }
               }
             }
@@ -2144,7 +2146,7 @@ void MemoryManager::FixupRoots(size_t* op_stack, size_t stack_pos)
           size_t fwd = self[MARKED_FLAG];
           if(fwd) {
             frame->mem[0] = fwd;
-            DiagNotForwarded(self, fwd, L"jit_self");  // [GC-DIAG] log-only
+            DiagNotForwarded(self, fwd, L"jit_self", method);  // [GC-DIAG] log-only
           }
         }
       }

--- a/core/vm/arch/memory.cpp
+++ b/core/vm/arch/memory.cpp
@@ -776,6 +776,11 @@ void MemoryManager::CollectAllMemory(size_t* op_stack, size_t stack_pos)
 #endif
 }
 
+// [GC-DIAG] young_used snapshot taken at the start of the promote walk, so
+// DiagNotForwarded can tell whether the offending self was inside the range the walk
+// covered. Set in the promote loop below. Temporary; remove with the diag.
+static size_t g_diag_promote_young_used = 0;
+
 #ifdef _WIN32
 unsigned int MemoryManager::CollectMemory(void* arg)
 #else
@@ -927,6 +932,7 @@ void* MemoryManager::CollectMemory(void* arg)
   size_t young_used = young_offset.load(std::memory_order_relaxed);
   size_t dead_young_size = 0;
   size_t promoted_count = 0;
+  g_diag_promote_young_used = young_used;  // [GC-DIAG] snapshot for DiagNotForwarded
 
   // Linear walk through young region
   uint8_t* scan_ptr = young_region;
@@ -1947,8 +1953,17 @@ void MemoryManager::FixupObject(size_t* mem)
 // windows-x64 LoadClsInstIntVar AV (gc-minor-stress-flake). A healthy young root that
 // survived the promote phase carries a forwarding pointer to a real old-gen object;
 // a non-zero MARKED_FLAG that is NOT an old-gen member is a bare GC bit (e.g. 0x1) left
-// by a skipped promotion. Prints ONLY on that bad path (rate-limited), so it adds no
-// per-object overhead and does not perturb the race timing on the healthy path.
+// by a skipped promotion. The extra fields distinguish the remaining hypotheses:
+//   self_off  = (self - young_region): position of self in the nursery
+//   promo_used= young_used the promote walk covered [0, promo_used)
+//   now_off   = young_offset at fixup time (== promo_used under correct STW)
+//   in_range  = self_off < promo_used (the walk SHOULD have visited+promoted it)
+//   type/cls  = is self a real object boundary (valid TYPE / class), or junk/interior?
+// If in_range==1 and type looks valid -> self was unmarked when the walk passed it but
+// marked afterwards => a mark/sweep ORDERING or STW race. If in_range==0 -> a
+// young_offset snapshot race (self beyond the walked range). If type is junk -> self is
+// not a real object start (interior/garbage self pointer).
+// Prints ONLY on the bad path (rate-limited): no per-object overhead, no timing perturb.
 // REMOVE once the forwarding gap is fixed.
 void MemoryManager::DiagNotForwarded(size_t* self, size_t fwd, const wchar_t* site)
 {
@@ -1957,9 +1972,19 @@ void MemoryManager::DiagNotForwarded(size_t* self, size_t fwd, const wchar_t* si
   }
   static std::atomic<int> diag_count{0};
   if(diag_count.fetch_add(1, std::memory_order_relaxed) < 50) {
+    const long long self_off = (long long)((uint8_t*)self - young_region);
+    const size_t now_off = young_offset.load(std::memory_order_acquire);
+    const int in_range = (self_off >= 0 && (size_t)self_off < g_diag_promote_young_used) ? 1 : 0;
+    StackClass* cls = (self[TYPE] == NIL_TYPE) ? (StackClass*)self[SIZE_OR_CLS] : nullptr;
     std::wcerr << L"[GC-DIAG] marked-but-not-forwarded young root @" << site
                << L": self=" << self << L" fwd=0x" << std::hex << fwd
                << L" markbits=0x" << (self[MARKED_FLAG] & 0x7ULL) << std::dec
+               << L" self_off=" << self_off
+               << L" promo_used=" << g_diag_promote_young_used
+               << L" now_off=" << now_off
+               << L" in_range=" << in_range
+               << L" type=" << self[TYPE]
+               << L" cls=" << (cls ? cls->GetName() : L"<n/a>")
                << L" minor=" << minor_gc_mode.load(std::memory_order_acquire) << std::endl;
   }
 }

--- a/core/vm/arch/memory.cpp
+++ b/core/vm/arch/memory.cpp
@@ -974,6 +974,20 @@ void* MemoryManager::CollectMemory(void* arg)
     scan_ptr += total;
   }
 
+  // [GC-DIAG] Promote walk must land EXACTLY on the end of the used nursery. If it
+  // overshoots/undershoots, a bad size header (raw_mem[0]) desynced the linear walk,
+  // which silently skips the objects after the desync point — they stay marked but
+  // unforwarded, and FixupRoots' "fix up self" then writes their bare GC_MARK_BIT (1)
+  // into a root slot -> later wild deref in LoadClsInstIntVar. Prints only on anomaly,
+  // so zero overhead on the healthy path (no Heisenbug masking). See gc-minor-stress-flake.
+  if(scan_ptr != young_region + young_used) {
+    std::wcerr << L"[GC-DIAG] promote-walk DESYNC: scan_ptr off by "
+               << (long long)((uint8_t*)scan_ptr - (young_region + young_used))
+               << L" bytes; young_used=" << young_used
+               << L"; promoted=" << promoted_count
+               << L"; minor=" << minor_gc_mode.load(std::memory_order_acquire) << std::endl;
+  }
+
 
   // --- Sweep old generation (major GC only) ---
   size_t dead_old_count = 0;
@@ -1929,6 +1943,27 @@ void MemoryManager::FixupObject(size_t* mem)
   }
 }
 
+// [GC-DIAG] Detects the marked-but-not-forwarded young root behind the intermittent
+// windows-x64 LoadClsInstIntVar AV (gc-minor-stress-flake). A healthy young root that
+// survived the promote phase carries a forwarding pointer to a real old-gen object;
+// a non-zero MARKED_FLAG that is NOT an old-gen member is a bare GC bit (e.g. 0x1) left
+// by a skipped promotion. Prints ONLY on that bad path (rate-limited), so it adds no
+// per-object overhead and does not perturb the race timing on the healthy path.
+// REMOVE once the forwarding gap is fixed.
+void MemoryManager::DiagNotForwarded(size_t* self, size_t fwd, const wchar_t* site)
+{
+  if(old_generation.count((size_t*)fwd)) {
+    return;  // genuine forwarded old-gen address — healthy
+  }
+  static std::atomic<int> diag_count{0};
+  if(diag_count.fetch_add(1, std::memory_order_relaxed) < 50) {
+    std::wcerr << L"[GC-DIAG] marked-but-not-forwarded young root @" << site
+               << L": self=" << self << L" fwd=0x" << std::hex << fwd
+               << L" markbits=0x" << (self[MARKED_FLAG] & 0x7ULL) << std::dec
+               << L" minor=" << minor_gc_mode.load(std::memory_order_acquire) << std::endl;
+  }
+}
+
 void MemoryManager::FixupRoots(size_t* op_stack, size_t stack_pos)
 {
   // Fix up GC-triggering thread's operand stack. Conservative scan of untyped words:
@@ -1982,7 +2017,10 @@ void MemoryManager::FixupRoots(size_t* op_stack, size_t stack_pos)
           size_t* self = (size_t*)(*mem);
           if(self && IsYoung(self)) {
             size_t fwd = self[MARKED_FLAG];
-            if(fwd) *mem = fwd;
+            if(fwd) {
+              *mem = fwd;
+              DiagNotForwarded(self, fwd, L"pda_frames");  // [GC-DIAG] log-only, no behavior change
+            }
           }
         }
 
@@ -2024,7 +2062,10 @@ void MemoryManager::FixupRoots(size_t* op_stack, size_t stack_pos)
             size_t* self = (size_t*)(*mem);
             if(self && IsYoung(self)) {
               size_t fwd = self[MARKED_FLAG];
-              if(fwd) *mem = fwd;
+              if(fwd) {
+                *mem = fwd;
+                DiagNotForwarded(self, fwd, L"cur_frame");  // [GC-DIAG] log-only
+              }
             }
           }
           size_t* local_mem = mem + (method->HasAndOr() ? 2 : 1);
@@ -2047,7 +2088,10 @@ void MemoryManager::FixupRoots(size_t* op_stack, size_t stack_pos)
               size_t* self = (size_t*)(*mem);
               if(self && IsYoung(self)) {
                 size_t fwd = self[MARKED_FLAG];
-                if(fwd) *mem = fwd;
+                if(fwd) {
+                  *mem = fwd;
+                  DiagNotForwarded(self, fwd, L"call_stack");  // [GC-DIAG] log-only
+                }
               }
             }
             size_t* local_mem = mem + (method->HasAndOr() ? 2 : 1);
@@ -2073,7 +2117,10 @@ void MemoryManager::FixupRoots(size_t* op_stack, size_t stack_pos)
         size_t* self = (size_t*)frame->mem[0];
         if(self && IsYoung(self)) {
           size_t fwd = self[MARKED_FLAG];
-          if(fwd) frame->mem[0] = fwd;
+          if(fwd) {
+            frame->mem[0] = fwd;
+            DiagNotForwarded(self, fwd, L"jit_self");  // [GC-DIAG] log-only
+          }
         }
       }
 

--- a/core/vm/arch/memory.h
+++ b/core/vm/arch/memory.h
@@ -255,7 +255,7 @@ class MemoryManager {
   static void FixupMemory(size_t* mem, StackDclr** dclrs, const long dcls_size);
   static void FixupRoots(size_t* op_stack, size_t stack_pos);
   // [GC-DIAG] temporary diagnostic for the windows-x64 minor-GC forwarding gap; remove after fix.
-  static void DiagNotForwarded(size_t* self, size_t fwd, const wchar_t* site);
+  static void DiagNotForwarded(size_t* self, size_t fwd, const wchar_t* site, StackMethod* method);
 
 #ifdef _MEM_LOGGING
   static ofstream mem_logger;

--- a/core/vm/arch/memory.h
+++ b/core/vm/arch/memory.h
@@ -254,6 +254,8 @@ class MemoryManager {
   static void FixupObject(size_t* mem);
   static void FixupMemory(size_t* mem, StackDclr** dclrs, const long dcls_size);
   static void FixupRoots(size_t* op_stack, size_t stack_pos);
+  // [GC-DIAG] temporary diagnostic for the windows-x64 minor-GC forwarding gap; remove after fix.
+  static void DiagNotForwarded(size_t* self, size_t fwd, const wchar_t* site);
 
 #ifdef _MEM_LOGGING
   static ofstream mem_logger;


### PR DESCRIPTION
## Why

`core_thread_gc_stress` (the multithreaded generational minor-GC stress test) **reliably segfaults (`0xC0000005`)** on the GitHub **windows-x64 (Intel)** runner — it failed 2/2 on the v2026.6.3 post-release CI run (28298489334) — but **never reproduces on local AMD** (two boxes, 68+ clean runs across default/4-core-pinned/3× oversubscribed). Optimization level is ruled out (`-opt s3` vs no-opt produce byte-identical bytecode). It's an Intel-vs-AMD timing-sensitive race in the new minor GC, so the only place to capture a stack is CI itself.

This is **not a v2026.6.3 release regression** (the release commit was docs-only; identical GC passed the 3 prior CI runs), but it should be root-caused before the next full release.

## What

Adds two windows-x64-only steps to the `build` job:
- **Enable WER crash dumps** before the test steps: registers `obr.exe` under `LocalDumps` with `DumpType=2` (full dump), writing to `$GITHUB_WORKSPACE\crashdumps`; sets `DontShowUI=1` so a crash can't hang the runner. Safe because `obr.exe` installs no default `SIGSEGV` handler, so the fault reaches WER.
- **Upload crash dump on failure** after the test steps: uploads `*.dmp` + the matching `obr.exe` (and `obr.pdb` if present) as artifact `obr-crashdump-windows-x64`, `if-no-files-found: warn`, 14-day retention.

## Follow-up

The Release|x64 build emits no PDB (LTCG + `OmitFramePointers`), so the dump will localize the fault (obr.exe code vs JIT'd RWX memory vs DLL) and give thread stacks/registers, but not function names. Full symbolication can follow with a codegen-preserving `/Zi` + `/DEBUG:FULL /OPT:REF,ICF` build if the raw dump isn't enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)