### PR TITLE
fix(web): repair a 404 logo, a dead API link, and five contrast failures

### DIFF
--- a/docs/readme.html
+++ b/docs/readme.html
@@ -32,11 +32,7 @@
     <div class="banner">
       <!-- Centered Logo -->
       <a href="https://objeck.org/">
-        <!-- dark wordmark on light themes; light wordmark on dark themes -->
-        <picture>
-          <source media="(prefers-color-scheme: dark)" srcset="style/objeck-logo-alt.png" />
-          <img alt="Objeck Logo" class="logo" src="style/objeck-logo.png" />
-        </picture>
+        <img alt="Objeck Logo" class="logo" src="style/objeck-logo.png" />
       </a>
       <!-- Centered Tagline -->
       <h1 class="tagline">High-level Code @ Native Speed</h1>
@@ -55,7 +51,7 @@
           <a href="https://objeck.org/ai_guide.html">AI Guide</a>
           <a href="https://github.com/objeck/objeck-lang/releases/latest">Downloads</a>
           <a href="https://objeck.org/readme.html">Changelog</a>
-          <a href="https://www.objeck.org/doc/api/index.html" target="_blank">API Docs</a>
+          <a href="https://www.objeck.org/api/latest/index.html" target="_blank">API Docs</a>
           <a href="https://github.com/objeck/objeck-lang">GitHub</a>
         </div>
       </div>

--- a/docs/web/ai_guide.html
+++ b/docs/web/ai_guide.html
@@ -58,7 +58,7 @@
     }
     .lib-flag::before {
       content: "obc flag: ";
-      color: #4b5563;
+      color: #9ca3af;
       font-size: 0.72rem;
     }
 
@@ -158,7 +158,7 @@
     </div>
   </header>
 
-  <main role="main" style="text-align: left;">
+  <main id="main" role="main" style="text-align: left;">
    <div class="container">
 
     <h1 class="page-title">AI &amp; ML Developer Guide</h1>

--- a/docs/web/getting_started.html
+++ b/docs/web/getting_started.html
@@ -57,7 +57,7 @@
     </div>
   </header>
   
-  <main role="main" style="text-align: left;">
+  <main id="main" role="main" style="text-align: left;">
    <div class="container">
     <p>
      Before you get started, checkout Objeck's

--- a/docs/web/index.html
+++ b/docs/web/index.html
@@ -59,7 +59,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="main">
     <!-- Hero Section -->
     <section class="hero">
       <h1 class="hero-title">From Vibe to Silicon.</h1>
@@ -244,12 +244,13 @@
     <!-- Deep Dives -->
     <section class="highlights">
       <h2 class="section-title">Deep Dives</h2>
-      <p style="text-align:center; color:#555; margin: -0.5rem 0 1.5rem;">AI-generated podcast overviews — great for commutes.</p>
+      <p style="text-align:center; color:#9ca3af; margin: -0.5rem 0 1.5rem;">AI-generated podcast overviews — great for commutes.</p>
       <div style="display:grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap:1.5rem;">
         <div>
           <p style="font-weight:600; margin-bottom:0.5rem;">AI-Native Language</p>
           <div style="position:relative; aspect-ratio:16/9;">
-            <iframe style="position:absolute;top:0;left:0;width:100%;height:100%;border-radius:8px;border:0;"
+            <iframe title="Objeck: AI-Native Language — podcast overview"
+              style="position:absolute;top:0;left:0;width:100%;height:100%;border-radius:8px;border:0;"
               src="https://www.youtube.com/embed/XMwrkeSODng"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowfullscreen loading="lazy"></iframe>
@@ -258,7 +259,8 @@
         <div>
           <p style="font-weight:600; margin-bottom:0.5rem;">Internals &amp; AI</p>
           <div style="position:relative; aspect-ratio:16/9;">
-            <iframe style="position:absolute;top:0;left:0;width:100%;height:100%;border-radius:8px;border:0;"
+            <iframe title="Objeck: Internals &amp; AI — podcast overview"
+              style="position:absolute;top:0;left:0;width:100%;height:100%;border-radius:8px;border:0;"
               src="https://www.youtube.com/embed/bm6wBZhQ6kY"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowfullscreen loading="lazy"></iframe>

--- a/docs/web/readme.html
+++ b/docs/web/readme.html
@@ -51,10 +51,10 @@
     </div>
   </header>
 
-  <main style="text-align: left;">
+  <main id="main" style="text-align: left;">
 
     <!-- Intro -->
