### PR TITLE
fix(compiler): repair two Try()/Otherwise() defects behind the nil-safe operators

### DIFF
--- a/core/compiler/context.cpp
+++ b/core/compiler/context.cpp
@@ -2644,6 +2644,47 @@ void ContextAnalyzer::AnalyzeMethodCall(MethodCall* method_call, const int depth
       }
     }
     
+    // Try()/Otherwise() are resolved here, before any class lookup. Neither
+    // intrinsic needs one -- both work off the receiver's type -- and the
+    // lookup does not resolve for an indexed receiver, so the checks that used
+    // to live inside the program/library branches below were never reached for
+    // 'arr[i]->Try()->m()'. It fell through to the variable path and reported
+    // "Invalid class type or assignment", even though 'arr[i]->m()' resolves.
+    if(method_call->GetCallType() == METHOD_CALL) {
+      const std::wstring intrinsic_name = method_call->GetMethodName();
+      const bool has_params = method_call->GetCallingParameters() != nullptr;
+      const size_t param_count = has_params ? method_call->GetCallingParameters()->GetExpressions().size() : 0;
+      const bool is_try = intrinsic_name == L"Try" && has_params && param_count == 0;
+      const bool is_otherwise = intrinsic_name == L"Otherwise" && has_params && param_count == 1;
+
+      if(is_try || is_otherwise) {
+        if(entry && entry->GetType()) {
+          Variable* recv_variable = method_call->GetVariable();
+          if(recv_variable && recv_variable->GetIndices()) {
+            // an indexed receiver is one element, so the chain has to resolve
+            // against the element type rather than the array type
+            Type* element_type = TypeFactory::Instance()->MakeType(entry->GetType());
+            element_type->SetDimension(0);
+            method_call->SetEvalType(element_type, false);
+          }
+          else {
+            method_call->SetEvalType(entry->GetType(), false);
+          }
+        }
+
+        if(is_try) {
+          AnalyzeTryIntrinsic(method_call, static_cast<Expression*>(method_call), depth);
+        }
+        else {
+          AnalyzeOtherwiseIntrinsic(method_call, static_cast<Expression*>(method_call), depth);
+        }
+
+        --nested_call_depth;
+        RogueReturn(method_call);
+        return;
+      }
+    }
+
     // local call
     std::wstring encoding;
     Class* klass = AnalyzeProgramMethodCall(method_call, encoding, depth);

--- a/core/compiler/intermediate.cpp
+++ b/core/compiler/intermediate.cpp
@@ -4722,6 +4722,64 @@ void IntermediateEmitter::EmitOtherwiseIntrinsic(MethodCall* method_call, Expres
   imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(current_statement, expression, cur_line_num, LBL, skip_label));
   imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(current_statement, expression, cur_line_num, LBL, end_label));
   imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(current_statement, expression, cur_line_num, LOAD_INT_VAR, 0, LOCL));
