### PR TITLE
obi editor phase 3: run pane with jump-to-error

### DIFF
--- a/core/repl/editor.cpp
+++ b/core/repl/editor.cpp
@@ -40,6 +40,7 @@
 #include "term.h"
 #include "screen.h"
 #include "tui_editor.h"
+#include "io_capture.h"
 #include <deque>
 
 //
@@ -568,7 +569,21 @@ void Editor::DoEdit()
     return;
   }
 
-  Tui::EditorView view(doc, term);
+  // F5 compiles and runs the buffer in-process; the capture keeps the
+  // program's output (and the VM's) off the raw-mode screen and hands it to
+  // the pane instead
+  auto run_program = [this](std::wstring& output) -> bool {
+    Tui::IoCapture capture;
+    if(!capture.Start()) {
+      output = L"unable to capture program output";
+      return false;
+    }
+    const bool ok = DoExecute();
+    capture.Finish(output);
+    return ok;
+  };
+
+  Tui::EditorView view(doc, term, run_program);
   const size_t left_at = view.Run(cur_pos);
 
   term.Clear();

--- a/core/repl/io_capture.h
+++ b/core/repl/io_capture.h
@@ -1,0 +1,212 @@
+/***************************************************************************
+ * Captures process stdout/stderr while the editor's run pane executes the
+ * program in-process (editor phase 3).
+ *
+ * Copyright (c) 2026, Randy Hollines
+ * All rights reserved.
+ ***************************************************************************/
+
+#ifndef __TUI_IO_CAPTURE_H__
+#define __TUI_IO_CAPTURE_H__
+
+#include <string>
+#include <cstdio>
+#include <cwchar>
+#include <iostream>
+
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#include <windows.h>
+#else
+#include <unistd.h>
+#include <cstdlib>
+#endif
+
+// The VM runs in-process, so a program's output would land straight on the
+// editor's screen. Redirection happens at the file-descriptor level -- the
+// same approach obd's DAP mode uses -- because that is the one place both C
+// stdio and the C++ wide streams converge. stdin is pointed at the null
+// device for the duration, so a program that reads input sees EOF instead of
+// stealing raw key bytes from the editor.
+
+namespace Tui {
+
+  class IoCapture {
+    bool active;
+    int saved_out;
+    int saved_err;
+    int saved_in;
+    std::string path;
+    FILE* sink;
+
+    static void FlushAll() {
+      std::wcout.flush();
+      std::wcerr.flush();
+      fflush(stdout);
+      fflush(stderr);
+    }
+
+  public:
+    IoCapture() : active(false), saved_out(-1), saved_err(-1), saved_in(-1), sink(nullptr) {
+    }
+
+    ~IoCapture() {
+      std::wstring dropped;
+      Finish(dropped);
+    }
+
+    bool Start() {
+      if(active) {
+        return true;
+      }
+
+      FlushAll();
+
+#ifdef _WIN32
+      char temp_dir[MAX_PATH];
+      char temp_name[MAX_PATH];
+      if(!GetTempPathA(MAX_PATH, temp_dir) || !GetTempFileNameA(temp_dir, "obi", 0, temp_name)) {
+        return false;
+      }
+      path = temp_name;
+      if(fopen_s(&sink, path.c_str(), "w+b") != 0 || !sink) {
+        return false;
+      }
+
+      saved_out = _dup(1);
+      saved_err = _dup(2);
+      saved_in = _dup(0);
+      if(_dup2(_fileno(sink), 1) != 0 || _dup2(_fileno(sink), 2) != 0) {
+        Restore();
+        return false;
+      }
+      FILE* null_in = nullptr;
+      fopen_s(&null_in, "NUL", "r");
+      if(null_in) {
+        _dup2(_fileno(null_in), 0);
+        fclose(null_in);
+      }
+#else
+      char temp_name[] = "/tmp/obi-run-XXXXXX";
+      const int fd = mkstemp(temp_name);
+      if(fd < 0) {
+        return false;
+      }
+      path = temp_name;
+      sink = fdopen(fd, "w+b");
+      if(!sink) {
+        close(fd);
+        return false;
+      }
+
+      saved_out = dup(1);
+      saved_err = dup(2);
+      saved_in = dup(0);
+      if(dup2(fileno(sink), 1) < 0 || dup2(fileno(sink), 2) < 0) {
+        Restore();
+        return false;
+      }
+      FILE* null_in = fopen("/dev/null", "r");
+      if(null_in) {
+        dup2(fileno(null_in), 0);
+        fclose(null_in);
+      }
+#endif
+
+      active = true;
+      return true;
+    }
+
+    // restores the descriptors and returns everything the program wrote
+    bool Finish(std::wstring& out) {
+      if(!active) {
+        return false;
+      }
+      FlushAll();
+      Restore();
+      active = false;
+
+      // read the sink back as UTF-8 bytes
+      std::string bytes;
+      if(sink) {
+        fseek(sink, 0, SEEK_END);
+        const long size = ftell(sink);
+        if(size > 0) {
+          bytes.resize((size_t)size);
+          fseek(sink, 0, SEEK_SET);
+          const size_t got = fread(&bytes[0], 1, (size_t)size, sink);
+          bytes.resize(got);
+        }
+        fclose(sink);
+        sink = nullptr;
+        remove(path.c_str());
+      }
+
+      // decode UTF-8 by hand -- the locale must not get a say (this repo has
+      // been bitten by locale-dependent conversions before)
+      out.clear();
+      out.reserve(bytes.size());
+      for(size_t i = 0; i < bytes.size();) {
+        const unsigned char lead = (unsigned char)bytes[i];
+        unsigned int cp;
+        int extra;
+        if(lead < 0x80) {
+          cp = lead;
+          extra = 0;
+        }
+        else if(lead >= 0xF0) {
+          cp = lead & 0x07;
+          extra = 3;
+        }
+        else if(lead >= 0xE0) {
+          cp = lead & 0x0F;
+          extra = 2;
+        }
+        else if(lead >= 0xC0) {
+          cp = lead & 0x1F;
+          extra = 1;
+        }
+        else {   // stray continuation byte
+          ++i;
+          continue;
+        }
+
+        if(i + extra >= bytes.size() + (extra ? 0 : 1)) {
+          break;
+        }
+        bool valid = true;
+        for(int k = 1; k <= extra; ++k) {
+          const unsigned char cont = (unsigned char)bytes[i + k];
+          if((cont & 0xC0) != 0x80) {
+            valid = false;
+            break;
+          }
+          cp = (cp << 6) | (cont & 0x3F);
+        }
+        if(!valid) {
+          ++i;
+          continue;
+        }
+        i += extra + 1;
+        out += (wchar_t)cp;
+      }
+      return true;
+    }
+
+  private:
+    void Restore() {
+#ifdef _WIN32
+      if(saved_out >= 0) { _dup2(saved_out, 1); _close(saved_out); saved_out = -1; }
+      if(saved_err >= 0) { _dup2(saved_err, 2); _close(saved_err); saved_err = -1; }
+      if(saved_in >= 0) { _dup2(saved_in, 0); _close(saved_in); saved_in = -1; }
+#else
+      if(saved_out >= 0) { dup2(saved_out, 1); close(saved_out); saved_out = -1; }
+      if(saved_err >= 0) { dup2(saved_err, 2); close(saved_err); saved_err = -1; }
+      if(saved_in >= 0) { dup2(saved_in, 0); close(saved_in); saved_in = -1; }
+#endif
+    }
+  };
+}
+
+#endif

