### PR TITLE
Emit the arguments of a call attached to a calculated operand

### DIFF
--- a/core/compiler/intermediate.cpp
+++ b/core/compiler/intermediate.cpp
@@ -5348,6 +5348,12 @@ void IntermediateEmitter::EmitCalculation(CalculatedExpression* expression)
   case BIT_XOR_EXPR:
     EmitCalculation(static_cast<CalculatedExpression*>(right));
     if(right->GetMethodCall()) {
+      // The attached call is emitted here rather than by EmitExpression, so its
+      // arguments have to be emitted too -- EmitMethodCall only emits the call.
+      // Without this the call consumes whatever happens to be on the stack
+      // beneath the receiver, which for a comparison operand is the other side
+      // of the comparison.
+      EmitMethodCallParameters(right->GetMethodCall());
       EmitMethodCall(right->GetMethodCall(), false);
       EmitCast(right->GetMethodCall());
     }
@@ -5378,6 +5384,12 @@ void IntermediateEmitter::EmitCalculation(CalculatedExpression* expression)
   case BIT_XOR_EXPR:
     EmitCalculation(static_cast<CalculatedExpression*>(left));
     if(left->GetMethodCall()) {
+      // The attached call is emitted here rather than by EmitExpression, so its
+      // arguments have to be emitted too -- EmitMethodCall only emits the call.
+      // Without this the call consumes whatever happens to be on the stack
+      // beneath the receiver, which for a comparison operand is the other side
+      // of the comparison.
+      EmitMethodCallParameters(left->GetMethodCall());
       EmitMethodCall(left->GetMethodCall(), false);
       EmitCast(left->GetMethodCall());
     }

--- a/programs/regression/calculated_receiver_call.obs
+++ b/programs/regression/calculated_receiver_call.obs
@@ -1,0 +1,81 @@
+#~
+A method call attached to a calculated expression, used inside another
+calculated expression.
+
+`(1 + 1)->Pow(10)` calls a static function on the hidden `$Int` class with the
+receiver as its first argument and 10 as its second. When that call sat inside
+another calculated expression -- most commonly a comparison -- the emitter
+dropped the written arguments entirely.
+
+`EmitCalculation` emits each operand, and for an operand that is itself a
+calculated expression it called `EmitMethodCall` directly. That emits the call
+but not its parameters, unlike the `EmitExpression` path which emits
+`GetCallingParameters()` first. So `if((1 + 1)->Pow(10) = 1024)` compiled to:
+
+    LOAD_INT_LIT 1024      <- the comparison's other operand
+    LOAD_INT_LIT 2         <- the receiver
+    MTHD_CALL $Int:Pow:i,i,
+
+with no `LOAD_INT_LIT 10`. `Pow` then consumed 1024 and 2 as its arguments and
+the comparison was left with an empty stack, which showed up as heap
+corruption rather than a wrong answer.
+
+Assigning the call to a variable first was unaffected, because that path goes
+through `EmitExpression`. A receiver that is a plain literal or variable was
+also unaffected, since neither is a calculated expression. That combination is
+why this survived: the obvious spellings all worked.
+
+Zero-argument calls could not expose it -- there were no arguments to drop --
+so `Abs()` is included below to keep that path covered too.
+~#
+
+class CalculatedReceiverCall {
+	function : Main(args : String[]) ~ Nil {
+		passed := 0;
+		failed := 0;
+
+		# --- the original repro: comparison operand ---
+		if((1 + 1)->Pow(10) = 1024) { passed += 1; } else { failed += 1; "FAIL: foldable receiver in a comparison"->PrintLine(); };
+
+		# a receiver the optimizer cannot fold takes the same path
+		n := 1;
+		if((n + 1)->Pow(10) = 1024) { passed += 1; } else { failed += 1; "FAIL: non-foldable receiver in a comparison"->PrintLine(); };
+
+		# --- both sides of a comparison ---
+		if((1 + 1)->Pow(10) = (1000 + 24)) { passed += 1; } else { failed += 1; "FAIL: calculated receiver on the left"->PrintLine(); };
+		if(1024 = (1 + 1)->Pow(10)) { passed += 1; } else { failed += 1; "FAIL: calculated receiver on the right"->PrintLine(); };
+
+		# --- other calculated contexts, not just comparisons ---
+		if(((3 + 4)->Pow(2) + 1) = 50) { passed += 1; } else { failed += 1; "FAIL: calculated receiver inside arithmetic"->PrintLine(); };
+		if(((1 + 1)->Pow(3) * 2) = 16) { passed += 1; } else { failed += 1; "FAIL: calculated receiver times a value"->PrintLine(); };
+
+		# --- more than one argument ---
+		if((4 + 1)->Clamp(1, 3) = Int->Clamp(5, 1, 3)) { passed += 1; } else { failed += 1; "FAIL: two-argument call on a calculated receiver"->PrintLine(); };
+
+		# --- ordered functions, where a dropped or swapped argument shows up ---
+		if((1 + 1)->Min(5) = 2) { passed += 1; } else { failed += 1; "FAIL: Min on a calculated receiver"->PrintLine(); };
+		if((7 + 0)->Compare(3) = 1) { passed += 1; } else { failed += 1; "FAIL: Compare on a calculated receiver"->PrintLine(); };
+
+		# --- zero-argument calls, which never had arguments to lose ---
+		if((0 - 2)->Abs() = 2) { passed += 1; } else { failed += 1; "FAIL: zero-argument call on a calculated receiver"->PrintLine(); };
+
+		# --- Float ---
+		if((2.0 + 0.0)->Pow(3.0) = 8.0) { passed += 1; } else { failed += 1; "FAIL: Float calculated receiver"->PrintLine(); };
+		if((7.0 + 0.0)->Mod(4.0) = 3.0) { passed += 1; } else { failed += 1; "FAIL: Float Mod on a calculated receiver"->PrintLine(); };
+
+		# --- the spellings that always worked, to keep them working ---
+		direct := (1 + 1)->Pow(10);
+		if(direct = 1024) { passed += 1; } else { failed += 1; "FAIL: call assigned before comparing"->PrintLine(); };
+		if(2->Pow(10) = 1024) { passed += 1; } else { failed += 1; "FAIL: literal receiver"->PrintLine(); };
+		v := 2;
+		if(v->Pow(10) = 1024) { passed += 1; } else { failed += 1; "FAIL: variable receiver"->PrintLine(); };
+
+		if(failed > 0) {
+			"---"->PrintLine();
+			"{$passed} passed, {$failed} failed"->PrintLine();
+			Runtime->Exit(1);
+		};
+
+		"{$passed} passed, 0 failed"->PrintLine();
+	}
+}


