### PR TITLE
CI: run the obu update/rollback tests on linux-x64

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -671,6 +671,15 @@ jobs:
         if not exist "%BIN%" set BIN=..\..\core\release\deploy\bin
         python run_dap_tests.py "%BIN%"
 
+    # obu update/rollback: offline end-to-end against fake releases (no network).
+    # The script builds obu with the test hooks, exercises verify/swap/rollback
+    # and the command-injection PoC, and exits non-zero on any failure. Its
+    # fixtures are linux-x64; it self-skips elsewhere, so it runs on that leg.
+    - name: Run updater tests (POSIX)
+      if: matrix.platform == 'linux-x64'
+      shell: bash
+      run: CXX=g++ sh core/utils/updater/test_update.sh
+
     # ============================================
     # Network Tests (quarantined / non-gating)
     #


### PR DESCRIPTION
Wires `core/utils/updater/test_update.sh` into the build job — the remaining phase-2 follow-up from #610.

The script builds `obu` with `-DOBU_TEST_HOOKS` and drives the whole update pipeline against fake releases **offline** (verify → staged swap → rollback, plus the command-injection PoC), exiting non-zero on any failure. Its fixtures are linux-x64 and it self-skips on other platforms, so the step is gated to that leg; the other platforms already compile the update path in their builds.

This is the gate that catches a regression in the security-critical swap logic — the same suite that, run manually, confirmed the injection fix and the tamper-rejection during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)