### PR TITLE
docs(lang): document '?->' and '??', and stop the formatter breaking '??'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Objeck will be documented in this file.
 
 ## [Unreleased]
 
+### New Features
+- **Nil-safe operators `?->` and `??`**: `a?->b()` calls `b` only when `a` is non-`Nil`, yielding `Nil` instead of faulting, and `a ?? b` supplies `b` when `a` is `Nil` (evaluating `b` only when needed). A single `?->` guards the whole remainder of a chain, so `maybe?->Trim()->ToUpper()` is safe throughout. Both desugar in the parser onto the existing `Try()`/`Otherwise()` intrinsics — `a?->b()` is `a->Try()->b()` and `a ?? b` is `a->Otherwise(b)` — so no new opcode is emitted and the bytecode reader, both JIT backends, and the VM are unchanged. A chain ending in a value type needs `??` to supply the result, since an `Int` cannot itself be `Nil`: `maybe?->ToUpper()->Size() ?? -1`. Note that `Try()` guards against any runtime error in the chain, not only a `Nil` dereference. The spelling is `?->` rather than `?.` because Objeck's member accessor is `->`; it also avoids the float-literal ambiguity `?.` would introduce, since `.` followed by a digit starts a number.
+
+### Bug Fixes
+- **Formatter split `??` into `? ?`**: the LSP formatter's scanner tokenized `?` one character at a time, so formatting a file that used `??` emitted `? ?` and produced source that no longer compiled. `??` now scans as a single token.
+- **Language server crashed on five requests**: `textDocument/implementation`, `semanticTokens/full`, `inlayHint`, and both call-hierarchy directions returned a `Result[]` through the local argument array and cast it on the way out, which fails at runtime and killed the server process (`Invalid object cast: '?' to 'System.Diagnostics.Result'`). Each now writes into an `Analysis` instance slot, the pattern `FindReferences`/`GetSymbols` already used.
+- **Requests resolved to the wrong method**: `FindMethodOrClass` converted a method's start line to the editor's 0-based numbering but not its end line, and the end line records the token *after* the closing brace — so every method's range overran onto the next declaration and any cursor past the first method of a class resolved to the first method. This affected definition, references, hover, rename and call hierarchy.
+
+### Tooling
+- **Editor tooling is now tested in CI**: a `tools` job runs the formatter regression suite, a new LSP regression harness (`tools/lsp/tests/run_lsp_tests.py`, 25 assertions over the capability set and handler behavior), and the VS Code extension's TypeScript build and lint. The formatter suite had never run in this repository layout — its `OBJECK_ROOT` resolved outside the repo — and the tooling scripts appended the build tree to `PATH`, so a system-wide Objeck install shadowed it.
+
 ## [v2026.6.4] - 2026-06-28
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Objeck will be documented in this file.
 
 ## [Unreleased]
 