### PR DESCRIPTION
`if((1 + 1)->Pow(10) = 1024)` corrupted the heap (`0xC0000374`).

## Cause

`EmitCalculation` emits each operand of a calculated expression. When an operand is *itself* a calculated expression carrying an attached method call, it called `EmitMethodCall` directly — which emits the call but **not its arguments**. The `EmitExpression` path emits `GetCallingParameters()` first; this path did not.

The comparison compiled to:

```
LOAD_INT_LIT 1024      <- the comparison's other operand
LOAD_INT_LIT 2         <- the receiver
LOAD_INST_MEM
MTHD_CALL System.$Int:Pow:i,i,
EQL_INT
```

with no `LOAD_INT_LIT 10`. `Pow` takes two parameters, so it consumed `1024` and `2`, and `EQL_INT` then ran against an empty stack. The symptom was heap corruption rather than a wrong answer, which is why it read as a runtime fault rather than a codegen defect.

Both operand branches now emit the call's parameters first.

## Pre-existing, and independent of #597

The **released** compiler emits byte-identical instructions for the same program. Found with `obc -asm`, which writes a `.obm` instruction listing.

## Why it survived

It needs all three: a calculated-expression receiver, **and** at least one written argument, **and** the result used inside another calculated expression. A literal or variable receiver, a zero-argument call, or assigning the result to a temporary before comparing all take different paths and all worked — so every obvious spelling was fine.

## Testing

New `programs/regression/calculated_receiver_call.obs` — 15 assertions: both sides of a comparison, arithmetic contexts, one- and two-argument calls, ordered functions where a dropped argument changes the answer, `Float`, and the spellings that already worked.

Full regression suite: **182/182**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)