-    <p style="font-size: 1.05rem; color: #555; margin: 0.5rem 0 1.25rem;">
+    <p style="font-size: 1.05rem; color: #9ca3af; margin: 0.5rem 0 1.25rem;">
       AI, networking, and vision — built in. Every release moves the stack forward.
     </p>
     <div style="display: flex; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 2rem;">
@@ -199,7 +199,7 @@
         <a href="https://rosettacode.org/wiki/Category:Objeck" target="_blank">Rosetta Code</a> &mdash;
         <a href="https://github.com/objeck/objeck-lang/issues" target="_blank">Report an Issue</a>
       </p>
-      <p style="font-size: 0.9rem; color: #777;">
+      <p style="font-size: 0.9rem; color: #9ca3af;">
         Tested on Windows 10/11, Ubuntu 24.04 LTS, and macOS 15 (ARM64 + x64).
         Licensed under <a href="https://opensource.org/licenses/BSD-2-Clause">BSD-2-Clause</a>.
         Source on <a href="https://github.com/objeck/objeck-lang">GitHub</a>.

--- a/docs/web/style/styles.css
+++ b/docs/web/style/styles.css
@@ -435,7 +435,9 @@ main {
   text-align: center;
   padding: 24px 20px;
   font-size: 0.85rem;
-  color: #545b68;
+  /* #545b68 measured 2.15:1 on the page background, well under the 4.5:1 AA
+     minimum, and this footer is on every page. */
+  color: #9ca3af;
   border-top: 1px solid #2d3a4d;
   margin-top: 50px;
 }
@@ -509,7 +511,8 @@ main {
   content: counter(toc-counter) "." counter(toc-sub-counter) " ";
   position: absolute;
   left: 0;
-  color: #5c7fad;
+  /* was #5c7fad, 3.77:1 on the TOC background */
+  color: #a3cefd;
   font-weight: 400;
 }
 


### PR DESCRIPTION
Phase A1 of the modernization roadmap — correctness fixes to the site, no infrastructure. Each item was measured or verified rather than eyeballed.

## Two broken links

- **`docs/readme.html` showed a broken logo to every dark-mode visitor.** A `<picture>` element pointed its `prefers-color-scheme: dark` `<source>` at `style/objeck-logo-alt.png`, which does not exist in `docs/style/`. Dropped the wrapper and kept the plain `<img>` — one wordmark reads fine on both backgrounds.
- **The API docs link on that page was dead.** It pointed at `/doc/api/index.html`. Verified with curl: that URL returns **404**, while `/api/latest/index.html` (already used across `docs/web/*`) returns **200**.

## Five contrast failures

Measured against the actual backgrounds. WCAG AA for normal text is 4.5:1:

| Where | Before | Ratio | After | Ratio |
|---|---|---|---|---|
| `.footer` (**all four pages**) | `#545b68` on `#1f2937` | 2.15:1 | `#9ca3af` | 5.78:1 |
| `index.html:247` | `#555` on `#1f2937` | 1.97:1 | `#9ca3af` | 5.78:1 |
| `readme.html:57` | `#555` on `#1f2937` | 1.97:1 | `#9ca3af` | 5.78:1 |
| `readme.html:202` | `#777` on `#1f2937` | 3.22:1 | `#9ca3af` | 5.78:1 |
| `ai_guide` `.lib-flag::before` | `#4b5563` on `#151d28` | 2.25:1 | `#9ca3af` | 6.68:1 |
| TOC sub-counter | `#5c7fad` on `#1a2332` | 3.77:1 | `#a3cefd` | 9.62:1 |

Both replacement colors are already in the palette, so nothing new was introduced. `#9ca3af` elsewhere on the site measures 5.70:1 and was already passing — it is left alone. The remaining `#4b5563` uses are **borders, not text**, so they are untouched.

## Accessibility odds and ends

- The two YouTube embeds had no `title`, so a screen reader announced them only as "iframe".
- Each `<main>` gained an `id`, so a skip link has somewhere to land when the shared-header work adds one.

## Verification

- Both API URLs checked with `curl -o /dev/null -w "%{http_code}"` before changing anything
- Contrast ratios computed with the WCAG relative-luminance formula, before and after
- All five touched pages still parse
- No reference to the missing logo asset remains outside the generated `api.zip`

Deliberately **not** in this PR: the shared header/footer partial, theming, copy-to-clipboard, and OG/sitemap work. Those are later phases and each carries more risk than these fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)