### PR TITLE
Divide and modulus by zero trap cleanly at every optimization level

### DIFF
--- a/core/compiler/optimization.cpp
+++ b/core/compiler/optimization.cpp
@@ -1599,8 +1599,17 @@ void ItermediateOptimizer::CalculateIntFold(IntermediateInstruction* instr, std:
 
     case DIV_INT: {
       if(right->GetOperand7() == 0) {
+        // the operation must survive to trap at runtime, and its operands must
+        // land in the output BEFORE it -- emitting the instruction here and
+        // leaving the literals on the working stack appended them after it,
+        // so the division executed against an empty stack and the clean
+        // "Divide by zero" trap became a silent crash at default optimization
         working_stack.push_front(right);
         working_stack.push_front(left);
+        while(!working_stack.empty()) {
+          outputs->AddInstruction(working_stack.back());
+          working_stack.pop_back();
+        }
         outputs->AddInstruction(instr);
         return;
       }
@@ -1611,8 +1620,17 @@ void ItermediateOptimizer::CalculateIntFold(IntermediateInstruction* instr, std:
 
     case MOD_INT: {
       if(right->GetOperand7() == 0) {
+        // the operation must survive to trap at runtime, and its operands must
+        // land in the output BEFORE it -- emitting the instruction here and
+        // leaving the literals on the working stack appended them after it,
+        // so the division executed against an empty stack and the clean
+        // "Divide by zero" trap became a silent crash at default optimization
         working_stack.push_front(right);
         working_stack.push_front(left);
+        while(!working_stack.empty()) {
+          outputs->AddInstruction(working_stack.back());
+          working_stack.pop_back();
+        }
         outputs->AddInstruction(instr);
         return;
       }

--- a/core/vm/interpreter.cpp
+++ b/core/vm/interpreter.cpp
@@ -977,6 +977,21 @@ void StackInterpreter::ModInt(size_t* &op_stack, size_t* &stack_pos)
   const size_t sp = *stack_pos;  // Cache stack position locally
   const INT64_VALUE left = static_cast<INT64_VALUE>(op_stack[sp - 1]);
   const INT64_VALUE right = static_cast<INT64_VALUE>(op_stack[sp - 2]);
+  // modulus by zero raises the same hardware fault division does; without
+  // this guard it died silently instead of trapping like DivInt
+  if(right == 0) [[unlikely]] {
+    if(TryErrorRecovery(stack_pos)) {
+      return;
+    }
+    std::wcerr << L">>> Divide by zero <<<" << std::endl;
+    StackErrorUnwind();
+#ifdef _NO_HALT
+    halt = true;
+    return;
+#else
+    exit(1);
+#endif
+  }
   op_stack[sp - 2] = left % right;
   *stack_pos = sp - 1;
 }

--- a/programs/regression/bad_div_zero_folded.obs
+++ b/programs/regression/bad_div_zero_folded.obs
@@ -1,0 +1,23 @@
+# EXPECT_RUNTIME_ERROR
+#~
+A constant division by zero must still trap at runtime, at every optimization
+level.
+
+The constant folder's zero-divisor guard kept the DIV instruction but emitted
+it BEFORE flushing its literal operands out of the fold's working stack, so at
+default optimization the division executed against an empty stack: exit 127
+with no output instead of the clean ">>> Divide by zero <<<" trap that -opt s0
+produced. Silent behavior difference between optimization levels.
+
+The harness passes this only on a non-zero exit WITH output -- which is
+precisely the trap-versus-silent-crash distinction.
+~#
+
+class DivZeroFolded {
+	function : Main(args : String[]) ~ Nil {
+		# folds to constants; the nested form exercises operand ordering when
+		# the guard bails out with literals still pending on the fold stack
+		x := 1 + 6 / 0;
+		x->PrintLine();
+	}
+}

--- a/programs/regression/bad_mod_zero.obs
+++ b/programs/regression/bad_mod_zero.obs
@@ -1,0 +1,21 @@
+# EXPECT_RUNTIME_ERROR
+#~
+Modulus by zero must trap like division by zero does.
+
+The interpreter's ModInt had no zero check at all -- `left % right` with a
+zero divisor raised the hardware fault directly, dying silently (exit 127, no
+output) at every optimization level, while DivInt printed the clean
+">>> Divide by zero <<<" trap and unwound. The guard now mirrors DivInt's.
+
+The harness passes this only on a non-zero exit WITH output, which separates
+the trap from the silent crash.
+~#
+
+class ModZero {
+	function : Main(args : String[]) ~ Nil {
+		# a variable divisor, so no fold path is involved: this pins the VM trap
+		n := 7;
+		z := 0;
+		(n % z)->PrintLine();
+	}
+}


### PR DESCRIPTION
Two related defects, one symptom family: a zero divisor dying as **silent exit 127** instead of the clean `>>> Divide by zero <<<` trap.

**Compiler** — the constant folder's zero-divisor guard (shared by `DIV_INT`/`MOD_INT`) correctly refused to fold, but emitted the kept instruction *before* flushing its literal operands off the fold's working stack — so the operands landed after the divide and it executed against an empty stack. `(5 / 0)` at default optimization crashed silently where `-opt s0` trapped. The guard now flushes the whole pending stack first, which also preserves operand order for enclosing expressions (`1 + 6 / 0`).

**VM** — `ModInt` had **no zero check at all**: `left % right` raised the hardware fault directly at every optimization level. It now carries the same guard, recovery hook, and trap `DivInt` has. (Found by probing both operators at both levels rather than only the audit's reported case.)

## Tests

`bad_div_zero_folded.obs` (folded + nested forms) and `bad_mod_zero.obs` (variable divisor — pins the VM trap with no fold involved). The harness's runtime-error gate — non-zero exit **and** non-empty output — is exactly the trap-versus-silent-crash discriminator: both tests fail against the pre-fix binaries and pass with the fixes, verified in both directions locally at `-opt s0` and `s3`.

Existing behavior preserved: normal folding results unchanged (`(2+3)*4/2` → 10 at both levels), division trap unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)