### PR TITLE
Updater phase 1: obu check, SHA256SUMS, download stats

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -264,6 +264,15 @@ jobs:
           name: release-final
           path: release-final/
 
+      - name: Generate SHA256SUMS
+        run: |
+          # Bare filenames (no paths) so `sha256sum -c SHA256SUMS` works after download.
+          # Written into release-final/ so the existing release-final/* upload includes it.
+          cd release-final
+          sha256sum * > SHA256SUMS
+          echo "✅ SHA256SUMS generated:"
+          cat SHA256SUMS
+
       - name: Generate release notes
         id: release-notes
         run: |

--- a/.github/workflows/release-stats.yml
+++ b/.github/workflows/release-stats.yml
@@ -1,0 +1,35 @@
+name: Release Stats
+
+on:
+  schedule:
+    # Weekly, Monday 05:17 UTC (off-peak, avoids the on-the-hour GitHub cron rush)
+    - cron: '17 5 * * 1'
+  workflow_dispatch:
+
+jobs:
+  snapshot:
+    name: Snapshot Download Counts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: master
+
+      - name: Snapshot release download counts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 tools/release-stats/snapshot_downloads.py --token "$GH_TOKEN"
+
+      - name: Commit updated CSV
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add tools/release-stats/downloads.csv
+          git diff --cached --quiet && echo "downloads.csv unchanged" || \
+            git commit -m "chore: weekly release download-stats snapshot [skip ci]"
+          git push origin master || echo "Push skipped (no changes)"

--- a/core/utils/updater/make/Makefile.amd64
+++ b/core/utils/updater/make/Makefile.amd64
@@ -1,0 +1,13 @@
+ARGS=-O3 -Wall -Wno-unused-function -std=c++17 -mavx2
+
+SRC=obu.o
+EXE=obu
+
+$(EXE): $(SRC)
+	$(CXX) -m64 -o $(EXE) $(SRC)
+
+%.o: %.cpp
+	$(CXX) -m64 $(ARGS) -c $<
+
+clean:
+	rm -f $(EXE) *.o *~

--- a/core/utils/updater/make/Makefile.arm64
+++ b/core/utils/updater/make/Makefile.arm64
@@ -1,0 +1,13 @@
+ARGS=-O3 -Wall -Wno-unused-function -std=c++17
+
+SRC=obu.o
+EXE=obu
+
+$(EXE): $(SRC)
+	$(CXX) -o $(EXE) $(SRC)
+
+%.o: %.cpp
+	$(CXX) $(ARGS) -c $<
+
+clean:
+	rm -f $(EXE) *.o *~

