### PR TITLE
fix(security): close CodeQL + Dependabot alerts in LSP client and docs

### DIFF
--- a/docs/web/ai_guide.html
+++ b/docs/web/ai_guide.html
@@ -7,8 +7,8 @@
   <meta name="description" content="Build AI and ML applications with Objeck's built-in libraries: OpenAI, Gemini, Ollama, ONNX, OpenCV, ML, and NLP — no third-party packages required."/>
   <link rel="icon" href="style/favicon.ico" type="image/x-icon" />
   <link href="style/styles.css" rel="stylesheet" />
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/base16/twilight.min.css" rel="stylesheet" />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/base16/twilight.min.css" rel="stylesheet" integrity="sha512-r2ZvyWx6iCZ80UPMo4oQbrRdV1hEaAp+x5eLmp+dYirS177GcReNy3h1UEBBh12uJ7EBj0KuWTD68kaiY8GqhA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js" integrity="sha512-EBLzUL8XLl+va/zAsmXwS7Z2B1F9HUHkZwyS/VKwh3S7T/U0nF4BaU29EP/ZSf6zgiIxYAnKLu6bJ8dqpmX5uw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script>hljs.highlightAll();</script>
 
   <style>

--- a/docs/web/getting_started.html
+++ b/docs/web/getting_started.html
@@ -7,8 +7,8 @@
   <meta name="description" content="Get started with Objeck: installation, language basics, collections, AI/ML, web programming, and more."/>
   <link rel="icon" href="style/favicon.ico" type="image/x-icon" />
   <link href="style/styles.css" rel="stylesheet" />
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/base16/twilight.min.css" rel="stylesheet" />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/base16/twilight.min.css" rel="stylesheet" integrity="sha512-r2ZvyWx6iCZ80UPMo4oQbrRdV1hEaAp+x5eLmp+dYirS177GcReNy3h1UEBBh12uJ7EBj0KuWTD68kaiY8GqhA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js" integrity="sha512-EBLzUL8XLl+va/zAsmXwS7Z2B1F9HUHkZwyS/VKwh3S7T/U0nF4BaU29EP/ZSf6zgiIxYAnKLu6bJ8dqpmX5uw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script>
    hljs.highlightAll();
   </script>

--- a/tools/lsp/clients/vscode/client/package-lock.json
+++ b/tools/lsp/clients/vscode/client/package-lock.json
@@ -95,9 +95,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -507,9 +507,9 @@
 			}
 		},
 		"node_modules/vscode-languageclient/node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"

