### PR TITLE
Security & correctness hardening from architecture audit (+ auto-JIT/diags/GC thread-safety)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -144,7 +144,7 @@ jobs:
         # annotations) even though the build is fine. Skip present packages and
         # install the rest, so genuine install failures still surface.
         for pkg in \
-          opencv \
+          opencv@4 \
           onnxruntime \
           mbedtls \
           nghttp2 \
@@ -171,6 +171,17 @@ jobs:
         # Add Homebrew bin to PATH (immediate + persistent)
         export PATH="/opt/homebrew/bin:$PATH"
         echo "/opt/homebrew/bin" >> $GITHUB_PATH
+
+        # Homebrew's default `opencv` is now OpenCV 5.0, which moved several
+        # functions out of the cv:: namespace (contourArea, boundingRect,
+        # getRotationMatrix2D, approxPolyDP, estimateAffinePartial2D, LMEDS) and
+        # relocated headers -> the opencv/onnx native libs no longer compile.
+        # The other platforms stay on OpenCV 4.x, so pin macOS to opencv@4 too.
+        # opencv@4 is keg-only (not symlinked into /opt/homebrew), so expose its
+        # pkg-config dir to every later step (onnx build.sh detects opencv4).
+        if [ -d /opt/homebrew/opt/opencv@4/lib/pkgconfig ]; then
+          echo "PKG_CONFIG_PATH=/opt/homebrew/opt/opencv@4/lib/pkgconfig:${PKG_CONFIG_PATH}" >> $GITHUB_ENV
+        fi
 
     - name: Build ngtcp2 with GnuTLS backend (macOS)
       if: runner.os == 'macOS'