--- a/core/repl/keymap.h
+++ b/core/repl/keymap.h
@@ -35,36 +35,47 @@ namespace Tui {
     ACT_DELETE_LINE,
     ACT_TAB,
     ACT_SAVE,
-    ACT_QUIT
+    ACT_QUIT,
+    ACT_RUN,          // compile and execute; output lands in the pane
+    ACT_TOGGLE_PANE,
+    ACT_NEXT_ERROR,
+    ACT_PANE_UP,
+    ACT_PANE_DOWN
   };
 
   struct Binding {
     KeyCode code;
     wchar_t ch;      // significant only for KEY_CHAR entries
     bool ctrl;
+    bool alt;
     Action action;
   };
 
   // the notepad-style default profile; discoverable, matches the hint bar
   inline const Binding* SimpleProfile(size_t& count) {
     static const Binding bindings[] = {
-      { KEY_LEFT, 0, false, ACT_LEFT },
-      { KEY_RIGHT, 0, false, ACT_RIGHT },
-      { KEY_UP, 0, false, ACT_UP },
-      { KEY_DOWN, 0, false, ACT_DOWN },
-      { KEY_HOME, 0, false, ACT_LINE_START },
-      { KEY_END, 0, false, ACT_LINE_END },
-      { KEY_HOME, 0, true, ACT_DOC_START },
-      { KEY_END, 0, true, ACT_DOC_END },
-      { KEY_PGUP, 0, false, ACT_PAGE_UP },
-      { KEY_PGDN, 0, false, ACT_PAGE_DOWN },
-      { KEY_ENTER, 0, false, ACT_NEWLINE },
-      { KEY_BACKSPACE, 0, false, ACT_BACKSPACE },
-      { KEY_DELETE, 0, false, ACT_DELETE },
-      { KEY_TAB, 0, false, ACT_TAB },
-      { KEY_CHAR, L's', true, ACT_SAVE },
-      { KEY_CHAR, L'q', true, ACT_QUIT },
-      { KEY_CHAR, L'k', true, ACT_DELETE_LINE },
+      { KEY_LEFT, 0, false, false, ACT_LEFT },
+      { KEY_RIGHT, 0, false, false, ACT_RIGHT },
+      { KEY_UP, 0, false, false, ACT_UP },
+      { KEY_DOWN, 0, false, false, ACT_DOWN },
+      { KEY_UP, 0, false, true, ACT_PANE_UP },
+      { KEY_DOWN, 0, false, true, ACT_PANE_DOWN },
+      { KEY_HOME, 0, false, false, ACT_LINE_START },
+      { KEY_END, 0, false, false, ACT_LINE_END },
+      { KEY_HOME, 0, true, false, ACT_DOC_START },
+      { KEY_END, 0, true, false, ACT_DOC_END },
+      { KEY_PGUP, 0, false, false, ACT_PAGE_UP },
+      { KEY_PGDN, 0, false, false, ACT_PAGE_DOWN },
+      { KEY_ENTER, 0, false, false, ACT_NEWLINE },
+      { KEY_BACKSPACE, 0, false, false, ACT_BACKSPACE },
+      { KEY_DELETE, 0, false, false, ACT_DELETE },
+      { KEY_TAB, 0, false, false, ACT_TAB },
+      { KEY_F5, 0, false, false, ACT_RUN },
+      { KEY_F6, 0, false, false, ACT_TOGGLE_PANE },
+      { KEY_F8, 0, false, false, ACT_NEXT_ERROR },
+      { KEY_CHAR, L's', true, false, ACT_SAVE },
+      { KEY_CHAR, L'q', true, false, ACT_QUIT },
+      { KEY_CHAR, L'k', true, false, ACT_DELETE_LINE },
     };
     count = sizeof(bindings) / sizeof(bindings[0]);
     return bindings;
@@ -75,7 +86,7 @@ namespace Tui {
     const Binding* bindings = SimpleProfile(count);
     for(size_t i = 0; i < count; ++i) {
       const Binding& binding = bindings[i];
-      if(binding.code != key.code || binding.ctrl != key.ctrl) {
+      if(binding.code != key.code || binding.ctrl != key.ctrl || binding.alt != key.alt) {
         continue;
       }
       if(binding.code == KEY_CHAR && binding.ch != key.ch) {

--- a/core/repl/tui_editor.h
+++ b/core/repl/tui_editor.h
@@ -12,6 +12,9 @@
 #include "term.h"
 #include "screen.h"
 #include "keymap.h"
+#include <functional>
+#include <vector>
+#include <cwctype>
 
 // A viewport over Document -- the same buffer the line commands edit, so
 // '/l', '/s' and friends keep working on whatever this editor produced. The
@@ -43,6 +46,14 @@ namespace Tui {
     bool quit_armed;     // set by a first Ctrl+Q with unsaved changes
     std::wstring status; // transient message; cleared by the next key
 
+    // run pane: compile-and-execute output, shown below the text area
+    std::function<bool(std::wstring&)> runner;
+    std::vector<std::wstring> pane;
+    size_t pane_top;
+    bool pane_visible;
+    std::vector<size_t> error_lines;   // 1-based document lines from diagnostics
+    size_t error_index;
+
     static const int TAB_STOP = 3;
 
     // display column of character index `col`, honoring tabs and wide chars
@@ -63,8 +74,20 @@ namespace Tui {
       return doc.GetLineType(row) != Line::Type::RW_LINE;
     }
 
+    // pane height: a third of the terminal, never starving the text area
+    int PaneRows() const {
+      if(!pane_visible || rows < 10) {
+        return 0;
+      }
+      int height = rows / 3;
+      if(height < 4) {
+        height = 4;
+      }
+      return height;
+    }
+
     int TextRows() const {
-      return rows - 2;   // title bar and hint bar
+      return rows - 2 - PaneRows();   // title bar, hint bar, pane
     }
 
     int GutterWidth() {
@@ -172,6 +195,21 @@ namespace Tui {
         }
       }
 
+      // run pane: a labeled rule, then output with error lines highlighted
+      if(PaneRows() > 0) {
+        const int pane_start = 1 + TextRows();
+        screen.Fill(pane_start, 0, cols, L'-', ATTR_GRAY);
+        screen.Put(pane_start, 1, L" output · F6 hide · Alt+Up/Down scroll ", ATTR_GRAY | ATTR_BOLD);
+        for(int i = 0; i < PaneRows() - 1; ++i) {
+          const size_t index = pane_top + i;
+          if(index >= pane.size()) {
+            break;
+          }
+          const bool is_error = pane[index].find(L":(") != std::wstring::npos;
+          screen.Put(pane_start + 1 + i, 1, pane[index], is_error ? ATTR_RED : ATTR_DEFAULT);
+        }
+      }
+
       // hint bar; a transient status message takes its place until a key
       screen.Fill(rows - 1, 0, cols, L' ', ATTR_REVERSE);
       const std::wstring pos = L" Ln " + std::to_wstring(cur_row + 1) + L", Col " + std::to_wstring(cur_col + 1) + L" ";
@@ -179,7 +217,7 @@ namespace Tui {
         screen.Put(rows - 1, 0, L" " + status, ATTR_REVERSE | ATTR_BOLD);
       }
       else {
-        screen.Put(rows - 1, 0, L" Ctrl+S save   Ctrl+Q quit   Ctrl+K delete line", ATTR_REVERSE);
+        screen.Put(rows - 1, 0, L" Ctrl+S save   Ctrl+Q quit   F5 run   Ctrl+K delete line", ATTR_REVERSE);
       }
       screen.Put(rows - 1, cols - (int)pos.size(), pos, ATTR_REVERSE);
 
@@ -322,6 +360,87 @@ namespace Tui {
       dirty = true;
     }
 
+    // strip ANSI color sequences the REPL's own error printing embeds
+    static std::wstring StripAnsi(const std::wstring& text) {
+      std::wstring out;
+      out.reserve(text.size());
+      for(size_t i = 0; i < text.size(); ++i) {
+        if(text[i] == L'\x1b' && i + 1 < text.size() && text[i + 1] == L'[') {
+          i += 2;
+          while(i < text.size() && !iswalpha(text[i])) {
+            ++i;
+          }
+          continue;
+        }
+        out += text[i];
+      }
+      return out;
+    }
+
+    void DoRun() {
+      if(!runner) {
+        status = L"running is not available here";
+        return;
+      }
+
+      std::wstring output;
+      const bool ok = runner(output);
+
+      // split into pane lines; diagnostics look like 'name:(line,col): text'
+      pane.clear();
+      error_lines.clear();
+      std::wstring line;
+      for(const wchar_t ch : StripAnsi(output) + L"\n") {
+        if(ch == L'\n') {
+          if(!line.empty() && line.back() == L'\r') {
+            line.pop_back();
+          }
+          const size_t mark = line.find(L":(");
+          if(mark != std::wstring::npos) {
+            const long parsed = wcstol(line.c_str() + mark + 2, nullptr, 10);
+            if(parsed > 0) {
+              error_lines.push_back((size_t)parsed);
+            }
+          }
+          pane.push_back(line);
+          line.clear();
+        }
+        else {
+          line += ch;
+        }
+      }
+      while(!pane.empty() && pane.back().empty()) {
+        pane.pop_back();
+      }
+
+      pane_visible = true;
+      pane_top = 0;
+      error_index = 0;
+      if(ok) {
+        status = L"program finished · " + std::to_wstring(pane.size()) + L" line(s) of output";
+      }
+      else {
+        status = std::to_wstring(error_lines.size()) + L" error(s) · F8 jumps to the next one";
+        if(!error_lines.empty()) {
+          cur_row = error_lines[0] > 0 ? error_lines[0] - 1 : 0;
+          ClampCursor();
+          cur_col = 0;
+        }
+      }
+    }
+
+    void DoNextError() {
+      if(error_lines.empty()) {
+        status = L"no errors to visit";
+        return;
+      }
+      error_index = (error_index + 1) % error_lines.size();
+      cur_row = error_lines[error_index] > 0 ? error_lines[error_index] - 1 : 0;
+      ClampCursor();
+      cur_col = 0;
+      status = L"error " + std::to_wstring(error_index + 1) + L" of " + std::to_wstring(error_lines.size());
+    }
+
     void DoDeleteLine() {
       if(!doc.DeleteLine(cur_row)) {   // refuses read-only lines itself
         status = L"read-only shell line";
@@ -333,8 +452,9 @@ namespace Tui {
     }
 
   public:
-    EditorView(Document& document, Term& terminal)
-      : doc(document), term(terminal) {
+    EditorView(Document& document, Term& terminal,
+               std::function<bool(std::wstring&)> run_program = nullptr)
+      : doc(document), term(terminal), runner(run_program) {
       rows = 24;
       cols = 80;
       top = 0;
@@ -342,6 +462,9 @@ namespace Tui {
       cur_row = cur_col = want_col = 0;
       dirty = false;
       quit_armed = false;
+      pane_top = 0;
+      pane_visible = false;
+      error_index = 0;
     }
 
     // returns the cursor's document line, so the REPL can keep its own
@@ -477,6 +600,31 @@ namespace Tui {
 
         case ACT_SAVE:
           DoSave();
+          break;
+
+        case ACT_RUN:
+          DoRun();
+          break;
+
+        case ACT_TOGGLE_PANE:
+          pane_visible = !pane_visible && !pane.empty();
+          ClampCursor();
+          break;
+
+        case ACT_NEXT_ERROR:
+          DoNextError();
+          break;
+
+        case ACT_PANE_UP:
+          if(pane_top > 0) {
+            --pane_top;
+          }
+          break;
+
+        case ACT_PANE_DOWN:
+          if(pane_top + 1 < pane.size()) {
+            ++pane_top;
+          }
           break;
 
         case ACT_QUIT:


### PR DESCRIPTION
F5 compiles and executes the buffer **without leaving the editor**. Output lands in a pane on the lower third; F6 toggles it, Alt+Up/Down scrolls, and on a failed compile F8 cycles the cursor through the offending lines — the first error is jumped to immediately. Diagnostics carry `name:(line,col)` and the composite buffer's line numbers are the document's, so the mapping is direct.

## The hard part

The VM runs in-process, so a program's output would land straight on the raw-mode screen. `io_capture.h` redirects at the **file-descriptor level** — the same approach `obd --dap` uses — since that's the one place C stdio and the wide streams converge. Read back with a locale-independent UTF-8 decode. `stdin` is pointed at the null device for the duration, so a program that reads input sees EOF instead of stealing raw key bytes and hanging the editor. ANSI sequences from the REPL's own error printer are stripped before display.

The editor stays decoupled: it takes a run callback, and `DoEdit` supplies one wrapping the existing `DoExecute` in a capture. Header-only, no build-file changes — same as the rest of the stack.

## Verification

- MSVC x64 clean
- `io_capture.h` unit-checked under WSL g++: both streams captured, descriptors restored, terminal reachable afterward
- Non-TTY guard still refuses piped sessions with the REPL continuing

To try: `obi` → `/e` → type a program between the shell braces → **F5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)