--- a/tools/lsp/clients/vscode/client/src/extension.ts
+++ b/tools/lsp/clients/vscode/client/src/extension.ts
@@ -98,7 +98,24 @@ function startExternalServer(context: ExtensionContext, objkInstallDir) {
     // path to plugin install directory
     const pluginDir = context.extensionPath;
 
-    serverProcess = child_process.spawn(serverScript, [`"${objkInstallDir}"`, `"${pluginDir}"`], { shell: true });
+    // Pass the directories through the environment rather than as command line
+    // arguments. The Windows launcher is a .cmd file, so it has to be started
+    // through a shell, and user configured paths interpolated into a shell
+    // command line could be parsed as shell metacharacters.
+    const serverEnv = {
+        ...process.env,
+        OBJECK_INSTALL_DIR: objkInstallDir ? String(objkInstallDir) : '',
+        OBJECK_PLUGIN_DIR: pluginDir
+    };
+
+    serverProcess = child_process.spawn(serverScript, [], {
+        shell: process.platform === 'win32',
+        env: serverEnv
+    });
+
+    serverProcess.on('error', (err) => {
+        console.error(`Failed to start Objeck LSP server: ${err.message}`);
+    });
 
     serverProcess.stdout.on('data', (data) => {
         console.log(`Server stdout: ${data}`);

--- a/tools/lsp/clients/vscode/package-lock.json
+++ b/tools/lsp/clients/vscode/package-lock.json
@@ -76,9 +76,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -126,9 +126,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -554,9 +554,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -907,9 +907,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1426,9 +1426,9 @@
 			"license": "ISC"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -1891,9 +1891,9 @@
 			}
 		},
 		"node_modules/rimraf/node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/tools/lsp/clients/vscode/server/lsp_server.cmd
+++ b/tools/lsp/clients/vscode/server/lsp_server.cmd
@@ -1,6 +1,14 @@
-set OBJECK_INSTALL_DIR=%~1
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
 
-set OBJECK_LIB_PATH=%OBJECK_INSTALL_DIR%\lib
-set PATH=%PATH%;%OBJECK_INSTALL_DIR%\bin
+rem The install directory arrives in OBJECK_INSTALL_DIR; %~1 is kept as a
+rem fallback for older clients that still pass it on the command line.
+rem The value comes from VS Code settings, so it is only ever expanded with
+rem !delayed! syntax -- that substitutes after the line is parsed, so quotes
+rem and other metacharacters in the path cannot start a new command.
+if not defined OBJECK_INSTALL_DIR set "OBJECK_INSTALL_DIR=%~1"
 
-"%OBJECK_INSTALL_DIR%\bin\obr" "%~dp0objeck_lsp.obe" "%~dp0objk_apis.json" pipe
+set "OBJECK_LIB_PATH=!OBJECK_INSTALL_DIR!\lib"
+set "PATH=!PATH!;!OBJECK_INSTALL_DIR!\bin"
+
+"!OBJECK_INSTALL_DIR!\bin\obr" "%~dp0objeck_lsp.obe" "%~dp0objk_apis.json" pipe

--- a/tools/lsp/clients/vscode/server/lsp_server.sh
+++ b/tools/lsp/clients/vscode/server/lsp_server.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-export OBJECK_INSTALL_DIR="$1"
+# The install directory arrives in OBJECK_INSTALL_DIR; $1 is kept as a fallback
+# for older clients that still pass it on the command line.
+export OBJECK_INSTALL_DIR="${OBJECK_INSTALL_DIR:-$1}"
 
 export OBJECK_LIB_PATH="$OBJECK_INSTALL_DIR/lib"
 export PATH="$PATH:$OBJECK_INSTALL_DIR/bin"


### PR DESCRIPTION
Closes every open alert on the GitHub Security tab: 2 CodeQL code scanning alerts and 3 Dependabot alerts (4 advisory instances).

## CodeQL #360 — unsafe shell command constructed from library input

`extension.ts` spawned the LSP launcher with `shell: true` and the Objeck install directory interpolated straight into the command line. That path comes from VS Code settings, so a workspace-level `.vscode/settings.json` could inject shell commands simply by opening a project.

The install and plugin directories now travel through the environment (`OBJECK_INSTALL_DIR` / `OBJECK_PLUGIN_DIR`) with no shell-parsed arguments, and `shell` is enabled only on Windows, where a `.cmd` launcher requires it.

Moving to the environment alone was **not** sufficient. `lsp_server.cmd` expands `%VAR%` textually, so metacharacters in the value were still parsed inside the batch file. A value of `C:\x" & echo PWNED & rem` executed the injected command even after quoting the `set` lines, because the embedded quote terminates a quoted `set`. The launcher now uses `EnableDelayedExpansion` with `!VAR!`, which substitutes after the line is parsed.

Both launchers keep the positional argument as a fallback, so clients that have not updated still work.

## CodeQL #359 — functionality from an untrusted source

Added `integrity`, `crossorigin` and `referrerpolicy` to the highlight.js script and stylesheet. SHA-512 hashes were computed from the downloaded assets rather than taken from the cdnjs API. Also applied to `getting_started.html`, which loads the same assets and was not yet flagged.

## Dependabot

`npm audit fix` for `brace-expansion` (x2) and `js-yaml` — all high-severity DoS advisories in transitive dev dependencies. Non-breaking bumps; the extension root and `client/` both report 0 vulnerabilities.

## Verification

- `tsc -b --force` clean, `bash -n lsp_server.sh` clean
- Launcher tested against space, ampersand and quote-breakout inputs plus the legacy arg fallback — metacharacters stay literal, no command executes
- x64 regression suite re-run against the final tree: **171 passed, 0 failed**

Note that the regression suite exercises the VM and compiler, not the VS Code extension; confidence in the launcher changes comes from the targeted tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)