### PR TITLE
fix(jit): serialize concurrent JIT code-page allocation (fixes dominant MT crash)

### DIFF
--- a/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
+++ b/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
@@ -31,6 +31,7 @@
 
 #include "jit_amd_lp64.h"
 #include <string>
+#include <mutex>
 
 using namespace Runtime;
 
@@ -6563,6 +6564,15 @@ PageManager::~PageManager()
 
 unsigned char* PageManager::GetPage(unsigned char* code, int32_t size)
 {
+  // page_manager is a process-global singleton, but several mutator threads can
+  // JIT-compile DIFFERENT methods concurrently (the compile-once election only
+  // serializes a single method). Without this lock, concurrent GetPage calls race
+  // the shared `holders` vector (push_back -> realloc/UAF) and a holder's bump
+  // index (two methods handed overlapping code regions -> corrupt machine code ->
+  // SIGILL/SIGSEGV with garbage values). Serialize code-page allocation.
+  static std::mutex page_mutex;
+  std::lock_guard<std::mutex> lock(page_mutex);
+
   bool placed = false;
 
   unsigned char* temp = nullptr;

--- a/core/vm/arch/jit/arm64/jit_arm_a64.cpp
+++ b/core/vm/arch/jit/arm64/jit_arm_a64.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "jit_arm_a64.h"
+#include <mutex>
 
 #include <bitset>
 #include <cstddef>
@@ -5431,6 +5432,13 @@ PageManager::~PageManager()
 
 uint32_t* PageManager::GetPage(uint32_t* code, int32_t size)
 {
+  // Serialize concurrent JIT code-page allocation across mutator threads: the
+  // page_manager singleton's `holders` vector and per-holder bump index are
+  // shared, so unsynchronized GetPage calls (several threads compiling different
+  // methods at once) corrupt the code pages. See the AMD64 GetPage for detail.
+  static std::mutex page_mutex;
+  std::lock_guard<std::mutex> lock(page_mutex);
+
   bool placed = false;
 
   uint32_t* temp = nullptr;

--- a/programs/regression/jit_concurrent_compile.obs
+++ b/programs/regression/jit_concurrent_compile.obs
@@ -1,0 +1,61 @@
+#~
+# Concurrency guard for the JIT code-page allocator (PageManager::GetPage).
+# Several threads JIT-compile DIFFERENT methods at once (heavy allocation of many
+# small objects + collection library churn forces Box/Vector/String methods to
+# cross the auto-JIT threshold concurrently). The page_manager singleton's holders
+# vector and per-holder bump index are shared; before the fix, unsynchronized
+# GetPage calls handed overlapping code regions to different methods -> corrupt
+# machine code -> SIGILL/SIGSEGV with garbage values (~20% of runs, JIT-only, not
+# GC-related, no floats). GetPage now serializes allocation. A regression surfaces
+# as a crash/hang or a wrong per-thread sum.
+#
+# IMPORTANT: must run with JIT ENABLED. Do NOT add a '# JIT_DISABLE' marker.
+# EXTRA_LIBS: gen_collect
+~#
+
+use System.Concurrency;
+use Collection;
+
+class Box {
+  @n : Int;
+  @s : String;
+  New(n : Int) { @n := n; @s := "box-{$n}"; }
+  method : public : N() ~ Int { return @n; }
+}
+
+class Worker from Thread {
+  @sum : Int;
+  New() { Parent("w"); @sum := 0; }
+  method : public : Sum() ~ Int { return @sum; }
+
+  method : public : Run(param : System.Base) ~ Nil {
+    total := 0;
+    v := Vector->New()<Box>;
+    for(i := 0; i < 5000; i += 1;) {
+      b := Box->New(i);
+      v->AddBack(b);
+      total += b->N();
+      if(i % 100 = 0) { v := Vector->New()<Box>; };
+    };
+    @sum := total;
+  }
+}
+
+class JitConcurrentCompile {
+  function : Main(args : String[]) ~ Nil {
+    expected := 0;
+    for(i := 0; i < 5000; i += 1;) { expected += i; };
+
+    workers := Worker->New[8];
+    for(t := 0; t < 8; t += 1;) { workers[t] := Worker->New(); };
+    for(t := 0; t < 8; t += 1;) { workers[t]->Execute(Nil); };
+    for(t := 0; t < 8; t += 1;) { workers[t]->Join(); };
+
+    ok := true;
+    for(t := 0; t < 8; t += 1;) {
+      if(workers[t]->Sum() <> expected) { ok := false; };
+    };
+    if(ok) { "PASS: concurrent JIT compile - all threads correct"->PrintLine(); }
+    else { "FAIL: wrong sum"->PrintLine(); Runtime->Exit(1); };
+  }
+}


### PR DESCRIPTION
## The bug

`PageManager` is a process-global singleton with **no locking**, but multiple mutator threads JIT-compile *different* methods concurrently. (The compile-once election added earlier only serializes a *single* method, not the shared code allocator.) Unsynchronized `GetPage` calls race:
- the shared `holders` vector — concurrent `push_back` → realloc / use-after-free
- a holder's bump index — two methods handed **overlapping code regions**

The result is corrupt machine code → **SIGILL/SIGSEGV with garbage register values**.

## Why this was hard to pin down

This is the dominant multithreaded crash — an 8-thread allocation stress crashed **~20% of runs**. It is:
- **JIT-only** — `OBJECK_JIT_DISABLE=1` is always clean;
- **not the GC** — reproduces with a 1 GB young region that triggers **zero collections** (ruling out moving/rooting, which an earlier diagnosis had wrongly blamed);
- **float-independent** — the workload has no floats (ruling out the separate float type-confusion hypothesis).

It's also the residual **~5% crash under concurrent `System.Diagnostics`/LSP analysis** that remained after the diags serialization lock — because diags JIT-compiles concurrently too.

## The fix

A `static std::mutex` serializing `PageManager::GetPage` on **both AMD64 and ARM64**. `program` (the only other JIT static) is read-only during compile, so `GetPage` is the sole shared mutable state — a targeted lock suffices. Compilation is infrequent relative to execution, so the added contention is negligible.

## Verification

- `mt_alloc` (8-thread stress): **0/100** crashes (was ~20%)
- concurrent-diags repro: **0/15** (was ~5%)
- other MT reproducers: **0**
- Full regression suite: **171/171**
- Adds `programs/regression/jit_concurrent_compile.obs` (8 threads compiling different methods) as a gating guard.

ARM64 is fixed identically but validated via CI's arm64 legs (no local ARM64 hardware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)