--- a/core/utils/updater/obu.cpp
+++ b/core/utils/updater/obu.cpp
@@ -1,0 +1,360 @@
+/***************************************************************************
+* Objeck updater ("obu")
+*
+* Phase 1: 'obu check' compares the installed version against a GitHub
+* release tag. Exit codes: 0 = update available, 1 = up to date, 2 = error.
+*
+* Copyright (c) 2026, Randy Hollines
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* - Redistributions of source code must retain the above copyright
+* notice, this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright
+* notice, this list of conditions and the following disclaimer in
+* the documentation and/or other materials provided with the distribution.
+* - Neither the name of the Objeck team nor the names of its
+* contributors may be used to endorse or promote products derived
+* from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+* A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+* OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+* TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+*  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+***************************************************************************/
+
+#include "../../shared/version.h"
+
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#define OBU_POPEN _popen
+#define OBU_PCLOSE _pclose
+#else
+#include <sys/wait.h>
+#define OBU_POPEN popen
+#define OBU_PCLOSE pclose
+#endif
+
+#define EXIT_UPDATE_AVAILABLE 0
+#define EXIT_UP_TO_DATE 1
+#define EXIT_CHECK_ERROR 2
+
+#define RELEASES_API_BASE "https://api.github.com/repos/objeck/objeck-lang/releases"
+
+/****************************
+* Usage
+****************************/
+static void Usage()
+{
+  std::cout << "Usage: obu <command> [options]" << std::endl << std::endl;
+  std::cout << "Commands:" << std::endl;
+  std::cout << "  check              check whether a newer Objeck release is available" << std::endl << std::endl;
+  std::cout << "Options for 'check':" << std::endl;
+  std::cout << "  --quiet            print nothing; communicate via the exit code" << std::endl;
+  std::cout << "  --channel <tag>    compare against a specific release tag (e.g. v2026.8.0)" << std::endl;
+  std::cout << "                     instead of the latest release" << std::endl << std::endl;
+  std::cout << "General options:" << std::endl;
+  std::cout << "  --help             show this message" << std::endl;
+  std::cout << "  --version          show the obu version" << std::endl << std::endl;
+  std::cout << "Exit codes for 'check': 0 = update available, 1 = up to date, 2 = error" << std::endl;
+}
+
+/****************************
+* Converts the compiled-in wide
+* version string to narrow text
+****************************/
+static std::string InstalledVersion()
+{
+  const wchar_t* wide_version = VERSION_STRING;
+  std::string version;
+  for(size_t i = 0; wide_version[i] != L'\0'; ++i) {
+    version += static_cast<char>(wide_version[i]);
+  }
+
+  return version;
+}
+
+/****************************
+* Ensures a tag is safe to place
+* in a shell command line
+****************************/
+static bool IsSafeTag(const std::string& tag)
+{
+  if(tag.empty()) {
+    return false;
+  }
+
+  for(size_t i = 0; i < tag.size(); ++i) {
+    const char c = tag[i];
+    if(!std::isalnum(static_cast<unsigned char>(c)) && c != '.' && c != '_' && c != '-') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/****************************
+* Fetches a URL by shelling out
+* to the system 'curl' binary
+****************************/
+static bool FetchUrl(const std::string& url, bool is_quiet, std::string& response, std::string& error)
+{
+  std::string command = "curl -fsSL --max-time 20 \"" + url + '"';
+  if(is_quiet) {
+#ifdef _WIN32
+    command += " 2>nul";
+#else
+    command += " 2>/dev/null";
+#endif
+  }
+
+  FILE* pipe = OBU_POPEN(command.c_str(), "r");
+  if(!pipe) {
+    error = "Unable to run 'curl'; please ensure it is installed and on the path.";
+    return false;
+  }
+
+  response.clear();
+  char buffer[4096];
+  size_t read;
+  while((read = fread(buffer, 1, sizeof(buffer), pipe)) > 0) {
+    response.append(buffer, read);
+  }
+
+  const int status = OBU_PCLOSE(pipe);
+#ifdef _WIN32
+  const int exit_code = status;
+#else
+  const int exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+#endif
+
+  if(status == -1 || exit_code != 0) {
+    error = "Request failed: " + url + " ('curl' exited with code " +
+      std::to_string(exit_code) + "; is curl installed and the network reachable?)";
+    return false;
+  }
+
+  return true;
+}
+
+/****************************
+* Extracts "tag_name" from a
+* GitHub release JSON response
+****************************/
+static bool ExtractTagName(const std::string& json, std::string& tag)
+{
+  const std::string key = "\"tag_name\"";
+  size_t index = json.find(key);
+  if(index == std::string::npos) {
+    return false;
+  }
+  index += key.size();
+
+  index = json.find(':', index);
+  if(index == std::string::npos) {
+    return false;
+  }
+
+  index = json.find('"', index);
+  if(index == std::string::npos) {
+    return false;
+  }
+  ++index;
+
+  const size_t end = json.find('"', index);
+  if(end == std::string::npos || end == index) {
+    return false;
+  }
+
+  tag = json.substr(index, end - index);
+  return true;
+}
+
+/****************************
+* Parses a version tag such as
+* 'v2026.8.0' into numeric parts
+****************************/
+static bool ParseVersion(const std::string& tag, std::vector<long>& parts)
+{
+  parts.clear();
+
+  size_t index = 0;
+  if(index < tag.size() && (tag[index] == 'v' || tag[index] == 'V')) {
+    ++index;
+  }
+
+  if(index >= tag.size()) {
+    return false;
+  }
+
+  std::string component;
+  for(; index <= tag.size(); ++index) {
+    if(index == tag.size() || tag[index] == '.') {
+      if(component.empty()) {
+        return false;
+      }
+      parts.push_back(std::strtol(component.c_str(), nullptr, 10));
+      component.clear();
+    }
+    else if(std::isdigit(static_cast<unsigned char>(tag[index]))) {
+      component += tag[index];
+    }
+    else {
+      return false;
+    }
+  }
+
+  return !parts.empty();
+}
+
+/****************************
+* Compares versions numerically;
+* returns <0, 0 or >0
+****************************/
+static int CompareVersions(const std::vector<long>& left, const std::vector<long>& right)
+{
+  const size_t count = left.size() > right.size() ? left.size() : right.size();
+  for(size_t i = 0; i < count; ++i) {
+    const long left_part = i < left.size() ? left[i] : 0;
+    const long right_part = i < right.size() ? right[i] : 0;
+    if(left_part != right_part) {
+      return left_part < right_part ? -1 : 1;
+    }
+  }
+
+  return 0;
+}
+
+/****************************
+* 'check' command
+****************************/
+static int DoCheck(bool is_quiet, const std::string& channel)
+{
+  const std::string installed = InstalledVersion();
+
+  std::string url = RELEASES_API_BASE;
+  if(channel.empty()) {
+    url += "/latest";
+  }
+  else {
+    if(!IsSafeTag(channel)) {
+      if(!is_quiet) {
+        std::cerr << "Invalid channel tag: '" << channel << '\'' << std::endl;
+      }
+      return EXIT_CHECK_ERROR;
+    }
+    url += "/tags/" + channel;
+  }
+
+  std::string response, error;
+  if(!FetchUrl(url, is_quiet, response, error)) {
+    if(!is_quiet) {
+      std::cerr << error << std::endl;
+    }
+    return EXIT_CHECK_ERROR;
+  }
+
+  std::string release_tag;
+  if(!ExtractTagName(response, release_tag)) {
+    if(!is_quiet) {
+      std::cerr << "Unable to find \"tag_name\" in the release response from " << url << std::endl;
+    }
+    return EXIT_CHECK_ERROR;
+  }
+
+  std::vector<long> installed_parts, release_parts;
+  if(!ParseVersion(installed, installed_parts)) {
+    if(!is_quiet) {
+      std::cerr << "Malformed installed version: '" << installed << '\'' << std::endl;
+    }
+    return EXIT_CHECK_ERROR;
+  }
+
+  if(!ParseVersion(release_tag, release_parts)) {
+    if(!is_quiet) {
+      std::cerr << "Malformed release tag: '" << release_tag << '\'' << std::endl;
+    }
+    return EXIT_CHECK_ERROR;
+  }
+
+  const bool update_available = CompareVersions(installed_parts, release_parts) < 0;
+  if(!is_quiet) {
+    std::cout << "Installed version: " << installed << std::endl;
+    std::cout << (channel.empty() ? "Latest release: " : "Channel release: ") << release_tag << std::endl;
+    if(update_available) {
+      std::cout << "An update is available." << std::endl;
+    }
+    else {
+      std::cout << "Objeck is up to date." << std::endl;
+    }
+  }
+
+  return update_available ? EXIT_UPDATE_AVAILABLE : EXIT_UP_TO_DATE;
+}
+
+/****************************
+* Program start
+****************************/
+int main(int argc, const char* argv[])
+{
+  if(argc < 2) {
+    Usage();
+    return EXIT_CHECK_ERROR;
+  }
+
+  const std::string command = argv[1];
+  if(command == "--help" || command == "-h" || command == "help") {
+    Usage();
+    return 0;
+  }
+
+  if(command == "--version" || command == "version") {
+    std::cout << "obu " << InstalledVersion() << std::endl;
+    return 0;
+  }
+
+  if(command != "check") {
+    std::cerr << "Unknown command: '" << command << '\'' << std::endl << std::endl;
+    Usage();
+    return EXIT_CHECK_ERROR;
+  }
+
+  bool is_quiet = false;
+  std::string channel;
+  for(int i = 2; i < argc; ++i) {
+    const std::string option = argv[i];
+    if(option == "--quiet" || option == "-q") {
+      is_quiet = true;
+    }
+    else if(option == "--channel") {
+      if(i + 1 >= argc) {
+        std::cerr << "Option '--channel' requires a release tag argument" << std::endl;
+        return EXIT_CHECK_ERROR;
+      }
+      channel = argv[++i];
+    }
+    else {
+      std::cerr << "Unknown option: '" << option << '\'' << std::endl << std::endl;
+      Usage();
+      return EXIT_CHECK_ERROR;
+    }
+  }
+
+  return DoCheck(is_quiet, channel);
+}

--- a/core/utils/updater/vs/obu.vcxproj
+++ b/core/utils/updater/vs/obu.vcxproj
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\obu.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\shared\version.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{4904587e-10f9-4e58-8f1d-0890529f2248}</ProjectGuid>
+    <RootNamespace>obu</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectName>obu</ProjectName>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>obu</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <TargetName>obu</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>obu</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <TargetName>obu</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/tools/release-stats/README.md
+++ b/tools/release-stats/README.md
@@ -1,0 +1,18 @@
+# Release download stats
+
+`downloads.csv` is a running history of download counts for Objeck release
+assets, with one row per asset per snapshot: `snapshot_utc`, `release_tag`,
+`asset_name`, `download_count`. The source of truth is GitHub's own per-asset
+`download_count` from the Releases API — no extra infrastructure or telemetry
+is involved. Counts are cumulative, so per-week deltas come from diffing
+successive snapshots.
+
+The `.github/workflows/release-stats.yml` workflow runs the snapshot weekly
+and commits the updated CSV. To run it manually:
+
+```
+python3 tools/release-stats/snapshot_downloads.py
+```
+
+An optional `--token <github-token>` raises the API rate limit (CI passes the
+built-in `GITHUB_TOKEN`); anonymous access works fine for occasional runs.

--- a/tools/release-stats/snapshot_downloads.py
+++ b/tools/release-stats/snapshot_downloads.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Snapshot per-asset download counts for objeck-lang GitHub Releases.
+
+Pages through the GitHub Releases API and appends one row per release asset
+(snapshot_utc, release_tag, asset_name, download_count) to downloads.csv,
+building download history over time from GitHub's own counters. CI runs this
+weekly via .github/workflows/release-stats.yml; it can also be run manually
+with no dependencies beyond the Python 3 standard library.
+"""
+
+import argparse
+import csv
+import json
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+API_URL = "https://api.github.com/repos/objeck/objeck-lang/releases"
+CSV_COLUMNS = ["snapshot_utc", "release_tag", "asset_name", "download_count"]
+
+
+def fetch_releases(token=None):
+    """Return all releases, following pagination until an empty page."""
+    releases = []
+    page = 1
+    while True:
+        url = f"{API_URL}?per_page=100&page={page}"
+        request = urllib.request.Request(url)
+        request.add_header("Accept", "application/vnd.github+json")
+        request.add_header("User-Agent", "objeck-release-stats")
+        if token:
+            request.add_header("Authorization", f"Bearer {token}")
+        with urllib.request.urlopen(request) as response:
+            batch = json.load(response)
+        if not batch:
+            break
+        releases.extend(batch)
+        page += 1
+    return releases
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--token", default=None,
+                        help="GitHub API token (optional; anonymous access works)")
+    parser.add_argument("--csv", default=str(Path(__file__).parent / "downloads.csv"),
+                        help="CSV file to append to (default: downloads.csv beside this script)")
+    args = parser.parse_args()
+
+    try:
+        releases = fetch_releases(args.token)
+    except (urllib.error.URLError, urllib.error.HTTPError) as error:
+        print(f"error: failed to fetch releases: {error}", file=sys.stderr)
+        return 1
+
+    snapshot_utc = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    rows = []
+    for release in releases:
+        for asset in release.get("assets", []):
+            rows.append([snapshot_utc, release["tag_name"],
+                         asset["name"], asset["download_count"]])
+    rows.sort(key=lambda row: (row[1], row[2]))
+
+    csv_path = Path(args.csv)
+    write_header = not csv_path.exists()
+    with csv_path.open("a", newline="", encoding="utf-8") as csv_file:
+        writer = csv.writer(csv_file)
+        if write_header:
+            writer.writerow(CSV_COLUMNS)
+        writer.writerows(rows)
+
+    print(f"Appended {len(rows)} rows to {csv_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements phase 1 of `docs/UPDATER_DESIGN.md` (#603) — the independently-shippable pieces, before any install/swap logic.

## `obu` (core/utils/updater)

The updater's native skeleton, `check` only: compares the compiled-in `VERSION_STRING` against the latest GitHub release (or a pinned `--channel <tag>`). **Exit 0** = update available, **1** = current, **2** = error; `--quiet` emits nothing so the REPL/launcher can shell to it for the exit code. The fetch shells to the **system curl** (Windows 10+, macOS, CI distros all ship it) so no library dependency enters the build; channel tags are character-validated before touching a command line. One-file vcxproj (`$(DefaultPlatformToolset)`, x64+ARM64) and POSIX Makefiles mirror the launcher's — the repo's simplest native-tool pattern. No Xcode project: `ci-build.yml` builds tools via the Makefile path only.

## SHA256SUMS

Generated in **`release-publish.yml`**'s `github-release` job over exactly the released file set, plain `sha256sum` format with bare names so `sha256sum -c` works after download. The design named `release-build.yml`, but that workflow never uploads release assets — the `gh release create` lives in release-publish, so the sums do too. Shell expansion ordering keeps the file out of its own digest.

## Download tracking (design tier 1)

`tools/release-stats/snapshot_downloads.py` (stdlib-only) pages the releases API and appends per-asset `download_count` rows to a committed CSV; a weekly cron (`release-stats.yml`, `contents: write`, existing bot-commit pattern) runs it. First run creates the CSV. Updater downloads are ordinary asset downloads, so they're counted with the rest — zero new infrastructure.

## Verification

- `obu` built clean on MSVC x64 **and** WSL g++; exercised against the live API on both: up-to-date (exit 1), `--channel` with older tags (exit 1), `--quiet` (silent, exit preserved), nonexistent tag → curl 404 → exit 2, injection-guard rejection
- Live curiosity: latest published release is `v2026.6.4`, so the compiled-in `2026.8.0` correctly reads as *newer than latest* → no update
- Stats script live-tested anonymously twice: 445 rows/snapshot, append semantics and single header confirmed
- Known gap, stated plainly: the exit-0 *update-available* path can't be exercised until a release newer than the compiled-in version exists; it shares the single comparator whose other directions are covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)