+
+  // Emit the rest of the chain, the way EmitTryIntrinsic does. Both callers
+  // break out of their chain loop right after calling this, so without it
+  // anything written after Otherwise() is dropped -- silently, producing a
+  // wrong value rather than an error: 'x->Otherwise("abc")->ToUpper()' yielded
+  // "abc", and a second Otherwise (which is what 'a ?? b ?? c' desugars to)
+  // never ran at all.
+  //
+  // The result is on the stack, so chained calls are nested. A chained
+  // Otherwise() recurses here and re-consumes that value as its receiver.
+  MethodCall* tail_call = method_call->GetMethodCall();
+  bool is_nested = true;
+  while(tail_call) {
+    if(tail_call->IsTryIntrinsic()) {
+      EmitTryIntrinsic(tail_call, expression, is_nested);
+      return;
+    }
+
+    if(tail_call->IsOtherwiseIntrinsic()) {
+      EmitOtherwiseIntrinsic(tail_call, expression);
+      return;
+    }
+
+    EmitMethodCall(tail_call, is_nested);
+    EmitCast(tail_call);
+    if(!tail_call->GetVariable()) {
+      EmitClassCast(tail_call);
+    }
+
+    // update is_nested
+    if(tail_call->GetMethod()) {
+      Method* method = tail_call->GetMethod();
+      if(method->GetReturn()->GetType() == CLASS_TYPE) {
+        const bool is_enum = parsed_program->GetLinker()->SearchEnumLibraries(method->GetReturn()->GetName(), parsed_program->GetLibUses()) ||
+          SearchProgramEnums(method->GetReturn()->GetName());
+        is_nested = !is_enum;
+      }
+      else {
+        is_nested = false;
+      }
+    }
+    else if(tail_call->GetLibraryMethod()) {
+      LibraryMethod* lib_method = tail_call->GetLibraryMethod();
+      if(lib_method->GetReturn()->GetType() == CLASS_TYPE) {
+        const bool is_enum = parsed_program->GetLinker()->SearchEnumLibraries(lib_method->GetReturn()->GetName(), parsed_program->GetLibUses()) ||
+          SearchProgramEnums(lib_method->GetReturn()->GetName());
+        is_nested = !is_enum;
+      }
+      else {
+        is_nested = false;
+      }
+    }
+    else {
+      is_nested = false;
+    }
+
+    tail_call = tail_call->GetMethodCall();
+  }
 }
 
 /****************************

--- a/programs/regression/TESTS.md
+++ b/programs/regression/TESTS.md
@@ -13,19 +13,20 @@ python gen_manifest.py
 ```
 
 
-**Total runtime tests: 156** (plus 14 debugger tests, see below).
+**Total runtime tests: 172** (plus 14 debugger tests, see below).
 
 
 ## Tests by Category
 
 | Category | Count |
 |----------|-------|
-| Core Language | 36 |
+| Core Language | 38 |
+| AMD64/JIT | 19 |
 | Negative | 16 |
-| AMD64/JIT | 13 |
 | Bug Fix | 13 |
 | System.ML | 13 |
 | Collections | 10 |
+| Other | 7 |
 | Math | 6 |
 | Functional | 5 |
 | Strings | 5 |
@@ -43,6 +44,7 @@ python gen_manifest.py
 | Concurrency/GC | 1 |
 | Control Flow | 1 |
 | Debugger | 1 |
+| Debugger (neg) | 1 |
 | Exceptions | 1 |
 | I/O | 1 |
 | LSP | 1 |
@@ -83,131 +85,147 @@ python gen_manifest.py
 | 29 | `bad_undefined_type.obs` | Negative | rejects undefined type | ✅ |
 | 30 | `bad_undefined_var.obs` | Negative | rejects undefined var | ✅ |
 | 31 | `bad_wrong_return.obs` | Negative | rejects wrong return | ✅ |
-| 32 | `collect_compare_vector.obs` | Collections | collect compare vector | ✅ |
-| 33 | `collect_each_patterns.obs` | Collections | collect each patterns | ✅ |
-| 34 | `collect_hash_ops.obs` | Collections | collect hash ops | ✅ |
-| 35 | `collect_map_ops.obs` | Collections | collect map ops | ✅ |
-| 36 | `collect_nested_ops.obs` | Collections | collect nested ops | ✅ |
-| 37 | `collect_pair_ops.obs` | Collections | collect pair ops | ✅ |
-| 38 | `collect_queue_ops.obs` | Collections | collect queue ops | ✅ |
-| 39 | `collect_set_ops.obs` | Collections | collect set ops | ✅ |
-| 40 | `collect_stack_ops.obs` | Collections | collect stack ops | ✅ |
-| 41 | `collect_vector_ops.obs` | Collections | collect vector ops | ✅ |
-| 42 | `core_abstract_virtual.obs` | Core Language | core abstract virtual | ✅ |
-| 43 | `core_arithmetic.obs` | Core Language | Core Arithmetic Operations Test Tests basic arithmetic operations, type conversions, and operator... | ✅ |
-| 44 | `core_array_operations.obs` | Core Language | core array operations | ✅ |
-| 45 | `core_arrays_simple.obs` | Core Language | Core Array Operations Test (Simplified) Tests basic array creation, access, and modification | ✅ |
-| 46 | `core_bitwise_ops.obs` | Core Language | core bitwise ops | ✅ |
-| 47 | `core_bool_ops.obs` | Core Language | core bool ops | ✅ |
-| 48 | `core_break_continue.obs` | Core Language | core break continue | ✅ |
-| 49 | `core_char_methods.obs` | Core Language | core char methods | ✅ |
-| 50 | `core_classes.obs` | Core Language | Core Classes Test Tests class instantiation, inheritance, method calls, and select statements Bas... | ✅ |
-| 51 | `core_collections_perf.obs` | Core Language | core collections perf | ✅ |
-| 52 | `core_control_flow.obs` | Core Language | Core Control Flow Test Tests if/else, loops, and select statements | ✅ |
-| 53 | `core_do_while.obs` | Core Language | core do while | ✅ |
-| 54 | `core_each_loop.obs` | Core Language | core each loop | ✅ |
-| 55 | `core_enum.obs` | Core Language | core enum | ✅ |
-| 56 | `core_function_refs.obs` | Core Language | core function refs | ✅ |
-| 57 | `core_generic_compound_bounds.obs` | Generics | Compound generic bounds (T : A & B): a concrete type argument must satisfy ALL bounds. Person imp... | ✅ |
-| 58 | `core_generic_fbound.obs` | Generics | F-bounded type-parameter constraint (T : Compare<T>): the bound may be generic and self-referenti... | ✅ |
-| 59 | `core_generic_structural.obs` | Generics | Exercises the structural generic type comparison: deeply nested generic type arguments must round... | ✅ |
-| 60 | `core_generic_variance.obs` | Generics | Declaration-site variance: 'out T' (covariant) lets Producer<Dog> be used where Producer<Animal>... | ✅ |
-| 61 | `core_http_server.obs` | Core Language | HTTP Client/Server Loopback Test Tests HTTP GET and POST using raw TCP server + HttpClient. Verif... | ✅ |
-| 62 | `core_inheritance_chain.obs` | Core Language | core inheritance chain | ✅ |
-| 63 | `core_int_methods.obs` | Core Language | core int methods | ✅ |
-| 64 | `core_interfaces.obs` | Core Language | core interfaces | ✅ |
-| 65 | `core_json_escape.obs` | Core Language | core json escape | ✅ |
-| 66 | `core_method_overload.obs` | Core Language | core method overload | ✅ |
-| 67 | `core_multi_dim_array.obs` | Core Language | core multi dim array | ✅ |
-| 68 | `core_net_buffer.obs` | Core Language | Network Buffer Read Test Tests that TCP socket ReadBuffer correctly handles partial reads by veri... | ✅ |
-| 69 | `core_odbc.obs` | Core Language | Core ODBC Bindings Test Tests Date, Timestamp, and ColumnInfo classes without requiring a databas... | ✅ |
-| 70 | `core_opencv.obs` | Core Language | Core OpenCV Bindings Test Tests helper classes, constants, and VideoWriter FourCC without requiri... | ✅ |
-| 71 | `core_records.obs` | Core Language | Core Records Test Exercises record-generated constructors, accessors, mutators, generics, readonl... | ✅ |
-| 72 | `core_recursion.obs` | Core Language | Core Recursion Test Tests recursive function calls and tail recursion | ✅ |
-| 73 | `core_select_ops.obs` | Core Language | core select ops | ✅ |
-| 74 | `core_static_array_literals.obs` | Core Language | Regression test for the static-array literal pool (compiler bug, 2026-06): the bool literal-pool... | ✅ |
-| 75 | `core_static_fields.obs` | Core Language | core static fields | ✅ |
-| 76 | `core_string_format.obs` | Core Language | core string format | ✅ |
-| 77 | `core_string_interp_expr.obs` | Core Language | Verifies operator expressions inside "{$...}" string interpolation. | ✅ |
-| 78 | `core_string_interp_format.obs` | Core Language | Verifies inline format specifiers "{$expr:spec}" in string interpolation. | ✅ |
-| 79 | `core_string_methods.obs` | Core Language | core string methods | ✅ |
-| 80 | `core_strings_simple.obs` | Core Language | Core String Operations Test (Simplified) Tests basic string operations without complex method cha... | ✅ |
-| 81 | `core_thread_gc_stress.obs` | Concurrency/GC | Multithreaded GC stop-the-world stress test. Guards the GC bugs fixed on branch fix/gc-stop-the-w... | ✅ |
-| 82 | `core_type_checking.obs` | Core Language | core type checking | ✅ |
-| 83 | `date_arithmetic.obs` | Date/Time | date arithmetic | ✅ |
-| 84 | `date_basic_ops.obs` | Date/Time | date basic ops | ✅ |
-| 85 | `debugger_test.obs` | Debugger | debugger test | ✅ |
-| 86 | `fix524_array_cast_chain.obs` | Bug Fix | Fix #524: Cannot chain method calls on array-indexed elements after cast Tests that Get(index)->A... | ✅ |
-| 87 | `fix534_substring_crash.obs` | Bug Fix | Fix #534: String->SubString crash on negative or zero length argument Tests that negative or zero... | ✅ |
-| 88 | `fix_array_bounds.obs` | Bug Fix | fix array bounds | ✅ |
-| 89 | `fix_chained_calls.obs` | Bug Fix | fix chained calls | ✅ |
-| 90 | `fix_deep_recursion.obs` | Bug Fix | fix deep recursion | ✅ |
-| 91 | `fix_float_precision.obs` | Bug Fix | fix float precision | ✅ |
-| 92 | `fix_int_boundary.obs` | Bug Fix | fix int boundary | ✅ |
-| 93 | `fix_large_arrays.obs` | Bug Fix | fix large arrays | ✅ |
-| 94 | `fix_nested_generics.obs` | Bug Fix | fix nested generics | ✅ |
-| 95 | `fix_nil_chain_ops.obs` | Bug Fix | fix nil chain ops | ✅ |
-| 96 | `fix_polymorphic_calls.obs` | Bug Fix | fix polymorphic calls | ✅ |
-| 97 | `fix_scope_shadowing.obs` | Bug Fix | fix scope shadowing | ✅ |
-| 98 | `fix_string_concat.obs` | Bug Fix | fix string concat | ✅ |
-| 99 | `func_closure_field.obs` | Functional | func closure field | ✅ |
-| 100 | `func_filter_ops.obs` | Functional | func filter ops | ✅ |
-| 101 | `func_higher_order.obs` | Functional | func higher order | ✅ |
-| 102 | `func_reduce_ops.obs` | Functional | func reduce ops | ✅ |
-| 103 | `func_sort_custom.obs` | Functional | func sort custom | ✅ |
-| 104 | `io_file_basic.obs` | I/O | io file basic | ✅ |
-| 105 | `jit_array_native.obs` | AMD64/JIT | jit array native | ✅ |
-| 106 | `jit_conditional_native.obs` | AMD64/JIT | jit conditional native | ✅ |
-| 107 | `jit_dispatch_native.obs` | AMD64/JIT | jit dispatch native | ✅ |
-| 108 | `jit_float_equality.obs` | AMD64/JIT | Regression test for float equality compares on array elements (2026-06). The front-end chose EQL_... | ✅ |
-| 109 | `jit_float_intensive.obs` | AMD64/JIT | jit float intensive | ✅ |
-| 110 | `jit_frame_trap_test.obs` | AMD64/JIT | Regression test for the JIT frame-dependent trap crash (2026-06). Traps such as SERL_INT/SERL_FLO... | ✅ |
-| 111 | `jit_gc_stress.obs` | AMD64/JIT | JIT + GC interaction stress (2026-06). One CI run on linux-x64 failed with a JIT-to-JIT runtime e... | ✅ |
-| 112 | `jit_loop_native.obs` | AMD64/JIT | jit loop native | ✅ |
-| 113 | `jit_native_cls_fields.obs` | AMD64/JIT | JIT Native Class Fields Test Tests object reference storage in class instance fields with GC pres... | ✅ |
-| 114 | `jit_native_float_array.obs` | AMD64/JIT | JIT Native Float Array Test Tests native function with float array creation and math operations R... | ✅ |
-| 115 | `jit_native_func_ref.obs` | AMD64/JIT | JIT Native Function Reference Test Tests native functions with function reference storage in clas... | ✅ |
-| 116 | `jit_native_math.obs` | AMD64/JIT | JIT Native Math Builtins Test Tests native math functions: Factorial, Sinh/Cosh/Tanh/Log2/Cbrt, P... | ✅ |
-| 117 | `jit_string_ops.obs` | AMD64/JIT | jit string ops | ✅ |
-| 118 | `json_build_ops.obs` | JSON | json build ops | ✅ |
-| 119 | `json_parse_ops.obs` | JSON | json parse ops | ✅ |
-| 120 | `lsp_features.obs` | LSP | lsp features | ✅ |
-| 121 | `math_float_ops.obs` | Math | math float ops | ✅ |
-| 122 | `math_log_exp.obs` | Math | math log exp | ✅ |
-| 123 | `math_random_ops.obs` | Math | math random ops | ✅ |
-| 124 | `math_rounding.obs` | Math | math rounding | ✅ |
-| 125 | `math_sqrt_ops.obs` | Math | math sqrt ops | ✅ |
-| 126 | `math_trig_funcs.obs` | Math | math trig funcs | ✅ |
-| 127 | `mcp_debug_test.obs` | MCP Server | DEBUG VERSION of mcp_server_test.obs Identical to programs/regression/mcp_server_test.obs except:... | ✅ |
-| 128 | `mcp_server_test.obs` | MCP Server | mcp server test | ✅ |
-| 129 | `ml_adaboost_test.obs` | System.ML | Regression tests for System.ML AdaBoost (overhaul phase 3): boosting over boolean decision stumps... | ✅ |
-| 130 | `ml_api_test.obs` | System.ML | Regression tests for the System.ML estimator API consistency sweep (item 11): RandomForest Fit (r... | ✅ |
-| 131 | `ml_dbscan_test.obs` | System.ML | Regression tests for System.ML DBSCAN (overhaul phase 3): two dense blobs plus far-away outliers... | ✅ |
-| 132 | `ml_gbt_test.obs` | System.ML | Regression tests for System.ML gradient boosting (overhaul phase 3 leftover): a RegressionTree le... | ✅ |
-| 133 | `ml_gmm_test.obs` | System.ML | Regression tests for System.ML GaussianMixture (overhaul phase 3): EM on two well-separated blobs... | ✅ |
-| 134 | `ml_kdtree_test.obs` | System.ML | Regression tests for System.ML KDTree (overhaul phase 3): for several queries and k values over a... | ✅ |
-| 135 | `ml_library_test.obs` | System.ML | ml library test | ✅ |
-| 136 | `ml_linearclf_test.obs` | System.ML | Regression tests for the System.ML linear classifiers (overhaul phase 2): Perceptron (mistake-dri... | ✅ |
-| 137 | `ml_nn_test.obs` | System.ML | Regression tests for the System.ML NeuralNetwork with hidden/output bias vectors (ML overhaul ite... | ✅ |
-| 138 | `ml_pca_gnb_test.obs` | System.ML | Regression tests for System.ML PCA (power-iteration decomposition: dominant diagonal direction re... | ✅ |
-| 139 | `ml_phase1_test.obs` | System.ML | Regression tests for the System.ML correctness fixes (phase 1): seedable PRNG, DotSigmoid dimensi... | ✅ |
-| 140 | `ml_regularized_test.obs` | System.ML | Regression tests for the System.ML regularized linear models (overhaul phase 2): RidgeRegression... | ✅ |
-| 141 | `ml_trees_test.obs` | System.ML | Regression tests for the System.ML tree models: the real recursive DecisionTree (left/right child... | ✅ |
-| 142 | `oauth_test.obs` | Networking | oauth test | ✅ |
-| 143 | `odbc_sqlite_test.obs` | ODBC | ODBC SQLite Integration Test Tests live database operations against an in-memory SQLite database.... | ✅ |
-| 144 | `regex_bench.obs` | Regex | regex bench | ✅ |
-| 145 | `regex_dfa_test.obs` | Regex | regex dfa test | ✅ |
-| 146 | `select_dispatch_test.obs` | Control Flow | Single-case, linear (2-5 cases), jump-table (dense >=6), and binary-tree (sparse) paths | ✅ |
-| 147 | `string_find_ops.obs` | Strings | string find ops | ✅ |
-| 148 | `string_format_ops.obs` | Strings | Verifies String->Format() positional substitution. | ✅ |
-| 149 | `string_number_conv.obs` | Strings | string number conv | ✅ |
-| 150 | `string_replace_ops.obs` | Strings | string replace ops | ✅ |
-| 151 | `string_split_ops.obs` | Strings | string split ops | ✅ |
-| 152 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
-| 153 | `websocket_test.obs` | Networking | websocket test | ✅ |
-| 154 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
-| 155 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
-| 156 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
+| 32 | `closure_bare_lambda.obs` | Other | Regression for bare lambdas `\(...) => body` with the return type inferred from context, auto-wra... | ✅ |
+| 33 | `closure_block_body.obs` | Other | Regression for lambda block bodies: `\(...) ~ R : () => { ...; return e; }`. Previously a `{ }` l... | ✅ |
+| 34 | `closure_direct_call.obs` | Other | Regression for direct FuncRef callability `v()` and functional-call result chaining `v()->Method(... | ✅ |
+| 35 | `closure_multi_capture.obs` | Other | Regression for multiple capturing lambdas in one class. Each lambda's captured variables live in... | ✅ |
+| 36 | `collect_compare_vector.obs` | Collections | collect compare vector | ✅ |
+| 37 | `collect_each_patterns.obs` | Collections | collect each patterns | ✅ |
+| 38 | `collect_hash_ops.obs` | Collections | collect hash ops | ✅ |
+| 39 | `collect_map_ops.obs` | Collections | collect map ops | ✅ |
+| 40 | `collect_nested_ops.obs` | Collections | collect nested ops | ✅ |
+| 41 | `collect_pair_ops.obs` | Collections | collect pair ops | ✅ |
+| 42 | `collect_queue_ops.obs` | Collections | collect queue ops | ✅ |
+| 43 | `collect_set_ops.obs` | Collections | collect set ops | ✅ |
+| 44 | `collect_stack_ops.obs` | Collections | collect stack ops | ✅ |
+| 45 | `collect_vector_ops.obs` | Collections | collect vector ops | ✅ |
+| 46 | `core_abstract_virtual.obs` | Core Language | core abstract virtual | ✅ |
+| 47 | `core_arithmetic.obs` | Core Language | Core Arithmetic Operations Test Tests basic arithmetic operations, type conversions, and operator... | ✅ |
+| 48 | `core_array_operations.obs` | Core Language | core array operations | ✅ |
+| 49 | `core_arrays_simple.obs` | Core Language | Core Array Operations Test (Simplified) Tests basic array creation, access, and modification | ✅ |
+| 50 | `core_bitwise_ops.obs` | Core Language | core bitwise ops | ✅ |
+| 51 | `core_bool_ops.obs` | Core Language | core bool ops | ✅ |
+| 52 | `core_break_continue.obs` | Core Language | core break continue | ✅ |
+| 53 | `core_char_methods.obs` | Core Language | core char methods | ✅ |
+| 54 | `core_classes.obs` | Core Language | Core Classes Test Tests class instantiation, inheritance, method calls, and select statements Bas... | ✅ |
+| 55 | `core_collections_perf.obs` | Core Language | core collections perf | ✅ |
+| 56 | `core_control_flow.obs` | Core Language | Core Control Flow Test Tests if/else, loops, and select statements | ✅ |
+| 57 | `core_do_while.obs` | Core Language | core do while | ✅ |
+| 58 | `core_each_loop.obs` | Core Language | core each loop | ✅ |
+| 59 | `core_enum.obs` | Core Language | core enum | ✅ |
+| 60 | `core_function_refs.obs` | Core Language | core function refs | ✅ |
+| 61 | `core_generic_compound_bounds.obs` | Generics | Compound generic bounds (T : A & B): a concrete type argument must satisfy ALL bounds. Person imp... | ✅ |
+| 62 | `core_generic_fbound.obs` | Generics | F-bounded type-parameter constraint (T : Compare<T>): the bound may be generic and self-referenti... | ✅ |
+| 63 | `core_generic_structural.obs` | Generics | Exercises the structural generic type comparison: deeply nested generic type arguments must round... | ✅ |
+| 64 | `core_generic_variance.obs` | Generics | Declaration-site variance: 'out T' (covariant) lets Producer<Dog> be used where Producer<Animal>... | ✅ |
+| 65 | `core_http_server.obs` | Core Language | HTTP Client/Server Loopback Test Tests HTTP GET and POST using raw TCP server + HttpClient. Verif... | ✅ |
+| 66 | `core_inheritance_chain.obs` | Core Language | core inheritance chain | ✅ |
+| 67 | `core_int_methods.obs` | Core Language | core int methods | ✅ |
+| 68 | `core_interfaces.obs` | Core Language | core interfaces | ✅ |
+| 69 | `core_json_escape.obs` | Core Language | core json escape | ✅ |
+| 70 | `core_method_overload.obs` | Core Language | core method overload | ✅ |
+| 71 | `core_multi_dim_array.obs` | Core Language | core multi dim array | ✅ |
+| 72 | `core_net_buffer.obs` | Core Language | Network Buffer Read Test Tests that TCP socket ReadBuffer correctly handles partial reads by veri... | ✅ |
+| 73 | `core_odbc.obs` | Core Language | Core ODBC Bindings Test Tests Date, Timestamp, and ColumnInfo classes without requiring a databas... | ✅ |
+| 74 | `core_opencv.obs` | Core Language | Core OpenCV Bindings Test Tests helper classes, constants, and VideoWriter FourCC without requiri... | ✅ |
+| 75 | `core_paren_method_chain.obs` | Core Language | Verifies a method call on a parenthesized method-call expression chains onto the parenthesized re... | ✅ |
+| 76 | `core_records.obs` | Core Language | Core Records Test Exercises record-generated constructors, accessors, mutators, generics, readonl... | ✅ |
+| 77 | `core_recursion.obs` | Core Language | Core Recursion Test Tests recursive function calls and tail recursion | ✅ |
+| 78 | `core_select_ops.obs` | Core Language | core select ops | ✅ |
+| 79 | `core_static_array_literals.obs` | Core Language | Regression test for the static-array literal pool (compiler bug, 2026-06): the bool literal-pool... | ✅ |
+| 80 | `core_static_fields.obs` | Core Language | core static fields | ✅ |
+| 81 | `core_string_format.obs` | Core Language | core string format | ✅ |
+| 82 | `core_string_interp_expr.obs` | Core Language | Verifies operator expressions inside "{$...}" string interpolation. | ✅ |
+| 83 | `core_string_interp_format.obs` | Core Language | Verifies inline format specifiers "{$expr:spec}" in string interpolation. | ✅ |
+| 84 | `core_string_methods.obs` | Core Language | core string methods | ✅ |
+| 85 | `core_strings_simple.obs` | Core Language | Core String Operations Test (Simplified) Tests basic string operations without complex method cha... | ✅ |
+| 86 | `core_thread_gc_stress.obs` | Concurrency/GC | Multithreaded GC stop-the-world stress test. Guards the GC bugs fixed on branch fix/gc-stop-the-w... | ✅ |
+| 87 | `core_type_checking.obs` | Core Language | core type checking | ✅ |
+| 88 | `dap_exception_test.obs` | Debugger (neg) | Triggers an uncaught runtime error (Nil dereference) so the DAP test suite can verify exception b... | ✅ |
+| 89 | `date_arithmetic.obs` | Date/Time | date arithmetic | ✅ |
+| 90 | `date_basic_ops.obs` | Date/Time | date basic ops | ✅ |
+| 91 | `debugger_test.obs` | Debugger | debugger test | ✅ |
+| 92 | `fix524_array_cast_chain.obs` | Bug Fix | Fix #524: Cannot chain method calls on array-indexed elements after cast Tests that Get(index)->A... | ✅ |
+| 93 | `fix534_substring_crash.obs` | Bug Fix | Fix #534: String->SubString crash on negative or zero length argument Tests that negative or zero... | ✅ |
+| 94 | `fix_array_bounds.obs` | Bug Fix | fix array bounds | ✅ |
+| 95 | `fix_chained_calls.obs` | Bug Fix | fix chained calls | ✅ |
+| 96 | `fix_deep_recursion.obs` | Bug Fix | fix deep recursion | ✅ |
+| 97 | `fix_float_precision.obs` | Bug Fix | fix float precision | ✅ |
+| 98 | `fix_int_boundary.obs` | Bug Fix | fix int boundary | ✅ |
+| 99 | `fix_large_arrays.obs` | Bug Fix | fix large arrays | ✅ |
+| 100 | `fix_nested_generics.obs` | Bug Fix | fix nested generics | ✅ |
+| 101 | `fix_nil_chain_ops.obs` | Bug Fix | fix nil chain ops | ✅ |
+| 102 | `fix_polymorphic_calls.obs` | Bug Fix | fix polymorphic calls | ✅ |
+| 103 | `fix_scope_shadowing.obs` | Bug Fix | fix scope shadowing | ✅ |
+| 104 | `fix_string_concat.obs` | Bug Fix | fix string concat | ✅ |
+| 105 | `func_closure_field.obs` | Functional | func closure field | ✅ |
+| 106 | `func_filter_ops.obs` | Functional | func filter ops | ✅ |
+| 107 | `func_higher_order.obs` | Functional | func higher order | ✅ |
+| 108 | `func_reduce_ops.obs` | Functional | func reduce ops | ✅ |
+| 109 | `func_sort_custom.obs` | Functional | func sort custom | ✅ |
+| 110 | `interp_float_fastpath.obs` | Other | Exercises the interpreter's inlined float fast-path (ADD/SUB/MUL_FLOAT and the six float comparis... | ✅ |
+| 111 | `io_file_basic.obs` | I/O | io file basic | ✅ |
+| 112 | `jit_array_native.obs` | AMD64/JIT | jit array native | ✅ |
+| 113 | `jit_autojit_race.obs` | AMD64/JIT | Auto-JIT concurrency guard. Many threads call the same hot method, crossing the auto-JIT threshol... | ✅ |
+| 114 | `jit_closure_gc_fixup.obs` | AMD64/JIT | Regression for the generational-GC fixup of closure captures (bug B1). The GC mark phase descends... | ✅ |
+| 115 | `jit_concurrent_compile.obs` | AMD64/JIT | Concurrency guard for the JIT code-page allocator (PageManager::GetPage). Several threads JIT-com... | ✅ |
+| 116 | `jit_conditional_native.obs` | AMD64/JIT | jit conditional native | ✅ |
+| 117 | `jit_dispatch_native.obs` | AMD64/JIT | jit dispatch native | ✅ |
+| 118 | `jit_float_equality.obs` | AMD64/JIT | Regression test for float equality compares on array elements (2026-06). The front-end chose EQL_... | ✅ |
+| 119 | `jit_float_intensive.obs` | AMD64/JIT | jit float intensive | ✅ |
+| 120 | `jit_float_round_trig.obs` | AMD64/JIT | Exercises two JIT float-codegen bugs that only surface once a method using them is auto-JIT'd (de... | ✅ |
+| 121 | `jit_frame_trap_test.obs` | AMD64/JIT | Regression test for the JIT frame-dependent trap crash (2026-06). Traps such as SERL_INT/SERL_FLO... | ✅ |
+| 122 | `jit_func_ref_hot.obs` | AMD64/JIT | jit func ref hot | ✅ |
+| 123 | `jit_gc_stress.obs` | AMD64/JIT | JIT + GC interaction stress (2026-06). One CI run on linux-x64 failed with a JIT-to-JIT runtime e... | ✅ |
+| 124 | `jit_loop_native.obs` | AMD64/JIT | jit loop native | ✅ |
+| 125 | `jit_native_cls_fields.obs` | AMD64/JIT | JIT Native Class Fields Test Tests object reference storage in class instance fields with GC pres... | ✅ |
+| 126 | `jit_native_float_array.obs` | AMD64/JIT | JIT Native Float Array Test Tests native function with float array creation and math operations R... | ✅ |
+| 127 | `jit_native_func_ref.obs` | AMD64/JIT | JIT Native Function Reference Test Tests native functions with function reference storage in clas... | ✅ |
+| 128 | `jit_native_math.obs` | AMD64/JIT | JIT Native Math Builtins Test Tests native math functions: Factorial, Sinh/Cosh/Tanh/Log2/Cbrt, P... | ✅ |
+| 129 | `jit_string_ops.obs` | AMD64/JIT | jit string ops | ✅ |
+| 130 | `jit_tco_bare_local.obs` | AMD64/JIT | Regression for the TCO deferred-local-load miscompile (both arches). A self-recursive tail call t... | ✅ |
+| 131 | `json_build_ops.obs` | JSON | json build ops | ✅ |
+| 132 | `json_parse_ops.obs` | JSON | json parse ops | ✅ |
+| 133 | `lsp_features.obs` | LSP | lsp features | ✅ |
+| 134 | `math_float_ops.obs` | Math | math float ops | ✅ |
+| 135 | `math_log_exp.obs` | Math | math log exp | ✅ |
+| 136 | `math_random_ops.obs` | Math | math random ops | ✅ |
+| 137 | `math_rounding.obs` | Math | math rounding | ✅ |
+| 138 | `math_sqrt_ops.obs` | Math | math sqrt ops | ✅ |
+| 139 | `math_trig_funcs.obs` | Math | math trig funcs | ✅ |
+| 140 | `mcp_debug_test.obs` | MCP Server | DEBUG VERSION of mcp_server_test.obs Identical to programs/regression/mcp_server_test.obs except:... | ✅ |
+| 141 | `mcp_server_test.obs` | MCP Server | mcp server test | ✅ |
+| 142 | `minor_gc_stress.obs` | Other | Regression for generational MINOR GC: old objects holding young references. 'keep' is an object a... | ✅ |
+| 143 | `ml_adaboost_test.obs` | System.ML | Regression tests for System.ML AdaBoost (overhaul phase 3): boosting over boolean decision stumps... | ✅ |
+| 144 | `ml_api_test.obs` | System.ML | Regression tests for the System.ML estimator API consistency sweep (item 11): RandomForest Fit (r... | ✅ |
+| 145 | `ml_dbscan_test.obs` | System.ML | Regression tests for System.ML DBSCAN (overhaul phase 3): two dense blobs plus far-away outliers... | ✅ |
+| 146 | `ml_gbt_test.obs` | System.ML | Regression tests for System.ML gradient boosting (overhaul phase 3 leftover): a RegressionTree le... | ✅ |
+| 147 | `ml_gmm_test.obs` | System.ML | Regression tests for System.ML GaussianMixture (overhaul phase 3): EM on two well-separated blobs... | ✅ |
+| 148 | `ml_kdtree_test.obs` | System.ML | Regression tests for System.ML KDTree (overhaul phase 3): for several queries and k values over a... | ✅ |
+| 149 | `ml_library_test.obs` | System.ML | ml library test | ✅ |
+| 150 | `ml_linearclf_test.obs` | System.ML | Regression tests for the System.ML linear classifiers (overhaul phase 2): Perceptron (mistake-dri... | ✅ |
+| 151 | `ml_nn_test.obs` | System.ML | Regression tests for the System.ML NeuralNetwork with hidden/output bias vectors (ML overhaul ite... | ✅ |
+| 152 | `ml_pca_gnb_test.obs` | System.ML | Regression tests for System.ML PCA (power-iteration decomposition: dominant diagonal direction re... | ✅ |
+| 153 | `ml_phase1_test.obs` | System.ML | Regression tests for the System.ML correctness fixes (phase 1): seedable PRNG, DotSigmoid dimensi... | ✅ |
+| 154 | `ml_regularized_test.obs` | System.ML | Regression tests for the System.ML regularized linear models (overhaul phase 2): RidgeRegression... | ✅ |
+| 155 | `ml_trees_test.obs` | System.ML | Regression tests for the System.ML tree models: the real recursive DecisionTree (left/right child... | ✅ |
+| 156 | `nil_safe_ops.obs` | Core Language | Nil-safe operators: '??' (nil-coalesce) and '?->' (nil-safe call). Both desugar onto existing int... | ✅ |
+| 157 | `oauth_test.obs` | Networking | oauth test | ✅ |
+| 158 | `odbc_sqlite_test.obs` | ODBC | ODBC SQLite Integration Test Tests live database operations against an in-memory SQLite database.... | ✅ |
+| 159 | `regex_bench.obs` | Regex | regex bench | ✅ |
+| 160 | `regex_dfa_test.obs` | Regex | regex dfa test | ✅ |
+| 161 | `select_dispatch_test.obs` | Control Flow | Single-case, linear (2-5 cases), jump-table (dense >=6), and binary-tree (sparse) paths | ✅ |
+| 162 | `string_find_ops.obs` | Strings | string find ops | ✅ |
+| 163 | `string_format_ops.obs` | Strings | Verifies String->Format() positional substitution. | ✅ |
+| 164 | `string_number_conv.obs` | Strings | string number conv | ✅ |
+| 165 | `string_replace_ops.obs` | Strings | string replace ops | ✅ |
+| 166 | `string_split_ops.obs` | Strings | string split ops | ✅ |
+| 167 | `task_scope.obs` | Other | Regression for a structured-concurrency nursery (TaskScope) built purely on the existing System.C... | ✅ |
+| 168 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
+| 169 | `websocket_test.obs` | Networking | websocket test | ✅ |
+| 170 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
+| 171 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
+| 172 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
 
 ## Debugger Tests (`run_debugger_tests.sh`)
 

--- a/programs/regression/gen_manifest.py
+++ b/programs/regression/gen_manifest.py
@@ -44,6 +44,7 @@ CATS = [
     ('arm64_', 'ARM64 JIT'), ('jit_', 'AMD64/JIT'),
     ('core_generic', 'Generics'), ('bad_generic', 'Generics (neg)'),
     ('core_thread', 'Concurrency/GC'), ('core_', 'Core Language'),
+    ('nil_safe', 'Core Language'),
     ('bad_', 'Negative'), ('fix', 'Bug Fix'), ('collect_', 'Collections'),
     ('ml_', 'System.ML'), ('ml', 'System.ML'), ('ai_', 'System.AI'),
     ('math', 'Math'), ('func_', 'Functional'), ('string', 'Strings'),

--- a/programs/regression/nil_safe_ops.obs
+++ b/programs/regression/nil_safe_ops.obs
@@ -11,11 +11,9 @@ lookahead, so a ternary whose true-branch starts with '-' or '.' must still
 parse as a ternary: 'flag ?-1 : 2' is the one that matters, since '?->'
 requires BOTH '-' and '>'.
 
-One limitation remains, inherited from the intrinsics rather than introduced by
-the operators, and verified to behave identically when written by hand:
-'?->' on an indexed receiver ('arr[i]?->m()') does not compile, because
-'arr[i]->Try()->m()' does not either. It cannot be exercised here, since a
-compile error would take the whole file down.
+Receivers are covered in every form the parser produces them: a local, an
+instance variable, a method-call result, and an indexed array element. The last
+two are the ones that previously went untested and each turned up a defect.
 ~#
 
 class NilSafeOps {
@@ -151,6 +149,31 @@ class NilSafeOps {
 
 		y := (real_str ?? "abc")->ToUpper();
 		if(y <> Nil & y->Equals("ACTUAL")) { passed += 1; } else { failed += 1; "FAIL: call chained after ?? (non-nil)"->PrintLine(); };
+
+		# --- indexed receiver. 'arr[i]?->m()' used to fail to compile: the
+		# Try()/Otherwise() check sat inside the program/library class branches,
+		# which do not resolve for an indexed receiver, so it fell through to
+		# the variable path and reported "Invalid class type or assignment" ---
+		arr := String->New[3];
+		arr[1] := "elem";
+
+		z := arr[0]?->ToUpper();
+		if(z = Nil) { passed += 1; } else { failed += 1; "FAIL: ?-> on nil array element"->PrintLine(); };
+
+		z2 := arr[1]?->ToUpper();
+		if(z2 <> Nil & z2->Equals("ELEM")) { passed += 1; } else { failed += 1; "FAIL: ?-> on set array element"->PrintLine(); };
+
+		z3 := arr[0]?->ToUpper() ?? "dflt";
+		if(z3->Equals("dflt")) { passed += 1; } else { failed += 1; "FAIL: ?-> array element fused with ??"->PrintLine(); };
+
+		# a computed index must resolve the same way as a literal one
+		idx := 1;
+		z4 := arr[idx]?->ToUpper() ?? "dflt";
+		if(z4->Equals("ELEM")) { passed += 1; } else { failed += 1; "FAIL: ?-> with computed index"->PrintLine(); };
+
+		# and the hand-written form the operator desugars to
+		z5 := arr[1]->Try()->ToUpper();
+		if(z5 <> Nil & z5->Equals("ELEM")) { passed += 1; } else { failed += 1; "FAIL: Try() on array element"->PrintLine(); };
 
 		# --- instance-variable receiver ---
 		inst := NilSafeOps->New();

--- a/programs/regression/nil_safe_ops.obs
+++ b/programs/regression/nil_safe_ops.obs
@@ -11,14 +11,11 @@ lookahead, so a ternary whose true-branch starts with '-' or '.' must still
 parse as a ternary: 'flag ?-1 : 2' is the one that matters, since '?->'
 requires BOTH '-' and '>'.
 
-Two limitations are inherited from the intrinsics rather than introduced by the
-operators, and both are verified to behave identically when written by hand:
-
-  1. A '??' chain whose operands are ALL Nil except the last yields Nil, not
-     the last default -- pinned below so a future fix is noticed.
-  2. '?->' on an indexed receiver ('arr[i]?->m()') does not compile, because
-     'arr[i]->Try()->m()' does not either. It cannot be exercised here since a
-     compile error would take the whole file down.
+One limitation remains, inherited from the intrinsics rather than introduced by
+the operators, and verified to behave identically when written by hand:
+'?->' on an indexed receiver ('arr[i]?->m()') does not compile, because
+'arr[i]->Try()->m()' does not either. It cannot be exercised here, since a
+compile error would take the whole file down.
 ~#
 
 class NilSafeOps {
@@ -140,15 +137,20 @@ class NilSafeOps {
 		v := nil_str ?? "second" ?? "third";
 		if(v <> Nil & v->Equals("second")) { passed += 1; } else { failed += 1; "FAIL: ?? chain"->PrintLine(); };
 
-		# --- KNOWN LIMITATION, pinned so a future fix is noticed.
-		# When EVERY operand before the last is Nil, a '??' chain yields Nil
-		# rather than the final default: Otherwise() does not re-test the
-		# result of a preceding Otherwise(). This is inherited from the
-		# intrinsic, not introduced by the operator -- the hand-written
-		# 'n->Otherwise(n)->Otherwise("third")' behaves identically. If this
-		# assertion starts failing, the intrinsic was fixed; assert "third".
+		# --- a '??' chain falls through every Nil operand to the last default.
+		# This used to yield Nil: EmitOtherwiseIntrinsic did not emit the rest
+		# of the chain, and its callers break immediately after it, so a second
+		# Otherwise() was dropped. ---
 		w := nil_str ?? nil_str ?? "third";
-		if(w = Nil) { passed += 1; } else { failed += 1; "FAIL: ?? all-nil chain changed behavior -- update this test"->PrintLine(); };
+		if(w <> Nil & w->Equals("third")) { passed += 1; } else { failed += 1; "FAIL: ?? all-nil chain"->PrintLine(); };
+
+		# --- and anything chained after '??' actually runs. Same root cause:
+		# 'x->Otherwise("abc")->ToUpper()' silently returned "abc" ---
+		x := (nil_str ?? "abc")->ToUpper();
+		if(x <> Nil & x->Equals("ABC")) { passed += 1; } else { failed += 1; "FAIL: call chained after ??"->PrintLine(); };
+
+		y := (real_str ?? "abc")->ToUpper();
+		if(y <> Nil & y->Equals("ACTUAL")) { passed += 1; } else { failed += 1; "FAIL: call chained after ?? (non-nil)"->PrintLine(); };
 
 		# --- instance-variable receiver ---
 		inst := NilSafeOps->New();


### PR DESCRIPTION
Fixes **both** limitations pinned in #586. Both are pre-existing defects in the `Try()`/`Otherwise()` intrinsics — the nil-safe operators didn't cause them, they just made them easy to hit, since `?->` and `??` desugar onto those intrinsics.

## 1. Anything chained after `Otherwise()` was silently dropped

Not an error — a wrong value:

| Written | Returned | Should be |
|---|---|---|
| `n->Otherwise("abc")->ToUpper()` | `"abc"` | `"ABC"` |
| `n->Otherwise(n)->Otherwise("x")` | `Nil` | `"x"` |

`EmitOtherwiseIntrinsic` emitted its nil test and stopped. Both call sites in `EmitExpression` `break` out of their chain loop immediately after calling it, so nobody emitted the remainder. `EmitTryIntrinsic` already walks its own tail — which is why `Try()` chains have always worked — so `Otherwise()` now does the same, reusing that function's `is_nested` bookkeeping.

A chained `Otherwise()` recurses and re-consumes the value left on the stack as its receiver. That is what makes `a ?? b ?? c` fall through every `Nil` operand to the last default.

## 2. `Try()`/`Otherwise()` on an indexed receiver did not compile

```
arr[i]?->m()          ->  Invalid class type or assignment
arr[i]->Try()->m()    ->  Invalid class type or assignment
arr[i]->m()           ->  fine
```

The intrinsic checks in `AnalyzeMethodCall` lived **inside** the program-class and library-class branches, so they only ran once the receiver's class had resolved. That lookup does not resolve for an indexed receiver, so control fell through to the variable path, which calls `AnalyzeExpressionMethodCall` on a `Variable` carrying indices and fails.

Neither intrinsic needs that lookup — both work off the receiver's type — so the check is hoisted ahead of it.

**Hoisting alone was not enough.** An indexed receiver denotes one element, so the chain has to resolve against the *element* type. Carrying the declared array type through would have traded a compile error for a silently misresolved chain, which is worse. When the receiver variable has indices, the eval type is now a copy of the entry type with dimension 0.

An earlier attempt hoisted the equivalent check at the *expression*-receiver dispatch site. It changed nothing, because the failure is on the variable path — I reverted it rather than leave a speculative reordering of analyzer dispatch in the tree.

## The pinned test did its job

#586 pinned the all-Nil `??` chain with a note to invert the assertion if the intrinsic was ever fixed. It **failed on the first regression run after fix 1**, exactly as designed. Both limitations are now gone, and the test header no longer records one.

## Verification

- `nil_safe_ops.obs` **34/34** (was 27 when this branch started)
- x64 regression **172/172**
- LSP harness **25/25**, formatter **39/39**

Receivers are now covered in every form the parser produces: a local, an instance variable, a method-call result, and an indexed element — nil and non-nil, with a computed index, fused with `??`, and in the hand-written `Try()` form. The last two receiver forms were the untested ones, and each turned up a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)