### PR TITLE
feat(lang): add the '??' and '?->' nil-safe operators

### DIFF
--- a/core/compiler/parser.cpp
+++ b/core/compiler/parser.cpp
@@ -6915,7 +6915,12 @@ MethodCall* Parser::ParseMethodCall(IdentifierContext& context, int depth)
 #endif
 
   MethodCall* method_call = nullptr;
+  // '?.' -- capture before NextToken() consumes the accessor. The call itself
+  // is built exactly as before; it is wrapped in Try() at the return, so every
+  // branch below (generics, casts, further chaining) is untouched.
+  bool nil_safe = false;
   if(Match(TOKEN_ASSESSOR)) {
+    nil_safe = scanner->GetToken()->IsNilSafe();
     NextToken();
 
     // method call
@@ -7078,6 +7083,20 @@ MethodCall* Parser::ParseMethodCall(IdentifierContext& context, int depth)
     ParseCastTypeOf(method_call, depth + 1);
   }
 
+  // 'a?.b()' becomes 'a->Try()->b()'. Try() guards the whole remainder of the
+  // chain, so wrapping the head is enough -- a later '?.' in the same chain is
+  // already covered and behaves as a plain accessor. The receiver is named
+  // once, so it is evaluated once.
+  if(nil_safe && method_call) {
+    MethodCall* try_call = TreeFactory::Instance()->MakeMethodCall(file_name, line_num, line_pos,
+                                                                   line_num, line_pos,
+                                                                   GetLineNumber(), GetLinePosition(),
+                                                                   ident, L"Try",
+                                                                   TreeFactory::Instance()->MakeExpressionList());
+    try_call->SetMethodCall(method_call);
+    return try_call;
+  }
+
   return method_call;
 }
 
@@ -7139,26 +7158,52 @@ MethodCall* Parser::ParseMethodCall(Variable* variable, int depth)
   const int line_pos = GetLinePosition();
   const std::wstring file_name = GetFileName();
 
+  // '?.' -- capture before NextToken() consumes the accessor
+  const bool nil_safe = scanner->GetToken()->IsNilSafe();
+
   NextToken();
   const std::wstring &method_ident = scanner->GetToken()->GetIdentifier();
-  
+
   NextToken();
   const int mid_line_num = GetLineNumber();
   const int mid_line_pos = GetLinePosition();
   const std::wstring mid_ident = variable->GetName();
   IdentifierContext ident_context(mid_ident, mid_line_num, mid_line_pos);
-  
+
   int end_pos = 0;
   ExpressionList* exprs = ParseExpressionList(end_pos, depth + 1);
 
-  MethodCall* call = TreeFactory::Instance()->MakeMethodCall(file_name, line_num, line_pos, mid_line_num, mid_line_pos,
-                                                             GetLineNumber(), end_pos, variable, method_ident, exprs);
+  // 'a?.b()' desugars to 'a->Try()->b()'. Try() guards the whole remainder of
+  // the chain, so only the first '?.' introduces one; a later '?.' in the same
+  // chain is already covered and parses as a plain accessor. The receiver is
+  // evaluated once, by Try().
+  MethodCall* call;
+  MethodCall* result;
+  if(nil_safe) {
+    MethodCall* try_call = TreeFactory::Instance()->MakeMethodCall(file_name, line_num, line_pos,
+                                                                   mid_line_num, mid_line_pos,
+                                                                   GetLineNumber(), end_pos, variable, L"Try",
+                                                                   TreeFactory::Instance()->MakeExpressionList());
+    // The guarded call hangs off Try() as a chained call, built exactly the way
+    // ParseMethodCall(IdentifierContext) builds one: the receiver slot carries
+    // the VARIABLE's name, not the enclosing class name.
+    call = TreeFactory::Instance()->MakeMethodCall(file_name, line_num, line_pos,
+                                                   mid_line_num, mid_line_pos,
+                                                   GetLineNumber(), end_pos, mid_ident, method_ident, exprs);
+    try_call->SetMethodCall(call);
+    result = try_call;
+  }
+  else {
+    call = TreeFactory::Instance()->MakeMethodCall(file_name, line_num, line_pos, mid_line_num, mid_line_pos,
+                                                   GetLineNumber(), end_pos, variable, method_ident, exprs);
+    result = call;
+  }
 
   if(Match(TOKEN_ASSESSOR) && !Match(TOKEN_AS_ID, SECOND_INDEX) && !Match(TOKEN_TYPE_OF_ID, SECOND_INDEX)) {
     call->SetMethodCall(ParseMethodCall(ident_context, depth + 1));
   }
 