--- a/core/compiler/optimization.cpp
+++ b/core/compiler/optimization.cpp
@@ -2234,8 +2234,13 @@ std::vector<IntermediateBlock*> ItermediateOptimizer::TailCallOpt(std::vector<In
       if(instr->GetType() == MTHD_CALL &&
          instr->GetOperand() == self_class_id &&
          instr->GetOperand2() == self_method_id &&
+         i > 0 &&
+         instrs[i - 1]->GetType() == LOAD_INST_MEM &&
          i + 1 < instrs.size() &&
          instrs[i + 1]->GetType() == RTRN) {
+        // self tail call: the receiver (pushed last, so directly before the call) must be
+        // @self -- a bare LOAD_INST_MEM. A call to a *different* instance of the same class
+        // loads its receiver via LOAD_INT_VAR/etc., so it must NOT reuse the current frame.
         // tail call: pop the instance (top of stack), re-store args to locals, jump to body
         out_block->AddInstruction(
           IntermediateFactory::Instance()->MakeInstruction(cur_line_num, POP_INT));

--- a/core/lib/diags/diags.cpp
+++ b/core/lib/diags/diags.cpp
@@ -38,13 +38,31 @@
 
 using namespace frontend;
 
-// SEH guard: prevents access violations from crashing the LSP server process
+// Serializes ALL diagnostics work across the LSP server's per-connection worker
+// threads (server.obs spawns a LintService/LspWorker thread per connection).
+// Parsing and analysis run on process-global singletons (TreeFactory/TypeFactory
+// and the analyzer cache below); concurrent requests corrupt those and segfault.
+// The LSP is latency-tolerant and correctness-sensitive, so a single coarse lock
+// around every entry point is the right trade-off. Recursive so a future entry
+// that calls another cannot self-deadlock.
+static std::recursive_mutex s_diag_global_mutex;
+
+// SEH guard: prevents access violations from crashing the LSP server process.
+// Kept in its own function because MSVC forbids __try in a function that also
+// needs C++ object unwinding (the lock_guard lives in the caller).
 #ifdef _WIN32
-static void SafeCallDiag(void (*fn)(VMContext&), VMContext& ctx) {
+static void SafeCallDiagGuarded(void (*fn)(VMContext&), VMContext& ctx) {
   __try { fn(ctx); } __except(EXCEPTION_EXECUTE_HANDLER) { }
 }
+static void SafeCallDiag(void (*fn)(VMContext&), VMContext& ctx) {
+  std::lock_guard<std::recursive_mutex> lock(s_diag_global_mutex);
+  SafeCallDiagGuarded(fn, ctx);
+}
 #else
-static inline void SafeCallDiag(void (*fn)(VMContext&), VMContext& ctx) { fn(ctx); }
+static inline void SafeCallDiag(void (*fn)(VMContext&), VMContext& ctx) {
+  std::lock_guard<std::recursive_mutex> lock(s_diag_global_mutex);
+  fn(ctx);
+}
 #endif
 
 // Cached ContextAnalyzer per parsed program.
@@ -133,6 +151,7 @@ extern "C" {
 #endif
   void diag_tree_release(VMContext& context)
   {
+    std::lock_guard<std::recursive_mutex> lock(s_diag_global_mutex);
     ParsedProgram* program = (ParsedProgram*)APITools_GetIntValue(context, 0);
     if(program) {
       InvalidateAnalyzerCache(program);
@@ -149,6 +168,7 @@ extern "C" {
 #endif
   void diag_parse_file(VMContext& context)
   {
+    std::lock_guard<std::recursive_mutex> lock(s_diag_global_mutex);
     const std::wstring src_file(APITools_GetStringValue(context, 2));
 
     std::vector<std::pair<std::wstring, std::wstring> > programs;
@@ -171,6 +191,7 @@ extern "C" {
 #endif
   void diag_parse_text(VMContext& context)
   {
+    std::lock_guard<std::recursive_mutex> lock(s_diag_global_mutex);
     size_t* names_array = APITools_GetArrayAddress(APITools_GetObjectValue(context, 2));
     const size_t names_array_size = APITools_GetArraySize(names_array);
 
@@ -764,6 +785,7 @@ extern "C" {
 #endif
   void diag_signature_help(VMContext& context)
   {
+    std::lock_guard<std::recursive_mutex> lock(s_diag_global_mutex);
     size_t* prgm_obj = APITools_GetObjectValue(context, 1);
     ParsedProgram* program = (ParsedProgram*)prgm_obj[0];
 
@@ -867,6 +889,7 @@ extern "C" {
 #endif
   void diag_code_rename(VMContext& context)
   {
+    std::lock_guard<std::recursive_mutex> lock(s_diag_global_mutex);
     size_t* prgm_obj = APITools_GetObjectValue(context, 0);
     ParsedProgram* program = (ParsedProgram*)prgm_obj[0];
 

--- a/core/lib/onnx/eq/build.sh
+++ b/core/lib/onnx/eq/build.sh
@@ -43,6 +43,22 @@ esac
 
 CXX=${CXX:-g++}
 
+# OpenCV renamed its pkg-config module across major versions (opencv -> opencv4
+# -> opencv5) and relocated headers (include/opencv4 -> include/opencv5). Detect
+# whichever module is installed so the build survives a Homebrew/apt OpenCV major
+# bump instead of failing with "opencv2/opencv.hpp file not found".
+OPENCV_PC=""
+for m in opencv4 opencv5 opencv; do
+	if pkg-config --exists "$m" 2>/dev/null; then
+		OPENCV_PC="$m"
+		break
+	fi
+done
+if [ -z "$OPENCV_PC" ]; then
+	echo "ERROR: no OpenCV pkg-config module found (tried opencv4, opencv5, opencv)" >&2
+	exit 1
+fi
+
 # On macOS, vm/common.h pulls in v3-API mbedtls headers. Use the in-tree v3
 # headers (same set the diags/matrix/opencv xcodeproj builds link against)
 # instead of homebrew's mbedtls — brew now ships v4, which removed entropy.h.
@@ -63,21 +79,21 @@ if [ "$(uname -s)" = "Darwin" ]; then
 fi
 
 $CXX -O3 -std=c++17 -Wall -fPIC $EP_DEFINE $ORT_INCLUDE $EXTRA_INCLUDE \
-	-c `pkg-config --cflags opencv4` onnx.cpp \
+	-c `pkg-config --cflags $OPENCV_PC` onnx.cpp \
 	-Wno-unused-function -Wno-deprecated-declarations
 
 OS=$(uname -s)
 case "$OS" in
 	Darwin)
 		$CXX -O3 -shared -o libobjk_onnx.dylib *.o \
-			`pkg-config --libs opencv4` $EXTRA_LIB $ORT_LIB
+			`pkg-config --libs $OPENCV_PC` $EXTRA_LIB $ORT_LIB
 		;;
 	MSYS*|MINGW*)
 		$CXX -O3 -shared -o libobjk_onnx.dll *.o \
-			`pkg-config --libs opencv4` $ORT_LIB
+			`pkg-config --libs $OPENCV_PC` $ORT_LIB
 		;;
 	*)
 		$CXX -O3 -shared -Wl,-soname,libobjk_onnx.so.1 -o libobjk_onnx.so *.o \
-			`pkg-config --libs opencv4` $ORT_LIB
+			`pkg-config --libs $OPENCV_PC` $ORT_LIB
 		;;
 esac

--- a/core/lib/onnx/eq/build.sh
+++ b/core/lib/onnx/eq/build.sh
@@ -43,6 +43,14 @@ esac
 
 CXX=${CXX:-g++}
 
+# macOS: Homebrew's default `opencv` is now 5.0 (moved functions out of cv::), so
+# the build pins to the keg-only opencv@4. Expose its pkg-config dir so the
+# detection below resolves `opencv4` to that keg. (CI also sets PKG_CONFIG_PATH.)
+if [ "$(uname -s)" = "Darwin" ] && [ -d /opt/homebrew/opt/opencv@4/lib/pkgconfig ]; then
+	PKG_CONFIG_PATH="/opt/homebrew/opt/opencv@4/lib/pkgconfig:${PKG_CONFIG_PATH}"
+	export PKG_CONFIG_PATH
+fi
+
 # OpenCV renamed its pkg-config module across major versions (opencv -> opencv4
 # -> opencv5) and relocated headers (include/opencv4 -> include/opencv5). Detect
 # whichever module is installed so the build survives a Homebrew/apt OpenCV major

--- a/core/lib/onnx/eq/common.h
+++ b/core/lib/onnx/eq/common.h
@@ -633,19 +633,45 @@ static inline Ort::Value make_tensor_match_input_type(const std::vector<float>& 
 
 // Read OpenCV image from raw data
 static cv::Mat opencv_raw_read(size_t* image_obj, VMContext& context) {
+   if(!image_obj) {
+      return cv::Mat();
+   }
+
    const int type = (int)image_obj[0];
    const int rows = (int)image_obj[2];
    const int cols = (int)image_obj[1];
    size_t* data_array = (size_t*)image_obj[3];
+   if(!data_array) {
+      return cv::Mat();
+   }
+
+   // reject non-positive dimensions before constructing the Mat
+   if(rows <= 0 || cols <= 0) {
+      return cv::Mat();
+   }
 
    // get parameters
    const size_t data_size = APITools_GetArraySize(data_array);
    const unsigned char* data = (unsigned char*)APITools_GetArray(data_array);
+   if(!data) {
+      return cv::Mat();
+   }
 
-   cv::Mat image(rows, cols, type);
-   memcpy(image.data, data, data_size);
+   // The dimensions and type are program-controlled; an attached byte array whose
+   // size does not match the Mat's footprint would overrun image.data on memcpy.
+   // A bogus 'type' can also make the Mat constructor throw across the C ABI.
+   try {
+      cv::Mat image(rows, cols, type);
+      if(image.data && data_size == image.total() * image.elemSize()) {
+         memcpy(image.data, data, data_size);
+         return image;
+      }
+   }
+   catch(const cv::Exception&) {
+      // fall through to empty Mat
+   }
 
-   return image;
+   return cv::Mat();
 }
 
 // Write OpenCV image to raw data

--- a/core/lib/opencv/macos/objk_opencv.xcodeproj/project.pbxproj
+++ b/core/lib/opencv/macos/objk_opencv.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 				GCC_ENABLE_CPP_EXCEPTIONS = YES;
 				GCC_ENABLE_CPP_RTTI = YES;
 				HEADER_SEARCH_PATHS = (
+					/opt/homebrew/include/opencv5,
 					/opt/homebrew/include/opencv4,
 					"$(SRCROOT)/../../openssl/macos/include",
 				);
@@ -287,6 +288,7 @@
 				GCC_ENABLE_CPP_EXCEPTIONS = YES;
 				GCC_ENABLE_CPP_RTTI = YES;
 				HEADER_SEARCH_PATHS = (
+					/opt/homebrew/include/opencv5,
 					/opt/homebrew/include/opencv4,
 					"$(SRCROOT)/../../openssl/macos/include",
 				);

--- a/core/lib/opencv/macos/objk_opencv.xcodeproj/project.pbxproj
+++ b/core/lib/opencv/macos/objk_opencv.xcodeproj/project.pbxproj
@@ -173,7 +173,10 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				LIBRARY_SEARCH_PATHS = /opt/homebrew/lib;
+				LIBRARY_SEARCH_PATHS = (
+					"/opt/homebrew/opt/opencv@4/lib",
+					/opt/homebrew/lib,
+				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACH_O_TYPE = mh_dylib;
 				MACOSX_DEPLOYMENT_TARGET = 13.3;
@@ -240,7 +243,10 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				LIBRARY_SEARCH_PATHS = /opt/homebrew/lib;
+				LIBRARY_SEARCH_PATHS = (
+					"/opt/homebrew/opt/opencv@4/lib",
+					/opt/homebrew/lib,
+				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACH_O_TYPE = mh_dylib;
 				MACOSX_DEPLOYMENT_TARGET = 13.3;
@@ -269,6 +275,7 @@
 				GCC_ENABLE_CPP_EXCEPTIONS = YES;
 				GCC_ENABLE_CPP_RTTI = YES;
 				HEADER_SEARCH_PATHS = (
+					"/opt/homebrew/opt/opencv@4/include/opencv4",
 					/opt/homebrew/include/opencv5,
 					/opt/homebrew/include/opencv4,
 					"$(SRCROOT)/../../openssl/macos/include",
@@ -288,6 +295,7 @@
 				GCC_ENABLE_CPP_EXCEPTIONS = YES;
 				GCC_ENABLE_CPP_RTTI = YES;
 				HEADER_SEARCH_PATHS = (
+					"/opt/homebrew/opt/opencv@4/include/opencv4",
 					/opt/homebrew/include/opencv5,
 					/opt/homebrew/include/opencv4,
 					"$(SRCROOT)/../../openssl/macos/include",

--- a/core/lib/opencv/opencv.h
+++ b/core/lib/opencv/opencv.h
@@ -125,19 +125,45 @@ std::vector<float> resnet_preprocess(const cv::Mat& img, int resize_height, int 
 
 // Read OpenCV image from raw data
 cv::Mat opencv_raw_read(size_t* image_obj, VMContext& context) {
+  if(!image_obj) {
+    return cv::Mat();
+  }
+
   const int type = (int)image_obj[0];
   const int rows = (int)image_obj[2];
   const int cols = (int)image_obj[1];
   size_t* data_array = (size_t*)image_obj[3];
+  if(!data_array) {
+    return cv::Mat();
+  }
+
+  // reject non-positive dimensions before constructing the Mat
+  if(rows <= 0 || cols <= 0) {
+    return cv::Mat();
+  }
 
   // get parameters
   const size_t data_size = APITools_GetArraySize(data_array);
   const unsigned char* data = (unsigned char*)APITools_GetArray(data_array);
+  if(!data) {
+    return cv::Mat();
+  }
 
-  cv::Mat image(rows, cols, type);
-  memcpy(image.data, data, data_size);
+  // The dimensions and type are program-controlled; an attached byte array whose
+  // size does not match the Mat's footprint would overrun image.data on memcpy.
+  // A bogus 'type' can also make the Mat constructor throw across the C ABI.
+  try {
+    cv::Mat image(rows, cols, type);
+    if(image.data && data_size == image.total() * image.elemSize()) {
+      memcpy(image.data, data, data_size);
+      return image;
+    }
+  }
+  catch(const cv::Exception&) {
+    // fall through to empty Mat
+  }
 
-  return image;
+  return cv::Mat();
 }
 
 // Write OpenCV image to raw data

--- a/core/vm/arch/jit/jit_common.cpp
+++ b/core/vm/arch/jit/jit_common.cpp
@@ -170,6 +170,15 @@ void JitCompiler::JitStackCallback(const long instr_id, StackInstr* instr, const
       // Pop instance from op_stack (same as ProcessMethodCall)
       size_t* callee_inst = (size_t*)op_stack[--(*stack_pos)];
 
+      // Bounds-check the call stack before writing the slot. This direct path
+      // bypasses PushFrame, which is the only place the interpreter enforces the
+      // CALL_STACK_SIZE limit -- without this, recursion deeper than 256 frames
+      // through JIT-compiled methods overruns the fixed call_stack[] buffer.
+      if((*call_stack_pos) >= CALL_STACK_SIZE) {
+        std::wcerr << L">>> call stack bounds have been exceeded! <<<" << std::endl;
+        exit(1);
+      }
+
       // Get a stack frame for the callee and register it on the call stack
       // so the GC can find and fixup pointers during young-gen promotion.
       // Uses same convention as PushFrame: store at pos, fence, then increment.

--- a/core/vm/arch/jit/jit_common.cpp
+++ b/core/vm/arch/jit/jit_common.cpp
@@ -65,8 +65,25 @@ bool JitCompiler::TryAutoJitCompile(StackMethod* callee)
     return true;
   }
 
-  // P2: DYN_MTHD_CALL auto-JIT enabled (function-reference/closure calls).
+  // Fast path on the shared compile state (avoids re-claiming after the outcome
+  // is settled). A method must be compiled by exactly ONE thread: concurrent
+  // mutators previously raced here, double-compiling (leaked NativeCode) and
+  // double-patching call sites.
+  const int state = callee->GetJitState();
+  if(state == StackMethod::JIT_DONE) {
+    return true;
+  }
+  if(state == StackMethod::JIT_FAILED) {
+    return false;
+  }
+  if(!callee->ClaimJitCompile()) {
+    // Another thread owns (or just settled) the compile. Re-read the outcome:
+    // treat anything but a definitive failure as "will be available" so the
+    // caller does not mark this call site as failed while a compile is in flight.
+    return callee->GetJitState() != StackMethod::JIT_FAILED;
+  }
 
+  // We own the compile. P2: DYN_MTHD_CALL auto-JIT enabled (func-ref/closure calls).
 #if defined(_M_ARM64)
   Runtime::JitArm64 jit_compiler;
 #elif defined(_WIN64) || defined(_X64)
@@ -76,13 +93,16 @@ bool JitCompiler::TryAutoJitCompile(StackMethod* callee)
 #endif
 
   if(jit_compiler.Compile(callee)) {
-    // patch all MTHD_CALL instructions that reference this callee
-    // so the interpreter's GetOperand3() fast path catches them
+    // Compile() published native_code (release). Patch all call sites AFTER that
+    // so any thread observing a *_JIT opcode / operand3>0 also sees native_code;
+    // the interpreter's JIT paths additionally re-check GetNativeCode() and fall
+    // back to interpreting if a patch is observed before the pointer is visible.
     PatchCallSites(callee, 1);
+    callee->SetJitDone();
     return true;
   }
 
-  // mark as permanently failed (operand3 stays 0, count at LONG_MAX stops further attempts)
+  // Definitive failure: mark so every call site can switch to interpret-only.
   callee->SetJitAttempted();
   return false;
 }

--- a/core/vm/arch/memory.cpp
+++ b/core/vm/arch/memory.cpp
@@ -844,6 +844,12 @@ void MemoryManager::CollectAllMemory(size_t* op_stack, size_t stack_pos)
   MUTEX_UNLOCK(&stw_lock);
 #endif
 
+  // Major collection mode. Set HERE, under marked_sweep_lock, not in the
+  // CollectMajor caller: an unlocked store there could land mid-CollectMinor (which
+  // set it true under the lock), flipping that minor sweep to major-mode and
+  // freeing live old-gen objects (UAF). Mirrors CollectMinor's locked store.
+  minor_gc_mode.store(false, std::memory_order_release);
+
   CollectionInfo* info = new CollectionInfo;
   info->op_stack = op_stack;
   info->stack_pos = stack_pos;
@@ -2036,8 +2042,14 @@ void MemoryManager::FixupRoots(size_t* op_stack, size_t stack_pos)
     FixupSlot(&op_stack[i]);
   }
 
-  // Fix up other threads' operand stacks via monitors
-  // (pda_monitor_lock is already held by the caller's CheckPdaRoots path)
+  // Fix up other threads' operand stacks via monitors.
+  // Must hold pda_monitor_lock: the caller (CollectMemory) does NOT hold it (the
+  // second monitor loop below re-acquires it, which would self-deadlock otherwise),
+  // and a thread tearing down (UnregisterMutator + ~StackInterpreter) can erase from
+  // pda_monitors and free the op_stack concurrently -> iterator invalidation / UAF.
+#ifndef _GC_SERIAL
+  MUTEX_LOCK(&pda_monitor_lock);
+#endif
   for(auto pda_iter = pda_monitors.begin(); pda_iter != pda_monitors.end(); ++pda_iter) {
     StackFrameMonitor* monitor = *pda_iter;
     size_t* other_op_stack = monitor->op_stack;
@@ -2049,6 +2061,9 @@ void MemoryManager::FixupRoots(size_t* op_stack, size_t stack_pos)
       }
     }
   }
+#ifndef _GC_SERIAL
+  MUTEX_UNLOCK(&pda_monitor_lock);
+#endif
 
   // Relocate self/param of threads still mid-spawn, so a child reads the promoted
   // address instead of a stale nursery pointer (mirrors the mark side).
@@ -2341,7 +2356,9 @@ void MemoryManager::CollectMinor(size_t* op_stack, size_t stack_pos)
 
 void MemoryManager::CollectMajor(size_t* op_stack, size_t stack_pos)
 {
-  minor_gc_mode.store(false, std::memory_order_release);
+  // NOTE: minor_gc_mode is set to false INSIDE CollectAllMemory (under
+  // marked_sweep_lock), not here. Setting it here (unlocked) raced an in-progress
+  // CollectMinor and could free live old-gen objects. See CollectAllMemory.
   CollectAllMemory(op_stack, stack_pos);
 }
 

--- a/core/vm/arch/memory.cpp
+++ b/core/vm/arch/memory.cpp
@@ -239,9 +239,13 @@ void MemoryManager::EndBlocking()
 }
 
 FLOAT_VALUE MemoryManager::GetRandomValue() {
-  std::random_device rd;
-  std::mt19937 gen(rd());
-  std::uniform_real_distribution<FLOAT_VALUE> dis(0.0, 1.0);
+  // Seed a Mersenne Twister once per thread. Re-constructing and re-seeding a
+  // fresh mt19937 (624-word state) from std::random_device on every call -- as
+  // this did -- is a per-draw syscall plus full state init, pathological in any
+  // RNG loop, and it also degrades quality (each draw is the first output of a
+  // freshly seeded generator).
+  static thread_local std::mt19937 gen(std::random_device{}());
+  static thread_local std::uniform_real_distribution<FLOAT_VALUE> dis(0.0, 1.0);
 
   return dis(gen);
 }
@@ -437,7 +441,17 @@ size_t* MemoryManager::AllocateObject(const long obj_id, size_t* op_stack, size_
 
   size_t* mem = nullptr;
   if(cls) {
-    const long size = cls->GetInstanceMemorySize();
+    const long inst_size = cls->GetInstanceMemorySize();
+    // Instance size comes from class metadata (loader-supplied, unvalidated). A
+    // negative or huge value would wrap the size math (on LLP64 `long` is 32-bit,
+    // so `size * 2` also wraps before widening to size_t), under-allocating the
+    // object while field stores use the class's declared offsets -> nursery heap
+    // overflow. Fail closed, mirroring the AllocateArray overflow guard.
+    if(inst_size < 0 || (size_t)inst_size > (~(size_t)0 - sizeof(size_t) * EXTRA_BUF_SIZE) / 2) {
+      std::wcerr << L">>> Object allocation size overflow <<<" << std::endl;
+      exit(1);
+    }
+    const size_t size = (size_t)inst_size;
     const size_t alloc_size = size * 2 + sizeof(size_t) * EXTRA_BUF_SIZE;
 
     // Total size including the size header for free cache

--- a/core/vm/common.cpp
+++ b/core/vm/common.cpp
@@ -3332,7 +3332,7 @@ bool TrapProcessor::StdInByteAryLen(StackProgram* program, size_t* inst, size_t*
   std::wcout << L"  STD_IN_BYTE_ARY_LEN: addr=" << array << L"(" << (size_t)array << L")" << std::endl;
 #endif
 
-  if(array && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     char* buffer = (char*)(array + 3);
     PushInt(fread(buffer + offset, num, 1, stdin), op_stack, stack_pos);
   }
@@ -3353,7 +3353,7 @@ bool TrapProcessor::StdInCharAryLen(StackProgram* program, size_t* inst, size_t*
   std::wcout << L"  STD_IN_CHAR_ARY: addr=" << array << L"(" << (size_t)array << L")" << std::endl;
 #endif
 
-  if(array && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     wchar_t* buffer = (wchar_t*)(array + 3);
     // allocate temporary buffer
     char* byte_buffer = new char[num * 2 + 1];
@@ -3421,7 +3421,7 @@ bool TrapProcessor::StdOutByteAryLen(StackProgram* program, size_t* inst, size_t
   std::wcout << L"  STD_OUT_BYTE_ARY_LEN: addr=" << array << L"(" << (size_t)array << L")" << std::endl;
 #endif
 
-  if(array && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     const char* buffer = (char*)(array + 3);
 #ifdef _MODULE_STDIO
     const std::wstring wide_buffer(BytesToUnicode(buffer));
@@ -3447,7 +3447,7 @@ bool TrapProcessor::StdOutCharAryLen(StackProgram* program, size_t* inst, size_t
   std::wcout << L"  STD_OUT_STRING: addr=" << array << L"(" << (size_t)array << L")" << std::endl;
 #endif
 
-  if(array && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
 #ifdef _MODULE_STDIO
     std::wstring wide_buffer((wchar_t*)(array + 3) + offset);
     program->output_buffer.write(wide_buffer.c_str(), wide_buffer.size());
@@ -5175,7 +5175,7 @@ bool TrapProcessor::SockUdpInByteAry(StackProgram* program, size_t* inst, size_t
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   const size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && instance[0] && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && instance[0] && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     SOCKET sock = static_cast<int>(inst[0]);
     struct sockaddr_in* addr_in = (struct sockaddr_in*)inst[1];
     char* buffer = (char*)(array + 3);
@@ -5202,7 +5202,7 @@ bool TrapProcessor::SockUdpInCharAry(StackProgram* program, size_t* inst, size_t
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && (long)instance[0] > -1 && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && (long)instance[0] > -1 && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     SOCKET sock = static_cast<int>(inst[0]);
     struct sockaddr_in* addr_in = (struct sockaddr_in*)inst[1];
 
@@ -5211,20 +5211,23 @@ bool TrapProcessor::SockUdpInCharAry(StackProgram* program, size_t* inst, size_t
 
     socklen_t addr_in_size = sizeof(struct sockaddr_in);
     const int read = static_cast<int>(recvfrom(sock, byte_buffer, num, 0, (struct sockaddr*)addr_in, &addr_in_size));
-    byte_buffer[read] = '\0';
-    std::wstring in(BytesToUnicode(byte_buffer));
+    // recvfrom returns -1 on error; only terminate/decode when bytes were read
+    if(read > -1) {
+      byte_buffer[read] = '\0';
+      std::wstring in(BytesToUnicode(byte_buffer));
 
-    // copy and remove file BOM UTF (8, 16, 32)
-    if(in.size() > 0 && (in[0] == (wchar_t)0xFEFF || in[0] == (wchar_t)0xFFFE || in[0] == (wchar_t)0xFFFE0000 || in[0] == (wchar_t)0xEFBBBF)) {
-      in.erase(in.begin(), in.begin() + 1);
-    }
+      // copy and remove file BOM UTF (8, 16, 32)
+      if(in.size() > 0 && (in[0] == (wchar_t)0xFEFF || in[0] == (wchar_t)0xFFFE || in[0] == (wchar_t)0xFFFE0000 || in[0] == (wchar_t)0xEFBBBF)) {
+        in.erase(in.begin(), in.begin() + 1);
+      }
 
-    // copy
+      // copy
 #ifdef _WIN32
-    wcsncpy_s(buffer, array[0] + 1, in.c_str(), in.size());
+      wcsncpy_s(buffer, array[0] + 1, in.c_str(), in.size());
 #else
-    wcsncpy(buffer, in.c_str(), in.size());
+      wcsncpy(buffer, in.c_str(), in.size());
 #endif
+    }
 
     // clean up
     delete[] byte_buffer;
@@ -5245,7 +5248,7 @@ bool TrapProcessor::SockUdpOutCharAry(StackProgram* program, size_t* inst, size_
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && (long)instance[0] > -1 && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && (long)instance[0] > -1 && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     SOCKET sock = static_cast<int>(inst[0]);
     struct sockaddr_in* addr_in = (struct sockaddr_in*)inst[1];
     socklen_t addr_in_size = sizeof(struct sockaddr_in);
@@ -5292,7 +5295,7 @@ bool TrapProcessor::SockUdpOutByteAry(StackProgram* program, size_t* inst, size_
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   const size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(instance && instance[0] && offset > -1 && offset + num <= (long)array[0]) {
+  if(instance && instance[0] && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
 
     SOCKET sock = static_cast<int>(inst[0]);
     struct sockaddr_in* addr_in = (struct sockaddr_in*)inst[1];
@@ -6122,7 +6125,7 @@ bool TrapProcessor::PipeInByteAry(StackProgram* program, size_t* inst, size_t*& 
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   const size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && (FILE*)instance[0] && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && (FILE*)instance[0] && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
 #ifdef _WIN32
     HANDLE pipe = (HANDLE)instance[0];
 #else
@@ -6145,7 +6148,7 @@ bool TrapProcessor::PipeInCharAry(StackProgram* program, size_t* inst, size_t*& 
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   const size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && (FILE*)instance[0] && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && (FILE*)instance[0] && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     wchar_t* out = (wchar_t*)(array + 3);
 #ifdef _WIN32
     HANDLE pipe = (HANDLE)instance[0];
@@ -6193,7 +6196,7 @@ bool TrapProcessor::PipeOutByteAry(StackProgram* program, size_t* inst, size_t*&
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   const size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && (FILE*)instance[0] && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && (FILE*)instance[0] && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
 #ifdef _WIN32
     HANDLE pipe = (HANDLE)instance[0];
 #else
@@ -6216,7 +6219,7 @@ bool TrapProcessor::PipeOutCharAry(StackProgram* program, size_t* inst, size_t*&
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   const size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && (FILE*)instance[0] && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && (FILE*)instance[0] && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
 #ifdef _WIN32
     HANDLE pipe = (HANDLE)instance[0];
 #else
@@ -6325,7 +6328,7 @@ bool TrapProcessor::SockTcpInByteAry(StackProgram* program, size_t* inst, size_t
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && (long)instance[0] > -1 && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && (long)instance[0] > -1 && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     SOCKET sock = (SOCKET)instance[0];
     // blocking read; park for the duration. recv() lands in a temp C buffer (a
     // parked thread's GC array can be moved by promotion mid-read), and the
@@ -6356,7 +6359,7 @@ bool TrapProcessor::SockTcpInCharAry(StackProgram* program, size_t* inst, size_t
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && (long)instance[0] > -1 && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && (long)instance[0] > -1 && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     SOCKET sock = (SOCKET)instance[0];
     // allocate temporary buffer
     char* byte_buffer = new char[num * 2 + 1];
@@ -6419,7 +6422,7 @@ bool TrapProcessor::SockTcpOutByteAry(StackProgram* program, size_t* inst, size_
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && (long)instance[0] > -1 && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && (long)instance[0] > -1 && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     SOCKET sock = (SOCKET)instance[0];
     // send() can block on a full buffer; park for the duration. Data is staged
     // in a temp C buffer first — a parked thread's GC array can be moved (and
@@ -6446,7 +6449,7 @@ bool TrapProcessor::SockTcpOutCharAry(StackProgram* program, size_t* inst, size_
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && (long)instance[0] > -1 && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && (long)instance[0] > -1 && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     SOCKET sock = (SOCKET)instance[0];
     const wchar_t* buffer = (wchar_t*)(array + 3);
     
@@ -6486,7 +6489,7 @@ bool TrapProcessor::SockTcpSslInByteAry(StackProgram* program, size_t* inst, siz
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     SecureSocketCtx* sctx = (SecureSocketCtx*)instance[0];
     char* buffer = (char*)(array + 3);
 
@@ -6521,7 +6524,7 @@ bool TrapProcessor::SockTcpSslInCharAry(StackProgram* program, size_t* inst, siz
   const INT64_VALUE offset = (long)PopInt(op_stack, stack_pos);
   size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     SecureSocketCtx* sctx = (SecureSocketCtx*)instance[0];
     wchar_t* buffer = (wchar_t*)(array + 3);
     char* byte_buffer = new char[num * 2 + 1];
@@ -6574,7 +6577,7 @@ bool TrapProcessor::SockTcpSslOutByteAry(StackProgram* program, size_t* inst, si
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     SecureSocketCtx* sctx = (SecureSocketCtx*)instance[0];
     char* buffer = (char*)(array + 3);
     PushInt(IPSecureSocket::WriteBytes(buffer + offset, static_cast<int>(num), sctx), op_stack, stack_pos);
@@ -6593,7 +6596,7 @@ bool TrapProcessor::SockTcpSslOutCharAry(StackProgram* program, size_t* inst, si
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     SecureSocketCtx* sctx = (SecureSocketCtx*)instance[0];
     const wchar_t* buffer = (wchar_t*)(array + 3);
     // copy sub buffer
@@ -7906,7 +7909,7 @@ bool TrapProcessor::SockDtlsInByteAry(StackProgram* program, size_t* inst, size_
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     DtlsSocketCtx* sctx = (DtlsSocketCtx*)instance[0];
     char* buffer = (char*)(array + 3);
     int read = IPDtlsSocket::ReadBytes(buffer + offset, static_cast<int>(num), sctx);
@@ -7926,7 +7929,7 @@ bool TrapProcessor::SockDtlsInCharAry(StackProgram* program, size_t* inst, size_
   const INT64_VALUE offset = (long)PopInt(op_stack, stack_pos);
   size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     DtlsSocketCtx* sctx = (DtlsSocketCtx*)instance[0];
     wchar_t* buffer = (wchar_t*)(array + 3);
     char* byte_buffer = new char[num * 2 + 1];
@@ -7979,7 +7982,7 @@ bool TrapProcessor::SockDtlsOutByteAry(StackProgram* program, size_t* inst, size
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     DtlsSocketCtx* sctx = (DtlsSocketCtx*)instance[0];
     char* buffer = (char*)(array + 3);
     PushInt(IPDtlsSocket::WriteBytes(buffer + offset, static_cast<int>(num), sctx), op_stack, stack_pos);
@@ -7998,7 +8001,7 @@ bool TrapProcessor::SockDtlsOutCharAry(StackProgram* program, size_t* inst, size
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     DtlsSocketCtx* sctx = (DtlsSocketCtx*)instance[0];
     const wchar_t* buffer = (wchar_t*)(array + 3);
     // copy sub buffer
@@ -8036,7 +8039,7 @@ bool TrapProcessor::FileInCharAry(StackProgram* program, size_t* inst, size_t* &
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   const size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
   
-  if(array && instance && (FILE*)instance[0] && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && (FILE*)instance[0] && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     FILE* file = (FILE*)instance[0];
     wchar_t* out = (wchar_t*)(array + 3);
 
@@ -8081,7 +8084,7 @@ bool TrapProcessor::FileInByteAry(StackProgram* program, size_t* inst, size_t* &
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   const size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && (FILE*)instance[0] && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && (FILE*)instance[0] && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     FILE* file = (FILE*)instance[0];
     char* buffer = (char*)(array + 3);
     const size_t read = fread(buffer + offset, 1, num, file);
@@ -8122,7 +8125,7 @@ bool TrapProcessor::FileOutByteAry(StackProgram* program, size_t* inst, size_t* 
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   const size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && (FILE*)instance[0] && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && (FILE*)instance[0] && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     FILE* file = (FILE*)instance[0];
     char* buffer = (char*)(array + 3);
     PushInt(fwrite(buffer + offset, 1, num, file), op_stack, stack_pos);
@@ -8141,7 +8144,7 @@ bool TrapProcessor::FileOutCharAry(StackProgram* program, size_t* inst, size_t* 
   const INT64_VALUE offset = (INT64_VALUE)PopInt(op_stack, stack_pos);
   const size_t* instance = (size_t*)PopInt(op_stack, stack_pos);
 
-  if(array && instance && (FILE*)instance[0] && offset > -1 && offset + num <= (long)array[0]) {
+  if(array && instance && (FILE*)instance[0] && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
     FILE* file = (FILE*)instance[0];
     const wchar_t* buffer = (wchar_t*)(array + 3);
     // copy sub buffer

--- a/core/vm/common.h
+++ b/core/vm/common.h
@@ -53,6 +53,7 @@
 #include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
+#include <atomic>
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -572,8 +573,14 @@ class StackMethod {
   int instr_count;
   long param_count;
   long mem_size;
-  NativeCode* native_code;
-  long jit_call_count;
+  // Auto-JIT state shared across mutator threads. native_code is the ready signal
+  // (release on publish / acquire on read so a non-null pointer implies the fully
+  // built NativeCode is visible). jit_call_count is a plain hot counter (relaxed).
+  // jit_state elects exactly one compiler thread (0=none,1=compiling,2=done,3=failed)
+  // so a method is never compiled twice or patched concurrently by two threads.
+  std::atomic<NativeCode*> native_code;
+  std::atomic<long> jit_call_count;
+  std::atomic<int> jit_state;
   MemoryType rtrn_type;
   StackDclr** dclrs;
   long num_dclrs;
@@ -588,8 +595,9 @@ class StackMethod {
     is_virtual = v;
     has_and_or = h;
     is_lambda = l;
-    native_code = nullptr;
-    jit_call_count = 0;
+    native_code.store(nullptr, std::memory_order_relaxed);
+    jit_call_count.store(0, std::memory_order_relaxed);
+    jit_state.store(JIT_NONE, std::memory_order_relaxed);
     dclrs = d;
     num_dclrs = nd;
     param_count = p;
@@ -612,10 +620,11 @@ class StackMethod {
       dclrs = nullptr;
     }
 
-    // clean up
-    if(native_code) {
-      delete native_code;
-      native_code = nullptr;
+    // clean up (single-threaded teardown; relaxed is fine)
+    NativeCode* nc = native_code.load(std::memory_order_relaxed);
+    if(nc) {
+      delete nc;
+      native_code.store(nullptr, std::memory_order_relaxed);
     }
 
     // contiguous array - single deallocation
@@ -680,24 +689,46 @@ class StackMethod {
     return num_dclrs;
   }
 
+  // Auto-JIT compile states (jit_state).
+  enum { JIT_NONE = 0, JIT_COMPILING = 1, JIT_DONE = 2, JIT_FAILED = 3 };
+
   void SetNativeCode(NativeCode* c) {
-    native_code = c;
+    // release: publish the fully constructed NativeCode before the pointer is
+    // observable, pairing with the acquire load in GetNativeCode.
+    native_code.store(c, std::memory_order_release);
   }
 
   inline NativeCode* GetNativeCode() const {
-    return native_code;
+    return native_code.load(std::memory_order_acquire);
   }
 
   inline long GetJitCallCount() const {
-    return jit_call_count;
+    return jit_call_count.load(std::memory_order_relaxed);
   }
 
-  inline void IncrementJitCallCount() {
-    ++jit_call_count;
+  // Returns the PREVIOUS value (fetch_add semantics) so a caller can detect the
+  // unique thread that crossed the auto-JIT threshold.
+  inline long IncrementJitCallCount() {
+    return jit_call_count.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  inline int GetJitState() const {
+    return jit_state.load(std::memory_order_acquire);
+  }
+
+  // Elect a single compiler thread: exactly one CAS from JIT_NONE succeeds.
+  inline bool ClaimJitCompile() {
+    int expected = JIT_NONE;
+    return jit_state.compare_exchange_strong(expected, JIT_COMPILING,
+                                             std::memory_order_acq_rel);
+  }
+
+  inline void SetJitDone() {
+    jit_state.store(JIT_DONE, std::memory_order_release);
   }
 
   inline void SetJitAttempted() {
-    jit_call_count = LONG_MAX;
+    jit_state.store(JIT_FAILED, std::memory_order_release);
   }
 
   MemoryType GetReturn() const {

--- a/core/vm/common.h
+++ b/core/vm/common.h
@@ -517,17 +517,23 @@ class NativeCode {
 #endif
 
   ~NativeCode() {
-#ifdef _ARM64
-    free(ints);
+#if defined(_ARM64) || defined(_M_ARM64)
+    // ARM64 allocates both constant pools with new[] (JitArm64::Compile), so they
+    // must be released with delete[]. The old code used free() on ints and, on
+    // Windows ARM64 (_ARM64 && _WIN64), VirtualFree() on a new[] buffer -- a hard
+    // allocator mismatch (UB / heap corruption) that ran for every method at teardown.
+    delete[] ints;
     ints = nullptr;
-#endif
-    
-#ifdef _WIN64
-    VirtualFree(floats, 0, MEM_RELEASE);
-#else
-    free(floats);
-#endif
+    delete[] floats;
     floats = nullptr;
+#else
+  #ifdef _WIN64
+    VirtualFree(floats, 0, MEM_RELEASE);
+  #else
+    free(floats);
+  #endif
+    floats = nullptr;
+#endif
   }
 
 #if defined(_ARM64) || defined(_M_ARM64)

--- a/core/vm/interpreter.cpp
+++ b/core/vm/interpreter.cpp
@@ -2155,19 +2155,30 @@ __declspec(noinline) void StackInterpreter::CheckAutoJit(StackMethod* called, St
 void __attribute__((noinline)) StackInterpreter::CheckAutoJit(StackMethod* called, StackInstr* instr)
 #endif
 {
-  if(called->GetJitCallCount() < JIT_AUTO_THRESHOLD) {
-    called->IncrementJitCallCount();
-    if(called->GetJitCallCount() == JIT_AUTO_THRESHOLD) {
-      if(!JitCompiler::TryAutoJitCompile(called)) {
-        // JIT failed: mark this call site so we skip auto-JIT on future calls
-        instr->SetOperand3(-1);
-      }
-      // success: PatchCallSites already set operand3=1 on all call sites
-    }
+  // Already compiled elsewhere: nothing to count (the *_JIT opcode / operand3
+  // patch drives dispatch from here on).
+  if(called->GetNativeCode()) {
+    return;
   }
-  else if(called->GetJitCallCount() > JIT_AUTO_THRESHOLD) {
-    // already attempted and failed on another call site -- mark this one too
-    instr->SetOperand3(-1);
+
+  // Once the threshold is reached we stop bumping the counter (no unbounded
+  // growth / overflow) and just consult the shared compile state.
+  if(called->GetJitCallCount() >= JIT_AUTO_THRESHOLD) {
+    if(!JitCompiler::TryAutoJitCompile(called)) {
+      instr->SetOperand3(-1);   // definitively failed: interpret this site
+    }
+    return;
+  }
+
+  // fetch_add returns the previous value, so exactly one thread observes the
+  // increment that crosses the threshold and triggers the (compile-once) compile.
+  const long prev = called->IncrementJitCallCount();
+  if(prev + 1 == JIT_AUTO_THRESHOLD) {
+    if(!JitCompiler::TryAutoJitCompile(called)) {
+      // JIT failed: mark this call site so we skip auto-JIT on future calls
+      instr->SetOperand3(-1);
+    }
+    // success: PatchCallSites already set operand3=1 on all call sites
   }
 }
 #endif
@@ -2368,25 +2379,21 @@ void StackInterpreter::ProcessJitMethodCall(StackMethod* called, size_t* instanc
 #if defined(_DEBUGGER) || defined(_NO_JIT)
   ProcessInterpretedMethodCall(called, instance, instrs, ip);
 #else
-  // compile, if needed
-  if(!called->GetNativeCode()) {   
-#if defined(_M_ARM64)
-    JitArm64 jit_compiler;
-#elif defined(_WIN64) || defined(_X64)
-    JitAmd64 jit_compiler;
-#else
-    JitArm64 jit_compiler;
-#endif
-
-    if(!jit_compiler.Compile(called)) {
+  // Compile if needed, via the shared compile-once path (claims the method so two
+  // threads never compile/patch it concurrently). If it is still not available --
+  // a definitive failure, or another thread is mid-compile / patched a call site
+  // before publishing native_code -- safely fall back to interpreting this call.
+  if(!called->GetNativeCode()) {
+    JitCompiler::TryAutoJitCompile(called);
+    if(!called->GetNativeCode()) {
       ProcessInterpretedMethodCall(called, instance, instrs, ip);
 #ifdef _DEBUG
-      std::wcerr << L"### Unable to compile: " << called->GetName() << L" ###" << std::endl;
+      std::wcerr << L"### Interpreting (native code unavailable): " << called->GetName() << L" ###" << std::endl;
 #endif
       return;
     }
   }
-  
+
   // execute
   (*stack_frame) = GetStackFrame(called, instance);
   JitRuntime jit_executor;

--- a/core/vm/loader.cpp
+++ b/core/vm/loader.cpp
@@ -88,10 +88,10 @@ void Loader::Load()
   //
   // read float strings
   //
-  num_float_strings = static_cast<int>(ReadInt());
+  num_float_strings = ReadCount();
   FLOAT_VALUE** float_strings = new FLOAT_VALUE*[num_float_strings];
   for(i = 0; i < num_float_strings; ++i) {
-    const int float_string_length = static_cast<int>(ReadInt());
+    const int float_string_length = ReadCount();
     FLOAT_VALUE* float_string = new FLOAT_VALUE[float_string_length];
     // copy string    
 #ifdef _DEBUG
@@ -113,10 +113,10 @@ void Loader::Load()
   //
   // read boolean strings
   //
-  num_bool_strings = static_cast<int>(ReadInt());
+  num_bool_strings = ReadCount();
   bool** bool_strings = new bool* [num_bool_strings];
   for(i = 0; i < num_bool_strings; ++i) {
-    const int bool_string_length = static_cast<int>(ReadInt());
+    const int bool_string_length = ReadCount();
     bool* bool_string = new bool[bool_string_length];
     // copy string    
 #ifdef _DEBUG
@@ -139,10 +139,10 @@ void Loader::Load()
   //
   // read byte strings
   //
-  num_byte_strings = static_cast<int>(ReadInt());
+  num_byte_strings = ReadCount();
   char** byte_strings = new char*[num_byte_strings];
   for(i = 0; i < num_byte_strings; ++i) {
-    const int byte_string_length = static_cast<int>(ReadInt());
+    const int byte_string_length = ReadCount();
     char* byte_string = new char[byte_string_length];
     // copy string    
 #ifdef _DEBUG
@@ -164,10 +164,10 @@ void Loader::Load()
   //
   // read int strings
   //
-  num_int_strings = static_cast<int>(ReadInt());
+  num_int_strings = ReadCount();
   INT64_VALUE** int_strings = new INT64_VALUE *[num_int_strings];
   for(i = 0; i < num_int_strings; ++i) {
-    const int int_string_length = static_cast<int>(ReadInt());
+    const int int_string_length = ReadCount();
     INT64_VALUE* int_string = new INT64_VALUE[int_string_length];
     // copy string    
 #ifdef _DEBUG
@@ -189,7 +189,7 @@ void Loader::Load()
   //
   // read char strings
   //
-  num_char_strings = static_cast<int>(ReadInt());
+  num_char_strings = ReadCount();
   wchar_t** char_strings = new wchar_t*[num_char_strings + arguments.size()];
   for(i = 0; i < num_char_strings; ++i) {
     const std::wstring value = ReadString();
@@ -292,6 +292,10 @@ char* Loader::LoadFileBuffer(std::wstring filename, size_t& buffer_size)
 
     free(buffer);
     buffer = nullptr;
+    // Report the DECOMPRESSED length to the caller so every subsequent Read* can
+    // be bounds-checked. Previously buffer_size kept the (smaller) compressed
+    // size, which made bounds checking impossible.
+    buffer_size = (size_t)dest_len;
     return out;
   }
   else {
@@ -357,20 +361,20 @@ void Loader::LoadClasses()
     const int inst_space = static_cast<int>(ReadInt());
 
     // read class declarations
-    const int cls_num_dclrs = static_cast<int>(ReadInt());
+    const int cls_num_dclrs = ReadCount();
     StackDclr** cls_dclrs = LoadDeclarations(cls_num_dclrs, is_debug);
 
     // read instance declarations
-    const int inst_num_dclrs = static_cast<int>(ReadInt());
+    const int inst_num_dclrs = ReadCount();
     StackDclr** inst_dclrs = LoadDeclarations(inst_num_dclrs, is_debug);
     
     // read closure declarations
     std::map<int, std::pair<int, StackDclr**> > closure_dclr_map;
-    const int num_closure_dclrs = static_cast<int>(ReadInt());
+    const int num_closure_dclrs = ReadCount();
     for(int i = 0; i < num_closure_dclrs; ++i) {
       const int closure_mthd_id = static_cast<int>(ReadInt());
       // read closure declarations
-      const int closure_num_dclrs = static_cast<int>(ReadInt());
+      const int closure_num_dclrs = ReadCount();
       StackDclr** closure_dclrs = LoadDeclarations(closure_num_dclrs, is_debug);
       // add declarations to map
       closure_dclr_map[closure_mthd_id] = std::pair<int, StackDclr**>(closure_num_dclrs, closure_dclrs);
@@ -455,7 +459,7 @@ void Loader::LoadMethods(StackClass* cls, bool is_debug)
     // space
     const int mem_size = static_cast<int>(ReadInt());
     // read type parameters
-    const int num_dclrs = static_cast<int>(ReadInt());
+    const int num_dclrs = ReadCount();
 
     StackDclr** dclrs = new StackDclr*[num_dclrs];
     for(int j = 0; j < num_dclrs; ++j) {
@@ -563,6 +567,12 @@ void Loader::LoadStatements(StackMethod* method, bool is_debug)
 {
   int line_num = -1;
   const unsigned long num_instrs = ReadUnsigned();
+  // Each instruction is at least one byte (opcode) in the stream, so a count
+  // exceeding the bytes remaining is corrupt -- reject before the allocation.
+  if(buffer_end && num_instrs > (size_t)(buffer_end - buffer)) {
+    std::wcerr << L">>> Corrupt bytecode: invalid instruction count <<<" << std::endl;
+    exit(1);
+  }
   StackInstr* mthd_instrs = new StackInstr[num_instrs];
 
   for(unsigned long i = 0; i < num_instrs; ++i) {

--- a/core/vm/loader.h
+++ b/core/vm/loader.h
@@ -48,6 +48,7 @@ class Loader {
   std::wstring filename;
   char* buffer;
   char* alloc_buffer;
+  char* buffer_end;
   size_t buffer_size;
   size_t buffer_pos;
   int start_class_id;
@@ -55,25 +56,55 @@ class Loader {
   std::map<const std::wstring, const int> params;
   bool from_mem;
   
+  // Bounds guard for the raw deserialization cursor. Bytecode (.obe/.obl) is
+  // untrusted input; a truncated or crafted file must never drive a read past the
+  // decompressed buffer. buffer_end is null only for the trusted in-memory
+  // (bundled-executable) path, where no size is available -- there the check is
+  // skipped, preserving prior behavior.
+  inline void EnsureBytes(size_t needed) {
+    if(buffer_end && (buffer > buffer_end || needed > (size_t)(buffer_end - buffer))) {
+      std::wcerr << L">>> Corrupt bytecode: read past end of buffer <<<" << std::endl;
+      exit(1);
+    }
+  }
+
   inline long ReadInt() {
+    EnsureBytes(sizeof(int32_t));
     int32_t value = *((int32_t*)buffer);
     buffer += sizeof(value);
     return value;
   }
 
+  // Reads a count/length that will drive a new[] allocation. Rejects negatives
+  // and any value larger than the bytes remaining in the buffer: every element
+  // consumes at least one more byte, so a count exceeding the remainder is
+  // necessarily corrupt. Prevents a crafted count from forcing a multi-GB
+  // allocation (bad_alloc/abort) before the element reads would fail.
+  inline int ReadCount() {
+    const long value = ReadInt();
+    if(value < 0 || (buffer_end && (size_t)value > (size_t)(buffer_end - buffer))) {
+      std::wcerr << L">>> Corrupt bytecode: invalid element count/length <<<" << std::endl;
+      exit(1);
+    }
+    return static_cast<int>(value);
+  }
+
   inline INT64_VALUE ReadInt64() {
+    EnsureBytes(sizeof(INT64_VALUE));
     INT64_VALUE value = *((INT64_VALUE*)buffer);
     buffer += sizeof(value);
     return value;
   }
 
   inline unsigned long ReadUnsigned() {
+    EnsureBytes(sizeof(uint32_t));
     uint32_t value = *((uint32_t*)buffer);
     buffer += sizeof(value);
     return value;
   }
-  
+
   inline int ReadByte() {
+    EnsureBytes(sizeof(uint8_t));
     uint8_t value = *((uint8_t*)buffer);
     buffer += sizeof(value);
     return value;
@@ -81,23 +112,33 @@ class Loader {
 
   inline std::wstring ReadString() {
     const int size = static_cast<int>(ReadInt());
+    if(size < 0) {
+      std::wcerr << L">>> Corrupt bytecode: negative string length <<<" << std::endl;
+      exit(1);
+    }
+    EnsureBytes((size_t)size);
     std::string in(buffer, size);
-    buffer += size;    
-    
+    buffer += size;
+
     std::wstring out;
     if(!BytesToUnicode(in, out)) {
       std::wcerr << L">>> Unable to read unicode std::string <<<" << std::endl;
       exit(1);
     }
-    
+
     return out;
   }
 
   inline wchar_t ReadChar() {
     wchar_t out;
-    
+
     const int size = static_cast<int>(ReadInt());
+    if(size < 0) {
+      std::wcerr << L">>> Corrupt bytecode: negative character length <<<" << std::endl;
+      exit(1);
+    }
     if(size) {
+      EnsureBytes((size_t)size);
       std::string in(buffer, size);
       buffer += size;
       if(!BytesToCharacter(in, out)) {
@@ -108,11 +149,12 @@ class Loader {
     else {
       out = L'\0';
     }
-    
+
     return out;
   }
 
   inline FLOAT_VALUE ReadDouble() {
+    EnsureBytes(sizeof(FLOAT_VALUE));
     FLOAT_VALUE value = *((FLOAT_VALUE*)buffer);
     buffer += sizeof(value);
     return value;
@@ -124,6 +166,8 @@ class Loader {
   void ReadFile() {
     buffer_pos = 0;
     alloc_buffer = buffer = LoadFileBuffer(filename, buffer_size);
+    // LoadFileBuffer sets buffer_size to the DECOMPRESSED length; bound all reads.
+    buffer_end = alloc_buffer ? alloc_buffer + buffer_size : nullptr;
   }
 
   // loading functions
@@ -143,6 +187,9 @@ public:
     string_cls_id = -1;
     buffer_pos = 0;
     alloc_buffer = buffer = b;
+    // Trusted in-memory (bundled-executable) path: no length is supplied, so the
+    // per-read bounds check is disabled (null buffer_end).
+    buffer_end = nullptr;
     program = new StackProgram;
   }
 

--- a/programs/regression/jit_autojit_race.obs
+++ b/programs/regression/jit_autojit_race.obs
@@ -1,0 +1,56 @@
+#~
+# Auto-JIT concurrency guard. Many threads call the same hot method, crossing the
+# auto-JIT threshold simultaneously. Before the fix, jit_call_count/native_code/
+# call-site patching were non-atomic: threads double-compiled a method and one
+# could observe a patched *_JIT opcode before native_code was published. Now the
+# compile is elected via an atomic CAS (compile-once) and native_code is published
+# release/acquire, with a safe interpret fallback. A regression surfaces as a
+# wrong per-thread sum (-> non-zero exit / FAIL) or a crash/hang.
+#
+# IMPORTANT: must run with JIT ENABLED. Do NOT add a '# JIT_DISABLE' marker.
+# EXTRA_LIBS: gen_collect
+~#
+
+use System.Concurrency;
+
+class Worker from Thread {
+  @sum : Int;
+  New() { Parent("w"); @sum := 0; }
+  method : public : Sum() ~ Int { return @sum; }
+
+  method : public : Hot(x : Int) ~ Int {
+    return (x * 3) + 7 - (x / 2);
+  }
+
+  method : public : Run(param : System.Base) ~ Nil {
+    s := 0;
+    for(i := 0; i < 100000; i += 1;) {
+      s += Hot(i);
+    };
+    @sum := s;
+  }
+}
+
+class JitAutoJitRace {
+  function : Main(args : String[]) ~ Nil {
+    expected := 0;
+    for(i := 0; i < 100000; i += 1;) {
+      expected += (i * 3) + 7 - (i / 2);
+    };
+
+    workers := Worker->New[8];
+    for(t := 0; t < 8; t += 1;) { workers[t] := Worker->New(); };
+    for(t := 0; t < 8; t += 1;) { workers[t]->Execute(Nil); };
+    for(t := 0; t < 8; t += 1;) { workers[t]->Join(); };
+
+    ok := true;
+    for(t := 0; t < 8; t += 1;) {
+      if(workers[t]->Sum() <> expected) {
+        "FAIL: thread {$t} sum mismatch"->PrintLine();
+        ok := false;
+      };
+    };
+    if(ok) { "PASS: auto-JIT race - all threads correct"->PrintLine(); }
+    else { Runtime->Exit(1); };
+  }
+}

--- a/programs/tests/diag_concurrent_analysis.obs
+++ b/programs/tests/diag_concurrent_analysis.obs
@@ -1,0 +1,49 @@
+#~
+# Concurrency guard for the diagnostics/LSP analysis path. The LSP server spawns a
+# worker thread per connection (server.obs), so requests run System.Diagnostics
+# analysis concurrently. Parsing/analysis use process-global singletons
+# (TreeFactory/TypeFactory + the analyzer cache); before the fix, concurrent
+# Analyzer->ParseText from multiple threads segfaulted (JIT-independent). diags.cpp
+# now serializes every entry point under one recursive mutex. A regression surfaces
+# as a segfault/hang (hard FAIL) or a null analysis (non-zero exit).
+#
+# EXTRA_LIBS: diags,gen_collect
+~#
+
+use System.Diagnostics;
+use System.Concurrency;
+use Collection;
+
+class AnalyzeWorker from Thread {
+  @ok : Bool;
+  New() { Parent("aw"); @ok := true; }
+  method : public : Ok() ~ Bool { return @ok; }
+
+  method : public : Run(param : System.Base) ~ Nil {
+    src := "class Counter {\r\n@count : Int;\r\nNew() { @count := 0; }\r\n";
+    src += "method : public : Increment() ~ Nil { @count += 1; }\r\n";
+    src += "method : public : GetCount() ~ Int { return @count; }\r\n}\r\n";
+    lib_path := "";
+    for(i := 0; i < 40; i += 1;) {
+      texts := String->New[1, 2];
+      texts[0, 0] := "file:///mt.obs";
+      texts[0, 1] := src;
+      analysis := Analyzer->ParseText(texts);
+      if(analysis = Nil) { @ok := false; return; };
+      analysis->GetSymbols("file:///mt.obs", lib_path);
+    };
+  }
+}
+
+class DiagConcurrentAnalysis {
+  function : Main(args : String[]) ~ Nil {
+    workers := AnalyzeWorker->New[8];
+    for(t := 0; t < 8; t += 1;) { workers[t] := AnalyzeWorker->New(); };
+    for(t := 0; t < 8; t += 1;) { workers[t]->Execute(Nil); };
+    for(t := 0; t < 8; t += 1;) { workers[t]->Join(); };
+    ok := true;
+    for(t := 0; t < 8; t += 1;) { if(<>workers[t]->Ok()) { ok := false; }; };
+    if(ok) { "PASS: concurrent diagnostics analysis - no crash"->PrintLine(); }
+    else { "FAIL: null analysis in a worker"->PrintLine(); Runtime->Exit(1); };
+  }
+}


### PR DESCRIPTION
Batch of fixes surfaced by a cross-subsystem architecture audit. Each commit is self-contained and the full 170-test regression suite passes throughout. Verified with the suite plus targeted reproducers.

## Commits

**1. `fix(vm/compiler)` — security & correctness hardening**
- **TCO miscompile (correctness, default builds):** the tail-call pass matched class+method id but ignored the receiver, so `other->Same(...)` on a *different* instance reused the caller's frame and dropped the new receiver — silent wrong output at default opt. Reproduced (`A A A A` vs `A B A B`); now gated on `LOAD_INST_MEM` (self-receiver only). Self-recursion still optimized (50k/40k-deep verified).
- **Load-time bytecode verifier:** untrusted `.obe`/`.obl` had no bounds checking — every `Read*` now validates against the buffer end, string/char lengths reject negatives, counts are validated (non-negative, capped at remaining bytes), and `LoadFileBuffer` reports the decompressed size (was the compressed size). Truncated/tampered input now fails cleanly instead of over-reading the heap.
- **Negative-length trap guards (28 sites):** the shared byte/char-array guard never checked `num >= 0` and used a 32-bit-truncating cast; a negative length reached `fread`/`recv` as `SIZE_MAX`. Hardened + `SockUdpInCharAry` terminator guarded on `recvfrom != -1`.
- **OpenCV `raw_read` heap overflow (RCE-capable):** validates `data_size == total()*elemSize`, null-checks, rejects bad dims, try/catch across the ABI (both opencv + onnx copies). *Header change — native DLLs must be rebuilt to ship it.*
- **AllocateObject overflow, JIT-to-JIT call-stack bounds, ARM64 `NativeCode` deallocator** (`free`/`VirtualFree` on `new[]`), and a `thread_local` RNG for `RAND_FLOAT`.

**2. `fix(vm/jit)` — auto-JIT compilation is now thread-safe (compile-once)**
`jit_call_count`/`native_code`/a new `jit_state` are `std::atomic`; `native_code` is published release/acquire; a CAS elects a single compiler so a method is never compiled or patched by two threads at once. Adds `programs/regression/jit_autojit_race.obs`.

**3. `fix(diags)` — serialize LSP analysis (partial)**
The LSP server runs a worker thread per connection; concurrent `Analyzer->ParseText` corrupts process-global `TreeFactory`/`TypeFactory` and segfaults. A single recursive mutex across all diags entry points takes the concurrent-analysis crash from ~100% to ~5%. **Partial** — the residual is deeper shared-state (needs per-`ParsedProgram` factories). Reproducer in `programs/tests/diag_concurrent_analysis.obs` (kept out of the gating suite as it's flaky). Note: this is *not* the JIT-threshold LSP crash — that turned out to already not reproduce single-threaded.

**4. `fix(gc)` — close two multithreaded GC races**
Minor/major mode race (`CollectMajor` stored `minor_gc_mode` unlocked → could free live old-gen) and the `FixupRoots` first monitor loop running without `pda_monitor_lock` (races thread teardown). Both correct and regression-clean.

## Known-open, out of scope for this PR

Investigating the diags residual surfaced a broader **pre-existing multithreaded-GC/JIT crash**: pure MT allocation segfaults ~17–36% of runs and reproduces on unmodified `master`. Root-caused (register-level, via a vectored-exception-handler dump) to JIT-side precise rooting — the JIT keeps live object pointers in working registers (RBX/RAX) across cross-thread safepoints, and the collector cannot see a parked thread's registers, so a moved object leaves the register stale. **Not fixable GC-side**; needs per-safepoint liveness/stack-map spilling in the JIT. **Workaround: multithreaded programs are safe with JIT disabled** (`OBJECK_JIT_THRESHOLD=999999999`). Reproducer `mt_alloc.obs` available. Commits 3 & 4 are honest partials against this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)