### PR TITLE
Fix CLI print reporting wrong collection sizes (and crashing on List)

### DIFF
--- a/core/debugger/debugger.cpp
+++ b/core/debugger/debugger.cpp
@@ -865,8 +865,11 @@ void Runtime::Debugger::ProcessPrint(Print* print) {
           else if(ref_klass && (ref_klass->GetName() == L"Collection.Vector" || ref_klass->GetName() == L"Collection.CompareVector")) {
             size_t* instance = (size_t*)reference->GetIntValue();
             if(instance && !reference->GetIndices()) {
-              size_t* vector_instance = (size_t*)instance[0];
-              const long vector_size = (long)vector_instance[1];
+              // Vector: @values at slot 0, @size at slot 1. This used to read
+              // slot 0 and then index into it -- that is the backing array, so
+              // it reported the array's dimension count and every Vector
+              // printed size=1.
+              const long vector_size = (long)instance[1];
               std::wcout << L"print: type=" << ref_klass->GetName() << L", size=" << vector_size << std::endl;
             }
             else {
@@ -876,8 +879,10 @@ void Runtime::Debugger::ProcessPrint(Print* print) {
           else if(ref_klass && (ref_klass->GetName() == L"Collection.List" || ref_klass->GetName() == L"Collection.CompareList")) {
             size_t* instance = (size_t*)reference->GetIntValue();
             if(instance && !reference->GetIndices()) {
-              size_t* list_instance = (size_t*)instance[0];
-              const long list_size = (long)list_instance[1];
+              // List: @size at slot 0. Slot 0 holds the count itself, so the
+              // old code cast that integer to a pointer and dereferenced it --
+              // printing a list crashed the debugger.
+              const long list_size = (long)instance[0];
               std::wcout << L"print: type=" << ref_klass->GetName() << L", size=" << list_size << std::endl;
             }
             else {
@@ -887,9 +892,12 @@ void Runtime::Debugger::ProcessPrint(Print* print) {
           else if(ref_klass && ref_klass->GetName() == L"Collection.Hash") {
             size_t* instance = (size_t*)reference->GetIntValue();
             if(instance && !reference->GetIndices()) {
-              size_t* hash_instance = (size_t*)instance[0];
-              const long hash_size = (long)hash_instance[1];
-              const long hash_capacity = (long)hash_instance[2];
+              // Hash: @buckets at slot 0, @size at 1, @capacity at 2. Reading
+              // through the bucket array happened to yield plausible numbers --
+              // its dimension count and bucket count -- so this looked right
+              // while never reflecting the entry count.
+              const long hash_size = (long)instance[1];
+              const long hash_capacity = (long)instance[2];
               std::wcout << L"print: type=" << ref_klass->GetName() << L", size=" << hash_size << L", capacity=" << hash_capacity << std::endl;
             }
             else {
@@ -899,8 +907,10 @@ void Runtime::Debugger::ProcessPrint(Print* print) {
           else if(ref_klass && ref_klass->GetName() == L"Collection.Map") {
             size_t* instance = (size_t*)reference->GetIntValue();
             if(instance && !reference->GetIndices()) {
-              size_t* map_instance = (size_t*)instance[0];
-              const long map_size = (long)map_instance[2];
+              // Map: @root at slot 0, @last at 1, @size at 2. Indexing through
+              // the root node read TreeNode::@left, i.e. a pointer printed as a
+              // count.
+              const long map_size = (long)instance[2];
               std::wcout << L"print: type=" << ref_klass->GetName() << L", size=" << map_size << std::endl;
             }
             else {

--- a/programs/regression/debugger_coll_test.obs
+++ b/programs/regression/debugger_coll_test.obs
@@ -1,0 +1,38 @@
+use Collection;
+
+#~
+Fixture for the CLI debugger's collection printing.
+
+Each collection holds a DIFFERENT number of entries, and none of those counts
+matches a value in the object's header or backing array -- that is the point.
+`print` used to reach through slot 0 into whatever it found there, which for a
+Vector was the backing array (so it reported the array's dimension count, 1),
+for a Map was the root node (reporting a child pointer), and for a Hash was the
+bucket array (whose dimension count and length happened to look like a
+plausible size and capacity). Equal counts would let those coincidences pass.
+
+List is the one that crashed: its slot 0 is @size, an Int, which the old code
+cast to a pointer and dereferenced.
+~#
+
+class CollPrint {
+	function : Main(args : String[]) ~ Nil {
+		vec := Vector->New()<IntRef>;
+		each(i : 5) { vec->AddBack(i); };
+
+		map := Map->New()<IntRef, String>;
+		each(i : 4) { map->Insert(i, "v"); };
+
+		hash := Hash->New()<String, IntRef>;
+		hash->Insert("a", IntRef->New(1));
+		hash->Insert("b", IntRef->New(2));
+		hash->Insert("c", IntRef->New(3));
+
+		list := List->New()<IntRef>;
+		each(i : 6) { list->AddBack(i); };
+
+		# BREAKPOINT LINE — every collection is populated
+		done := true;
+		done->PrintLine();
+	}
+}

--- a/programs/regression/run_debugger_tests.cmd
+++ b/programs/regression/run_debugger_tests.cmd
@@ -67,11 +67,26 @@ if !COMPILE_RESULT! neq 0 (
 echo   Compiled successfully.
 echo.
 
+REM Collection-printing fixture (needs gen_collect)
+echo Compiling collection test program...
+pushd "%ABS_BIN_DIR%"
+"%ABS_COMPILER%" -src "%REGRESSION_DIR%\debugger_coll_test.obs" -lib gen_collect -dest "%REGRESSION_DIR%\debugger_coll_test.obe" -debug > nul 2>&1
+set COLL_COMPILE_RESULT=!errorlevel!
+popd
+
+if !COLL_COMPILE_RESULT! neq 0 (
+    echo   FAIL ^(collection test compilation error^)
+    exit /b 1
+)
+echo   Compiled successfully.
+echo.
+
 REM Run debugger tests via PowerShell
-powershell.exe -ExecutionPolicy Bypass -File "%REGRESSION_DIR%\run_debugger_tests_win.ps1" -Debugger "%ABS_DEBUGGER%" -TestBin "%REGRESSION_DIR%\debugger_test.obe" -SrcDir "%REGRESSION_DIR%" -ResultsDir "%REGRESSION_DIR%\%RESULTS_DIR%"
+powershell.exe -ExecutionPolicy Bypass -File "%REGRESSION_DIR%\run_debugger_tests_win.ps1" -Debugger "%ABS_DEBUGGER%" -TestBin "%REGRESSION_DIR%\debugger_test.obe" -CollBin "%REGRESSION_DIR%\debugger_coll_test.obe" -SrcDir "%REGRESSION_DIR%" -ResultsDir "%REGRESSION_DIR%\%RESULTS_DIR%"
 set TEST_RESULT=!errorlevel!
 
 REM Clean up
 del /q "%REGRESSION_DIR%\debugger_test.obe" 2>nul
+del /q "%REGRESSION_DIR%\debugger_coll_test.obe" 2>nul
 
 exit /b !TEST_RESULT!

--- a/programs/regression/run_debugger_tests.sh
+++ b/programs/regression/run_debugger_tests.sh
@@ -74,11 +74,27 @@ cd "$REGRESSION_DIR"
 echo "  Compiled successfully."
 echo ""
 
+# Collection-printing fixture (needs gen_collect)
+COLL_SRC="debugger_coll_test.obs"
+COLL_BIN="${REGRESSION_DIR}/debugger_coll_test.obe"
+
+echo "Compiling collection test program..."
+cd "${DEPLOY_DIR}/bin"
+"$ABS_COMPILER" -src "${REGRESSION_DIR}/${COLL_SRC}" -lib gen_collect -dest "$COLL_BIN" -debug > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "  [FAIL] Collection test compilation error"
+    exit 1
+fi
+cd "$REGRESSION_DIR"
+echo "  Compiled successfully."
+echo ""
+
 # Helper function to run an expect test
 run_test() {
     local TEST_NAME="$1"
     local EXPECT_SCRIPT="$2"
     local EXPECTED_PATTERNS="$3"
+    local BIN="${4:-$TEST_BIN}"
 
     echo -n "Running: ${TEST_NAME}..."
 
@@ -86,7 +102,7 @@ run_test() {
     OUTPUT=$(expect -c "
         log_user 1
         set timeout 10
-        spawn $ABS_DEBUGGER -b $TEST_BIN -src $REGRESSION_DIR
+        spawn $ABS_DEBUGGER -b $BIN -src $REGRESSION_DIR
         $EXPECT_SCRIPT
     " 2>&1)
 
@@ -551,6 +567,33 @@ run_test "watchpoint" '
     send "q\r"
     expect eof
 ' "added watchpoint|watch #1 changed"
+
+# ========================================
+# Collection sizes. `print` reached through slot 0 into the backing array or
+# root node, so a Vector always reported 1, a Map reported a child pointer, and
+# printing a List dereferenced its @size as a pointer and crashed. The counts
+# below are all different so a header value cannot pass by coincidence.
+# ========================================
+run_test "print_collections" '
+    expect ">"
+    send "b debugger_coll_test.obs:35"
+    expect ">"
+    send "r"
+    expect "break:"
+    expect ">"
+    send "p vec"
+    expect ">"
+    send "p map"
+    expect ">"
+    send "p hash"
+    expect ">"
+    send "p list"
+    expect ">"
+    send "c"
+    expect ">"
+    send "q"
+    expect eof
+' "type=Collection.Vector, size=5|type=Collection.Map, size=4|type=Collection.Hash, size=3|type=Collection.List, size=6" "$COLL_BIN"
 
 echo ""
 echo "========================================"

--- a/programs/regression/run_debugger_tests_win.ps1
+++ b/programs/regression/run_debugger_tests_win.ps1
@@ -1,6 +1,7 @@
 param(
     [string]$Debugger,
     [string]$TestBin,
+    [string]$CollBin,
     [string]$SrcDir,
     [string]$ResultsDir
 )
@@ -12,7 +13,8 @@ function Run-DebuggerTest {
     param(
         [string]$TestName,
         [string[]]$Commands,
-        [string[]]$ExpectedPatterns
+        [string[]]$ExpectedPatterns,
+        [string]$Bin = $TestBin
     )
 
     Write-Host -NoNewline "Running: ${TestName}..."
@@ -28,7 +30,7 @@ function Run-DebuggerTest {
     # Build a temp batch file that uses native cmd I/O redirection.
     # This avoids the Start-Process stdout-pipe race condition on CI runners.
     $batch = "@echo off`r`n"
-    $batch += "`"$Debugger`" -b `"$TestBin`" -src `"$SrcDir`" < `"$inputFile`" > `"$outputFile`" 2> `"$errFile`"`r`n"
+    $batch += "`"$Debugger`" -b `"$Bin`" -src `"$SrcDir`" < `"$inputFile`" > `"$outputFile`" 2> `"$errFile`"`r`n"
     [System.IO.File]::WriteAllText($batchFile, $batch, [System.Text.Encoding]::ASCII)
 
     # cmd /c runs the batch synchronously; output files are fully written on return
@@ -112,6 +114,24 @@ Run-DebuggerTest "print_vars" @(
     "p counter",
     "c"
 ) @("print: type=Int/Byte/Bool, value=100", "print: type=Int[], value=", "print: type=Counter")
+
+# Test 4b: Collection sizes. `print` reached through slot 0 into the backing
+# array or root node, so a Vector always reported 1, a Map reported a child
+# pointer, and printing a List dereferenced its @size as a pointer and crashed.
+Run-DebuggerTest "print_collections" @(
+    "b debugger_coll_test.obs:35",
+    "r",
+    "p vec",
+    "p map",
+    "p hash",
+    "p list",
+    "c"
+) @(
+    "print: type=Collection.Vector, size=5",
+    "print: type=Collection.Map, size=4",
+    "print: type=Collection.Hash, size=3",
+    "print: type=Collection.List, size=6"
+) -Bin $CollBin
 
 # Test 5: Step into method
 Run-DebuggerTest "step_into" @(


### PR DESCRIPTION
## The bug

`print` on a collection reached through slot 0 and then indexed into whatever it found there — but slot 0 is a **field**, not a header. Reproduced against a fixture holding 5 / 4 / 3 / 6 entries:

| | before | actual |
|---|---|---|
| Vector | `size=1` | 5 |
| Map | `size=0` | 4 |
| Hash | `size=1, capacity=769` | 3, 769 |
| **List** | **Segmentation fault** | 6 |

Per branch:

- **Vector/CompareVector** read the backing array's *dimension count*, so every vector printed `size=1` regardless of contents
- **Map** read `TreeNode::@left` through the root node — a child pointer rendered as a count
- **Hash** read the bucket array's dimension count and length. Those *looked* like a plausible size and capacity, which is why it went unnoticed: capacity was right by accident, and size was `1` for any non-empty hash
- **List/CompareList** read slot 0, which is `@size` — an `Int`. Casting that integer to a pointer and dereferencing it **segfaulted the debugger**, so `p` on a list killed the session

## The fix

Each branch now reads the size from the object's own slot, matching the declarations in `gen_collect.obs`: Vector `@size` at 1, List `@size` at 0, Hash `@size` at 1 with `@capacity` at 2, Map `@size` at 2.

The DAP path added in #590 already had these right — that disagreement is how the drift surfaced during the `/simplify` review. The two now agree.

## Tests

`debugger_coll_test.obs` plus a `print_collections` case in **both** the Windows and POSIX runners (previously a test added to one runner would not have run in the other — that gap bit an existing test earlier).

The four collections deliberately hold **different** counts (5, 4, 3, 6), none matching a header value. Equal counts would let the old coincidences pass — the Hash case in particular printed a believable answer for the wrong reason.

A separate fixture rather than extending `debugger_test.obs`, whose line numbers are pinned by a dozen existing tests.

## Verification

| Suite | Result |
|---|---|
| Debugger (CLI) | 25 passed, 0 failed |
| Regression | 179 passed, 0 failed |
| LSP | 45 passed, 0 failed |
| DAP | 13 passed, 0 failed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)