-  return call;
+  return result;
 }
 
 /****************************

--- a/core/compiler/parser.cpp
+++ b/core/compiler/parser.cpp
@@ -6915,7 +6915,7 @@ MethodCall* Parser::ParseMethodCall(IdentifierContext& context, int depth)
 #endif
 
   MethodCall* method_call = nullptr;
-  // '?.' -- capture before NextToken() consumes the accessor. The call itself
+  // '?->' -- capture before NextToken() consumes the accessor. The call itself
   // is built exactly as before; it is wrapped in Try() at the return, so every
   // branch below (generics, casts, further chaining) is untouched.
   bool nil_safe = false;
@@ -7083,8 +7083,8 @@ MethodCall* Parser::ParseMethodCall(IdentifierContext& context, int depth)
     ParseCastTypeOf(method_call, depth + 1);
   }
 
-  // 'a?.b()' becomes 'a->Try()->b()'. Try() guards the whole remainder of the
-  // chain, so wrapping the head is enough -- a later '?.' in the same chain is
+  // 'a?->b()' becomes 'a->Try()->b()'. Try() guards the whole remainder of the
+  // chain, so wrapping the head is enough -- a later '?->' in the same chain is
   // already covered and behaves as a plain accessor. The receiver is named
   // once, so it is evaluated once.
   if(nil_safe && method_call) {
@@ -7158,7 +7158,7 @@ MethodCall* Parser::ParseMethodCall(Variable* variable, int depth)
   const int line_pos = GetLinePosition();
   const std::wstring file_name = GetFileName();
 
-  // '?.' -- capture before NextToken() consumes the accessor
+  // '?->' -- capture before NextToken() consumes the accessor
   const bool nil_safe = scanner->GetToken()->IsNilSafe();
 
   NextToken();
@@ -7173,8 +7173,8 @@ MethodCall* Parser::ParseMethodCall(Variable* variable, int depth)
   int end_pos = 0;
   ExpressionList* exprs = ParseExpressionList(end_pos, depth + 1);
 
-  // 'a?.b()' desugars to 'a->Try()->b()'. Try() guards the whole remainder of
-  // the chain, so only the first '?.' introduces one; a later '?.' in the same
+  // 'a?->b()' desugars to 'a->Try()->b()'. Try() guards the whole remainder of
+  // the chain, so only the first '?->' introduces one; a later '?->' in the same
   // chain is already covered and parses as a plain accessor. The receiver is
   // evaluated once, by Try().
   MethodCall* call;

--- a/core/compiler/parser.cpp
+++ b/core/compiler/parser.cpp
@@ -6193,6 +6193,47 @@ Expression* Parser::ParseExpression(int depth)
   else {
     expression = ParseLogic(depth + 1);
     //
+    // parses '??', the nil-coalesce operator
+    //
+    // Desugars to the existing Otherwise() intrinsic, which the context
+    // analyzer recognizes by method name and arity and which already emits its
+    // default inside the nil branch -- so short-circuiting comes for free and
+    // no new opcode is needed. Handled before the ternary below, so
+    // 'a ?? b ? c : d' groups as '(a ?? b) ? c : d'.
+    //
+    while(Match(TOKEN_QUESTION_QUESTION)) {
+#ifdef _DEBUG
+      Debug(L"Nil coalesce", depth);
+#endif
+      NextToken();
+      Expression* default_expression = ParseLogic(depth + 1);
+
+      ExpressionList* otherwise_args = TreeFactory::Instance()->MakeExpressionList();
+      otherwise_args->AddExpression(default_expression);
+
+      // A bare variable receiver takes the Variable* form, the same node
+      // 'a->Otherwise(b)' produces; anything else is appended to the end of the
+      // existing call chain.
+      if(expression->GetExpressionType() == VAR_EXPR && !expression->GetMethodCall()) {
+        expression = TreeFactory::Instance()->MakeMethodCall(file_name, line_num, line_pos,
+                                                             line_num, line_pos,
+                                                             GetLineNumber(), GetLinePosition(),
+                                                             static_cast<Variable*>(expression),
+                                                             L"Otherwise", otherwise_args);
+      }
+      else {
+        Expression* tail = expression;
+        while(tail->GetMethodCall()) {
+          tail = tail->GetMethodCall();
+        }
+        tail->SetMethodCall(TreeFactory::Instance()->MakeMethodCall(file_name, line_num, line_pos,
+                                                                    -1, -1,
+                                                                    GetLineNumber(), GetLinePosition(),
+                                                                    L"", L"Otherwise", otherwise_args));
+      }
+    }
+
+    //
     // parses a ternary conditional
     //
     if(Match(TOKEN_QUESTION)) {

--- a/core/compiler/scanner.cpp
+++ b/core/compiler/scanner.cpp
@@ -1540,6 +1540,16 @@ void Scanner::ParseToken(int index)
         tokens[index]->SetType(TOKEN_QUESTION_QUESTION);
         NextChar();
       }
+      // '?.' is the nil-safe accessor, but '.' followed by a digit starts a
+      // float literal, so 'a ?.5 : 1.0' must stay a ternary with a .5 operand.
+      // It scans as a plain accessor carrying a flag, so every existing
+      // Match(TOKEN_ASSESSOR) site keeps working untouched.
+      else if(nxt_char == L'.' && !iswdigit(nxt_nxt_char)) {
+        NextChar();
+        tokens[index]->SetType(TOKEN_ASSESSOR);
+        tokens[index]->SetNilSafe(true);
+        NextChar();
+      }
       else {
         tokens[index]->SetType(TOKEN_QUESTION);
         NextChar();

--- a/core/compiler/scanner.cpp
+++ b/core/compiler/scanner.cpp
@@ -1540,11 +1540,14 @@ void Scanner::ParseToken(int index)
         tokens[index]->SetType(TOKEN_QUESTION_QUESTION);
         NextChar();
       }
-      // '?.' is the nil-safe accessor, but '.' followed by a digit starts a
-      // float literal, so 'a ?.5 : 1.0' must stay a ternary with a .5 operand.
-      // It scans as a plain accessor carrying a flag, so every existing
+      // '?->' is the nil-safe accessor: the language's own '->' with a guard
+      // prefix. It scans as a plain accessor carrying a flag, so every existing
       // Match(TOKEN_ASSESSOR) site keeps working untouched.
-      else if(nxt_char == L'.' && !iswdigit(nxt_nxt_char)) {
+      //
+      // Requiring both '-' and '>' keeps a negative ternary branch intact:
+      // 'a ?-b : c' has nxt_nxt_char == 'b', so it stays a ternary.
+      else if(nxt_char == L'-' && nxt_nxt_char == L'>') {
+        NextChar();
         NextChar();
         tokens[index]->SetType(TOKEN_ASSESSOR);
         tokens[index]->SetNilSafe(true);

--- a/core/compiler/scanner.cpp
+++ b/core/compiler/scanner.cpp
@@ -1535,8 +1535,15 @@ void Scanner::ParseToken(int index)
       break;
 
     case L'?':
-      tokens[index]->SetType(TOKEN_QUESTION);
-      NextChar();
+      if(nxt_char == L'?') {
+        NextChar();
+        tokens[index]->SetType(TOKEN_QUESTION_QUESTION);
+        NextChar();
+      }
+      else {
+        tokens[index]->SetType(TOKEN_QUESTION);
+        NextChar();
+      }
       break;
 
     case L'=':

--- a/core/compiler/scanner.h
+++ b/core/compiler/scanner.h
@@ -81,6 +81,11 @@ enum ScannerTokenType {
   TOKEN_AND,
   TOKEN_OR,
   TOKEN_QUESTION,
+  // Nil-safe operators. Deliberately placed here, outside the ordered token
+  // ranges the parser scans as spans (TOKEN_LES..TOKEN_NEQL just below, and
+  // TOKEN_MUL..TOKEN_XOR_ID further down) -- inserting inside either would
+  // silently change what those range checks accept.
+  TOKEN_QUESTION_QUESTION,   // ?? nil-coalesce
   TOKEN_NOT,
   // --- start logic ---
   TOKEN_LES,

--- a/core/compiler/scanner.h
+++ b/core/compiler/scanner.h
@@ -496,7 +496,7 @@ class Token {
   int line_pos;
   std::wstring filename;
   std::wstring ident;
-  // '?.' scans as TOKEN_ASSESSOR carrying this flag rather than as its own
+  // '?->' scans as TOKEN_ASSESSOR carrying this flag rather than as its own
   // token type, so the parser's many Match(TOKEN_ASSESSOR) sites keep working
   // unchanged and only the place that builds the call consults it.
   bool nil_safe = false;
@@ -604,7 +604,7 @@ class Token {
   inline void SetType(ScannerTokenType t) {
     token_type = t;
     // Tokens are reused as the scanner advances, so clear the nil-safe flag
-    // here; the '?.' case sets it immediately after calling SetType.
+    // here; the '?->' case sets it immediately after calling SetType.
     nil_safe = false;
   }
 };

--- a/core/compiler/scanner.h
+++ b/core/compiler/scanner.h
@@ -496,6 +496,10 @@ class Token {
   int line_pos;
   std::wstring filename;
   std::wstring ident;
+  // '?.' scans as TOKEN_ASSESSOR carrying this flag rather than as its own
+  // token type, so the parser's many Match(TOKEN_ASSESSOR) sites keep working
+  // unchanged and only the place that builds the call consults it.
+  bool nil_safe = false;
 
   union {
     INT64_VALUE int64_lit;
@@ -518,6 +522,15 @@ class Token {
     ident = token->ident;
     token_type = token->token_type;
     filename = token->filename;
+    nil_safe = token->nil_safe;
+  }
+
+  inline bool IsNilSafe() {
+    return nil_safe;
+  }
+
+  inline void SetNilSafe(bool n) {
+    nil_safe = n;
   }
 
   inline std::wstring GetFileName() {
@@ -590,6 +603,9 @@ class Token {
 
   inline void SetType(ScannerTokenType t) {
     token_type = t;
+    // Tokens are reused as the scanner advances, so clear the nil-safe flag
+    // here; the '?.' case sets it immediately after calling SetType.
+    nil_safe = false;
   }
 };
 

--- a/programs/regression/nil_safe_ops.obs
+++ b/programs/regression/nil_safe_ops.obs
@@ -1,14 +1,15 @@
 #~
-Nil-safe operators: '??' (nil-coalesce) and '?.' (nil-safe call).
+Nil-safe operators: '??' (nil-coalesce) and '?->' (nil-safe call).
 
-Both desugar onto existing intrinsics -- '??' onto Otherwise(), '?.' onto
+Both desugar onto existing intrinsics -- '??' onto Otherwise(), '?->' onto
 Try() -- so these tests also guard that the desugaring preserves the
 intrinsics' behavior: the '??' default is evaluated only when the left side is
-Nil, and a '?.' receiver is evaluated exactly once.
+Nil, and a '?->' receiver is evaluated exactly once.
 
-The ternary cases at the end are scanner guards, not feature tests. '?' now
-needs lookahead to tell '?.' from a ternary followed by a float literal, so
-'flag ?.5 : 1.5' must keep parsing as a ternary.
+The ternary cases are scanner guards, not feature tests. '?' now needs
+lookahead, so a ternary whose true-branch starts with '-' or '.' must still
+parse as a ternary: 'flag ?-1 : 2' is the one that matters, since '?->'
+requires BOTH '-' and '>'.
 ~#
 
 class NilSafeOps {
@@ -62,39 +63,48 @@ class NilSafeOps {
 		j := flag ? (flag ? "aa" : "ab") : "b";
 		if(j->Equals("aa")) { passed += 1; } else { failed += 1; "FAIL: nested ternary"->PrintLine(); };
 
-		# --- '?.5' with no space is still a ternary, not a nil-safe call ---
+		# --- '?.5' with no space is still a ternary ---
 		k := flag ?.5 : 1.5;
 		if(k = 0.5) { passed += 1; } else { failed += 1; "FAIL: '?.5' must stay a ternary"->PrintLine(); };
 
-		# --- '?.' on a nil receiver yields Nil instead of faulting ---
-		l := nil_str?.ToUpper();
-		if(l = Nil) { passed += 1; } else { failed += 1; "FAIL: ?. on nil"->PrintLine(); };
+		# --- '?-' with no space is still a ternary. This is the case '?->'
+		# has to be careful about: a negative true-branch starts with '-', and
+		# only a following '>' makes it a nil-safe accessor.
+		k2 := flag ?-1 : 2;
+		if(k2 = -1) { passed += 1; } else { failed += 1; "FAIL: '?-1' must stay a ternary"->PrintLine(); };
 
-		# --- '?.' on a non-nil receiver calls through ---
-		m := real_str?.ToUpper();
-		if(m <> Nil & m->Equals("ACTUAL")) { passed += 1; } else { failed += 1; "FAIL: ?. on non-nil"->PrintLine(); };
+		k3 := flag ?-1.5 : 2.5;
+		if(k3 = -1.5) { passed += 1; } else { failed += 1; "FAIL: '?-1.5' must stay a ternary"->PrintLine(); };
+
+		# --- '?->' on a nil receiver yields Nil instead of faulting ---
+		l := nil_str?->ToUpper();
+		if(l = Nil) { passed += 1; } else { failed += 1; "FAIL: ?-> on nil"->PrintLine(); };
+
+		# --- '?->' on a non-nil receiver calls through ---
+		m := real_str?->ToUpper();
+		if(m <> Nil & m->Equals("ACTUAL")) { passed += 1; } else { failed += 1; "FAIL: ?-> on non-nil"->PrintLine(); };
 
 		# --- a longer chain on a nil receiver is guarded end to end. A chain
 		# ending in a value type needs '??' to supply the result, since an Int
 		# cannot itself be Nil.
-		n := nil_str?.ToUpper()->Size() ?? -1;
-		if(n = -1) { passed += 1; } else { failed += 1; "FAIL: ?. chain on nil"->PrintLine(); };
+		n := nil_str?->ToUpper()->Size() ?? -1;
+		if(n = -1) { passed += 1; } else { failed += 1; "FAIL: ?-> chain on nil"->PrintLine(); };
 
-		n2 := real_str?.ToUpper()->Size() ?? -1;
-		if(n2 = 6) { passed += 1; } else { failed += 1; "FAIL: ?. chain on non-nil"->PrintLine(); };
+		n2 := real_str?->ToUpper()->Size() ?? -1;
+		if(n2 = 6) { passed += 1; } else { failed += 1; "FAIL: ?-> chain on non-nil"->PrintLine(); };
 
-		# --- '?.' fused with '??' supplies the default ---
-		o := nil_str?.ToUpper() ?? "fused";
-		if(o->Equals("fused")) { passed += 1; } else { failed += 1; "FAIL: ?. fused with ??"->PrintLine(); };
+		# --- '?->' fused with '??' supplies the default ---
+		o := nil_str?->ToUpper() ?? "fused";
+		if(o->Equals("fused")) { passed += 1; } else { failed += 1; "FAIL: ?-> fused with ??"->PrintLine(); };
 
-		p := real_str?.ToUpper() ?? "fused";
-		if(p->Equals("ACTUAL")) { passed += 1; } else { failed += 1; "FAIL: ?. ?? on non-nil"->PrintLine(); };
+		p := real_str?->ToUpper() ?? "fused";
+		if(p->Equals("ACTUAL")) { passed += 1; } else { failed += 1; "FAIL: ?-> ?? on non-nil"->PrintLine(); };
 
 		# --- the receiver is evaluated exactly once ---
 		@recv_calls := 0;
-		q := Receiver()?.ToUpper();
+		q := Receiver()?->ToUpper();
 		if(q <> Nil & q->Equals("RECV") & @recv_calls = 1) { passed += 1; }
-		else { failed += 1; "FAIL: ?. evaluated receiver {$@recv_calls} times"->PrintLine(); };
+		else { failed += 1; "FAIL: ?-> evaluated receiver {$@recv_calls} times"->PrintLine(); };
 
 		# --- plain '->' is unaffected ---
 		r := real_str->ToUpper();

--- a/programs/regression/nil_safe_ops.obs
+++ b/programs/regression/nil_safe_ops.obs
@@ -1,13 +1,19 @@
 #~
-Nil-safe operators: '??' (nil-coalesce).
+Nil-safe operators: '??' (nil-coalesce) and '?.' (nil-safe call).
 
-'a ?? b' desugars to the existing Otherwise() intrinsic, so this also guards
-that the desugaring keeps Otherwise's short-circuit behavior: the default is
-only evaluated when the left side is Nil.
+Both desugar onto existing intrinsics -- '??' onto Otherwise(), '?.' onto
+Try() -- so these tests also guard that the desugaring preserves the
+intrinsics' behavior: the '??' default is evaluated only when the left side is
+Nil, and a '?.' receiver is evaluated exactly once.
+
+The ternary cases at the end are scanner guards, not feature tests. '?' now
+needs lookahead to tell '?.' from a ternary followed by a float literal, so
+'flag ?.5 : 1.5' must keep parsing as a ternary.
 ~#
 
 class NilSafeOps {
 	@calls : static : Int;
+	@recv_calls : static : Int;
 
 	function : Main(args : String[]) ~ Nil {
 		passed := 0;
@@ -56,6 +62,44 @@ class NilSafeOps {
 		j := flag ? (flag ? "aa" : "ab") : "b";
 		if(j->Equals("aa")) { passed += 1; } else { failed += 1; "FAIL: nested ternary"->PrintLine(); };
 
+		# --- '?.5' with no space is still a ternary, not a nil-safe call ---
+		k := flag ?.5 : 1.5;
+		if(k = 0.5) { passed += 1; } else { failed += 1; "FAIL: '?.5' must stay a ternary"->PrintLine(); };
+
+		# --- '?.' on a nil receiver yields Nil instead of faulting ---
+		l := nil_str?.ToUpper();
+		if(l = Nil) { passed += 1; } else { failed += 1; "FAIL: ?. on nil"->PrintLine(); };
+
+		# --- '?.' on a non-nil receiver calls through ---
+		m := real_str?.ToUpper();
+		if(m <> Nil & m->Equals("ACTUAL")) { passed += 1; } else { failed += 1; "FAIL: ?. on non-nil"->PrintLine(); };
+
+		# --- a longer chain on a nil receiver is guarded end to end. A chain
+		# ending in a value type needs '??' to supply the result, since an Int
+		# cannot itself be Nil.
+		n := nil_str?.ToUpper()->Size() ?? -1;
+		if(n = -1) { passed += 1; } else { failed += 1; "FAIL: ?. chain on nil"->PrintLine(); };
+
+		n2 := real_str?.ToUpper()->Size() ?? -1;
+		if(n2 = 6) { passed += 1; } else { failed += 1; "FAIL: ?. chain on non-nil"->PrintLine(); };
+
+		# --- '?.' fused with '??' supplies the default ---
+		o := nil_str?.ToUpper() ?? "fused";
+		if(o->Equals("fused")) { passed += 1; } else { failed += 1; "FAIL: ?. fused with ??"->PrintLine(); };
+
+		p := real_str?.ToUpper() ?? "fused";
+		if(p->Equals("ACTUAL")) { passed += 1; } else { failed += 1; "FAIL: ?. ?? on non-nil"->PrintLine(); };
+
+		# --- the receiver is evaluated exactly once ---
+		@recv_calls := 0;
+		q := Receiver()?.ToUpper();
+		if(q <> Nil & q->Equals("RECV") & @recv_calls = 1) { passed += 1; }
+		else { failed += 1; "FAIL: ?. evaluated receiver {$@recv_calls} times"->PrintLine(); };
+
+		# --- plain '->' is unaffected ---
+		r := real_str->ToUpper();
+		if(r->Equals("ACTUAL")) { passed += 1; } else { failed += 1; "FAIL: plain -> regressed"->PrintLine(); };
+
 		"Results: {$passed} passed, {$failed} failed"->PrintLine();
 		if(failed > 0) {
 			"FAIL"->PrintLine();
@@ -75,5 +119,10 @@ class NilSafeOps {
 	function : Counted() ~ String {
 		@calls += 1;
 		return "counted";
+	}
+
+	function : Receiver() ~ String {
+		@recv_calls += 1;
+		return "recv";
 	}
 }

--- a/programs/regression/nil_safe_ops.obs
+++ b/programs/regression/nil_safe_ops.obs
@@ -1,0 +1,79 @@
+#~
+Nil-safe operators: '??' (nil-coalesce).
+
+'a ?? b' desugars to the existing Otherwise() intrinsic, so this also guards
+that the desugaring keeps Otherwise's short-circuit behavior: the default is
+only evaluated when the left side is Nil.
+~#
+
+class NilSafeOps {
+	@calls : static : Int;
+
+	function : Main(args : String[]) ~ Nil {
+		passed := 0;
+		failed := 0;
+
+		# --- '??' on a nil receiver returns the default ---
+		nil_str : String;
+		a := nil_str ?? "fallback";
+		if(a <> Nil & a->Equals("fallback")) { passed += 1; } else { failed += 1; "FAIL: ?? on nil"->PrintLine(); };
+
+		# --- '??' on a non-nil receiver returns the receiver ---
+		real_str := "actual";
+		b := real_str ?? "fallback";
+		if(b <> Nil & b->Equals("actual")) { passed += 1; } else { failed += 1; "FAIL: ?? on non-nil"->PrintLine(); };
+
+		# --- chained after a method call ---
+		c := Lookup(false) ?? "defaulted";
+		if(c <> Nil & c->Equals("defaulted")) { passed += 1; } else { failed += 1; "FAIL: ?? after call (nil)"->PrintLine(); };
+
+		d := Lookup(true) ?? "defaulted";
+		if(d <> Nil & d->Equals("found")) { passed += 1; } else { failed += 1; "FAIL: ?? after call (non-nil)"->PrintLine(); };
+
+		# --- the default is NOT evaluated when the receiver is non-nil ---
+		@calls := 0;
+		e := real_str ?? Counted();
+		if(e->Equals("actual") & @calls = 0) { passed += 1; } else { failed += 1; "FAIL: ?? evaluated default eagerly"->PrintLine(); };
+
+		# --- ...and IS evaluated when the receiver is nil ---
+		@calls := 0;
+		f := nil_str ?? Counted();
+		if(f->Equals("counted") & @calls = 1) { passed += 1; } else { failed += 1; "FAIL: ?? skipped default"->PrintLine(); };
+
+		# --- '??' binds tighter than the ternary: (a ?? b) ? c : d ---
+		g := (nil_str ?? "x")->Equals("x") ? "yes" : "no";
+		if(g->Equals("yes")) { passed += 1; } else { failed += 1; "FAIL: ?? with ternary"->PrintLine(); };
+
+		# --- ternary and float literals still scan correctly ---
+		flag := true;
+		h := flag ? .5 : 1.5;
+		if(h = 0.5) { passed += 1; } else { failed += 1; "FAIL: ternary with .5 literal"->PrintLine(); };
+
+		i := flag ? 2.5 : .25;
+		if(i = 2.5) { passed += 1; } else { failed += 1; "FAIL: ternary literal (else branch)"->PrintLine(); };
+
+		# --- nested ternary still parses ---
+		j := flag ? (flag ? "aa" : "ab") : "b";
+		if(j->Equals("aa")) { passed += 1; } else { failed += 1; "FAIL: nested ternary"->PrintLine(); };
+
+		"Results: {$passed} passed, {$failed} failed"->PrintLine();
+		if(failed > 0) {
+			"FAIL"->PrintLine();
+			Runtime->Exit(1);
+		};
+		"PASS"->PrintLine();
+	}
+
+	function : Lookup(found : Bool) ~ String {
+		if(found) {
+			return "found";
+		};
+
+		return Nil;
+	}
+
+	function : Counted() ~ String {
+		@calls += 1;
+		return "counted";
+	}
+}


### PR DESCRIPTION
Two nil-safe operators, both desugared onto intrinsics that already exist.

```objeck
display := name ?? "(unknown)";              # nil-coalesce
city    := person?->GetAddress()?->GetCity(); # nil-safe call: Nil, not a fault
size    := maybe?->ToUpper()->Size() ?? -1;
```

## How they work

| Source | Desugars to |
|---|---|
| `a ?? b` | `a->Otherwise(b)` |
| `a?->b()` | `a->Try()->b()` |

The context analyzer already recognizes `Try`/`Otherwise` by method name and arity, and `EmitOtherwiseIntrinsic` already emits the default *inside* the Nil branch — so short-circuiting comes for free. `Try()` guards the whole remainder of a chain, so only its head needs wrapping: `a?->b()?->c()` and `a?->b()->c()` are both fully guarded by one `Try()`.

**No new opcode.** `linker.cpp`'s bytecode reader, both JIT whitelists, and the VM are untouched — where the risk in this codebase usually lives.

## Why `?->` and not `?.`

The first version used `?.`, borrowed from C#/Kotlin/Swift. But those languages use `.` as the member accessor and **Objeck uses `->`** — so `?.` introduced a `.` meaning member access in a language where `.` otherwise appears only in bundle paths and float literals. `?->` is the language's own accessor with a guard prefix.

It also **removes an ambiguity class rather than working around one**. `?.` had to be disambiguated from a float literal, because `.` followed by a digit starts a number and `flag ?.5 : 1.5` must stay a ternary. That guard is gone — `-` never starts a literal.

The replacement ambiguity is narrower and handled by requiring both characters: `flag ?-1 : 2` has `nxt_nxt_char == '1'`, so it stays a ternary; only `-` followed by `>` is the accessor. Three characters is exactly the scanner's existing `LOOK_AHEAD`.

`??` is unchanged — it's a binary operator, not an accessor, so the `->` consistency argument doesn't apply, and `??` is the near-universal spelling.

## Implementation notes

`?->` doesn't get its own token type. It scans as `TOKEN_ASSESSOR` carrying a `nil_safe` flag, so all eight existing `Match(TOKEN_ASSESSOR)` sites keep working and only the call-building site consults it. That's also why the rename touched the scanner alone — the parser desugaring keys off the flag, not the spelling.

Two wrong turns worth recording, since one is a silent-failure mode:

- The first attempt put the enclosing **class** name in the guarded call's receiver slot; `ParseMethodCall(IdentifierContext)` uses the **receiver's** name there.
- The second put the flag check in `ParseMethodCall(Variable*)` — not the path a local variable takes. `a->b()` on a local goes through the `IdentifierContext` overload, so the flag was never read and the operator **silently behaved as plain `->`**. That's why the tests assert guarding behavior rather than just "it compiles".

## Verification

`programs/regression/nil_safe_ops.obs` — **21/21**:

- `??` and `?->` on nil and non-nil receivers
- a chain guarded end to end
- fusion (`a?->b() ?? default`) in both directions
- the `??` default **not** evaluated when the receiver is non-Nil, and **is** when it is Nil
- the `?->` receiver evaluated **exactly once** (counter-backed)
- ternary guards: `flag ?-1 : 2`, `flag ?-1.5 : 2.5`, `flag ?.5 : 1.5`, `flag ? .5 : 1.5`, `flag ? 2.5 : .25`, nested ternaries
- plain `->` unaffected

Full x64 regression: **172 passed, 0 failed**. The previous revision was green on all five platforms; this one is rebuilding.

## One pre-existing constraint this surfaces

A `?->` chain ending in a **value type** needs `??` to supply the result, because an `Int` cannot itself be `Nil`: `a?->b()->Size() ?? -1`. That mirrors what `Try()`/`Otherwise()` already required and is documented in the test.

Also worth knowing: `Try()` catches *any* runtime error in the chain, not only a nil dereference — so `a?->Get(999)` yields `Nil` on an out-of-bounds index rather than faulting. That is broader than Kotlin's or C#'s `?.`, inherited from the intrinsic it builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)