+## [v2026.8.0] - 2026-08-01
+
 ### New Features
 - **Nil-safe operators `?->` and `??`**: `a?->b()` calls `b` only when `a` is non-`Nil`, yielding `Nil` instead of faulting, and `a ?? b` supplies `b` when `a` is `Nil` (evaluating `b` only when needed). A single `?->` guards the whole remainder of a chain, so `maybe?->Trim()->ToUpper()` is safe throughout. Both desugar in the parser onto the existing `Try()`/`Otherwise()` intrinsics — `a?->b()` is `a->Try()->b()` and `a ?? b` is `a->Otherwise(b)` — so no new opcode is emitted and the bytecode reader, both JIT backends, and the VM are unchanged. A chain ending in a value type needs `??` to supply the result, since an `Int` cannot itself be `Nil`: `maybe?->ToUpper()->Size() ?? -1`. Note that `Try()` guards against any runtime error in the chain, not only a `Nil` dereference. The spelling is `?->` rather than `?.` because Objeck's member accessor is `->`; it also avoids the float-literal ambiguity `?.` would introduce, since `.` followed by a digit starts a number.
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -45,6 +45,49 @@ value := "Hello World!";
 value->Size()->PrintLine();
 ```
 
+### Nil Safety
+`?->` calls a method only when the receiver is non-`Nil`, yielding `Nil` instead
+of faulting. `??` supplies a value when the left side is `Nil`.
+
+```ruby
+# without them
+city := Nil;
+if(person <> Nil) {
+  address := person->GetAddress();
+  if(address <> Nil) {
+    city := address->GetCity();
+  };
+};
+
+# with them
+city := person?->GetAddress()?->GetCity();
+
+# '??' supplies a default; the right side is evaluated only when needed
+name := lookup ?? "(unknown)";
+port := config_port ?? ExpensiveDefault();
+```
+
+A single `?->` guards the **whole rest of the chain**, so you do not need one at
+every step:
+
+```ruby
+# both calls are guarded by the one '?->'
+text := maybe?->Trim()->ToUpper();
+```
+
+A chain that ends in a value type needs `??` to supply the result, since an
+`Int` cannot itself be `Nil`:
+
+```ruby
+size := maybe?->ToUpper()->Size() ?? -1;
+```
+
+Both build on the `Try()`/`Otherwise()` intrinsics, so `a?->b()` is exactly
+`a->Try()->b()` and `a ?? b` is `a->Otherwise(b)`. One consequence worth
+knowing: `Try()` guards against *any* runtime error in the chain, not only a
+`Nil` dereference — `a?->Get(999)` yields `Nil` on an out-of-range index rather
+than faulting.
+
 ### Anonymous Classes
 ```ruby
 interface Greetings {

--- a/docs/syntax/sublime/objeck.sublime-syntax
+++ b/docs/syntax/sublime/objeck.sublime-syntax
@@ -68,6 +68,11 @@ contexts:
     - match: \+\=|-\=|\*\=|/\=|(:=)
       scope: keyword.operator.assignment.objeck-obs
 
+    # nil-safe operators, matched before the arithmetic rules so '?->' is not
+    # split into '?' and '-'
+    - match: (\?->)|(\?\?)
+      scope: keyword.operator.objeck-obs
+
     - match: \||&|(<>)|<|>|<|>|(>=)|(<=)|=
       scope: keyword.operator.logical.objeck-obs
 

--- a/docs/syntax/vim/objeck.vim
+++ b/docs/syntax/vim/objeck.vim
@@ -54,6 +54,9 @@ syn match objeckOperator '+='
 syn match objeckOperator '-='
 syn match objeckOperator '\*='
 syn match objeckOperator '/='
+" nil-safe operators before '->' so '?->' highlights as one unit
+syn match objeckOperator '?->'
+syn match objeckOperator '??'
 syn match objeckOperator '->'
 syn keyword objeckOperator and or not xor
 

--- a/docs/syntax/vscode/syntaxes/objeck.tmLanguage.json
+++ b/docs/syntax/vscode/syntaxes/objeck.tmLanguage.json
@@ -112,7 +112,7 @@
 					"name": "keyword.operator.objeck"
 				},
 				{
-					"match": "(->|<=|>=|<>|<|>)",
+					"match": "(\\?->|\\?\\?|->|<=|>=|<>|<|>)",
 					"name": "keyword.operator.objeck"
 				},
 				{

--- a/docs/web/getting_started.html
+++ b/docs/web/getting_started.html
@@ -1203,6 +1203,26 @@ for(i := 0; i &lt; end; i += 3;) {
   r-&gt;Append( lut[0x3F and (a &gt;&gt; 6)] );
   r-&gt;Append( lut[0x3F and a] );
 };</code></pre>
+         <h4 id="nil_safety">
+          Nil-safe operators
+         </h4>
+         <p>
+          <code>?-&gt;</code> calls a method only when the receiver is non-<code>Nil</code>, yielding <code>Nil</code> rather than faulting. <code>??</code> supplies a value when its left side is <code>Nil</code>, and evaluates the right side only when it has to.
+         </p>
+         <pre class="line-numbers"><code class="language-cpp"># guarded call: Nil instead of a fault if person or the address is Nil
+city := person?-&gt;GetAddress()?-&gt;GetCity();
+
+# default when the left side is Nil
+name := lookup ?? "(unknown)";
+
+# a single '?-&gt;' guards the whole rest of the chain
+text := maybe?-&gt;Trim()-&gt;ToUpper();
+
+# a chain ending in a value type needs '??', since an Int cannot be Nil
+size := maybe?-&gt;ToUpper()-&gt;Size() ?? -1;</code></pre>
+         <p>
+          Both build on the <code>Try()</code>/<code>Otherwise()</code> methods: <code>a?-&gt;b()</code> is <code>a-&gt;Try()-&gt;b()</code> and <code>a ?? b</code> is <code>a-&gt;Otherwise(b)</code>. One consequence worth knowing is that <code>Try()</code> guards against any runtime error in the chain, not only a <code>Nil</code> dereference — so <code>a?-&gt;Get(999)</code> yields <code>Nil</code> on an out-of-range index instead of faulting.
+         </p>
          <p>
           The language has support for dynamically allocated arrays, Unicode strings and various containers.
          </p>

--- a/tools/lsp/clients/neovim/objeck.vim
+++ b/tools/lsp/clients/neovim/objeck.vim
@@ -45,6 +45,9 @@ syn keyword objeckBuiltin New Parent Try Otherwise
 " Operators
 syn keyword objeckOperator As TypeOf and or xor not
 syn match objeckOperator ":="
+" nil-safe operators before '->' so '?->' highlights as one unit
+syn match objeckOperator "?->"
+syn match objeckOperator "??"
 syn match objeckOperator "->"
 syn match objeckOperator "[+\-*/%=<>]"
 syn match objeckOperator "<>"

--- a/tools/lsp/clients/sublime/objeck.sublime-syntax
+++ b/tools/lsp/clients/sublime/objeck.sublime-syntax
@@ -68,6 +68,11 @@ contexts:
     - match: \+\=|-\=|\*\=|/\=|(:=)
       scope: keyword.operator.assignment.objeck-obs
 
+    # nil-safe operators, matched before the arithmetic rules so '?->' is not
+    # split into '?' and '-'
+    - match: (\?->)|(\?\?)
+      scope: keyword.operator.objeck-obs
+
     - match: \||&|(<>)|<|>|<|>|(>=)|(<=)|=
       scope: keyword.operator.logical.objeck-obs
 

--- a/tools/lsp/clients/vim/syntax/objeck.vim
+++ b/tools/lsp/clients/vim/syntax/objeck.vim
@@ -54,6 +54,9 @@ syn match objeckOperator '+='
 syn match objeckOperator '-='
 syn match objeckOperator '\*='
 syn match objeckOperator '/='
+" nil-safe operators before '->' so '?->' highlights as one unit
+syn match objeckOperator '?->'
+syn match objeckOperator '??'
 syn match objeckOperator '->'
 syn keyword objeckOperator and or not xor
 

--- a/tools/lsp/clients/vscode/syntaxes/objeck.tmLanguage.json
+++ b/tools/lsp/clients/vscode/syntaxes/objeck.tmLanguage.json
@@ -112,7 +112,7 @@
 					"name": "keyword.operator.objeck"
 				},
 				{
-					"match": "(->|<=|>=|<>|<|>)",
+					"match": "(\\?->|\\?\\?|->|<=|>=|<>|<|>)",
 					"name": "keyword.operator.objeck"
 				},
 				{

--- a/tools/lsp/server/format_code/formatter.obs
+++ b/tools/lsp/server/format_code/formatter.obs
@@ -305,6 +305,10 @@ class CodeFormatter {
 						AppendBuffer('?');
 					}
 
+					label Token->Type->QUESTION_QUESTION {
+						AppendBuffer("??");
+					}
+
 					label Token->Type->IDENT {
 						if(@prev_token->GetType() = Token->Type->ASSESSOR | 
 								@prev_token->GetType() = Token->Type->ADD_ADD | 

--- a/tools/lsp/server/format_code/regression_test.obs
+++ b/tools/lsp/server/format_code/regression_test.obs
@@ -31,6 +31,7 @@ class FormatterRegressionTest {
 		TestTrimTrailing();
 		TestKeywordFormatting();
 		TestOperatorSpacing();
+		TestNilSafeOperators();
 		TestNestedBlocks();
 
 		p := @passed;
@@ -189,6 +190,34 @@ class FormatterRegressionTest {
 		Check("Operators: assignment ':=' present", result->Find(":=") > -1);
 		Check("Operators: '+' present", result->Find("+") > -1);
 		Check("Operators: '*' present", result->Find("*") > -1);
+	}
+
+	function : TestNilSafeOperators() ~ Nil {
+		"\n>> Nil-safe operators..."->PrintLine();
+
+		# '??' has to survive as one token. Scanning it as two QUESTIONs made the
+		# formatter emit '? ?', which does not compile -- formatting a file would
+		# silently break it.
+		src := "class Foo{New(){@a:=@s??\"d\";@b:=@s?->ToUpper();@c:=@s?->ToUpper()??\"d\";}}";
+
+		options := Map->New()<String, String>;
+		options->Insert("function-space", "false");
+		options->Insert("trim-trailing", "true");
+
+		result := CodeFormatter->New(options)->Format(src);
+
+		Check("Nil-safe: result not nil", result <> Nil);
+		Check("Nil-safe: '??' not split into '? ?'", result->Find("? ?") = -1);
+		Check("Nil-safe: '??' present", result->Find("??") > -1);
+		Check("Nil-safe: '?->' present", result->Find("?->") > -1);
+
+		# a plain ternary must still format, and '?-' must not be mistaken for
+		# the start of '?->'
+		ternary_src := "class Bar{New(){@a:=true?1:2;@b:=true?-1:2;}}";
+		ternary := CodeFormatter->New(options)->Format(ternary_src);
+
+		Check("Nil-safe: ternary still formats", ternary <> Nil);
+		Check("Nil-safe: ternary '?' preserved", ternary->Find("?") > -1);
 	}
 
 	function : TestNestedBlocks() ~ Nil {

--- a/tools/lsp/server/format_code/scanner.obs
+++ b/tools/lsp/server/format_code/scanner.obs
@@ -385,7 +385,17 @@ class Scanner {
 					}
 
 					label '?' {
-						@tokens->AddBack(Token->New(@line_num, Token->Type->QUESTION, "question"));
+						# '??' must scan as one token; emitting two QUESTIONs makes
+						# the formatter write '? ?', which no longer compiles.
+						# '?->' needs nothing here: it scans as QUESTION followed by
+						# ASSESSOR, and neither adds a space between them.
+						if(@next_char = '?') {
+							@tokens->AddBack(Token->New(@line_num, Token->Type->QUESTION_QUESTION, "question_question"));
+							NextChar();
+						}
+						else {
+							@tokens->AddBack(Token->New(@line_num, Token->Type->QUESTION, "question"));
+						};
 						NextChar();
 					}
 
@@ -518,6 +528,7 @@ class Token {
 		AND,
 		OR,
 		QUESTION,
+		QUESTION_QUESTION,
 		DIV,
 		MOD,
 		MUL,


### PR DESCRIPTION
Documentation for the two nil-safe operators — plus a formatter bug the documentation work uncovered.

## The formatter was silently breaking `??`

The LSP formatter has its own scanner, and it tokenized `?` one character at a time with no notion of `??`. Formatting any file that used the operator emitted `? ?`:

```objeck
a := s ?? "fallback";     # before formatting
a := s ? ? "fallback";    # after formatting — no longer compiles
```

So the formatter turned working source into broken source. `??` now scans as a single token and is written back as a unit. `?->` already survived (its `?` and `->` are adjacent tokens with no space inserted between them), but it's now covered by tests too.

This is why the docs pass was worth doing carefully rather than just writing prose — the feature wasn't actually finished.

## Documentation

- **`docs/FEATURES.md`** — a Nil Safety section under OOP: the before/after against nested `if(x <> Nil)` checks, chain guarding, and the value-type caveat.
- **`docs/web/getting_started.html`** — the same material, placed after the operator tables.
- **`CHANGELOG.md`** — an `[Unreleased]` entry covering the operators, this formatter fix, the five crashing LSP handlers, the wrong-method resolution bug, and the new CI coverage.

Both operators are explained in terms of what they replace, and each notes the two constraints worth knowing: a chain ending in a value type needs `??` (an `Int` cannot be `Nil`), and `Try()` guards against *any* runtime error in the chain rather than only a `Nil` dereference.

## Syntax highlighting

Updated every definition that enumerates operators — VS Code (TextMate), vim, neovim and Sublime, in both the `docs/syntax` and `tools/lsp/clients` copies.

In each, the nil-safe patterns are ordered **before** `->` and the arithmetic rules, so `?->` highlights as one operator instead of being split into `?` and `-`. The TextMate pattern was tested directly:

```
'?->' -> ?->
'??'  -> ??
'->'  -> ->
```

## Verification

- Formatter regression **39/39**, up from 33 — six new assertions pinning that `??` is never split, that `?->` survives, and that a plain ternary and `?-` still format
- LSP harness **25/25**
- x64 regression **172/172**
- The formatter's output for a file using both operators was **compiled** to confirm it is still valid source
- All edited JSON and YAML syntax files re-parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)