### PR TITLE
fix(debugger): obd shipped with HTTP/2 and HTTP/3 compiled out

### DIFF
--- a/core/debugger/vs/debugger.vcxproj
+++ b/core/debugger/vs/debugger.vcxproj
@@ -103,14 +103,14 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_NO_HALT;_NO_JIT;_DEBUGGER;_DEBUGGER;WIN32;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>OBJECK_HAS_NGHTTP2;OBJECK_HAS_WINHTTP_H3;_NO_HALT;_NO_JIT;_DEBUGGER;_DEBUGGER;WIN32;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/arch:AVX2 /U "_DEBUG" %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>msvcrtd.lib;mbedtls.lib;mbedcrypto.lib;mbedx509.lib;bcrypt.lib;crypt32.lib;libz-static.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>msvcrtd.lib;mbedtls.lib;nghttp2.lib;winhttp.lib;mbedcrypto.lib;mbedx509.lib;bcrypt.lib;crypt32.lib;libz-static.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/ignore:4099 /ignore:4286 %(AdditionalOptions)</AdditionalOptions>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
@@ -120,14 +120,14 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_NO_HALT;_NO_JIT;_DEBUGGER;_DEBUGGER;WIN32;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>OBJECK_HAS_NGHTTP2;OBJECK_HAS_WINHTTP_H3;_NO_HALT;_NO_JIT;_DEBUGGER;_DEBUGGER;WIN32;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/arch:AVX2 /U "_DEBUG" %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>msvcrt.lib;msvcmrt.lib;libz-static.lib;mbedtls.lib;mbedcrypto.lib;mbedx509.lib;bcrypt.lib;crypt32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>msvcrt.lib;msvcmrt.lib;libz-static.lib;mbedtls.lib;nghttp2.lib;winhttp.lib;mbedcrypto.lib;mbedx509.lib;bcrypt.lib;crypt32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/ignore:4099 /ignore:4286 %(AdditionalOptions)</AdditionalOptions>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
@@ -139,7 +139,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_NO_HALT;_OBJECK_NATIVE_LIB_PATH;_NO_JIT;_DEBUGGER;_NO_JIT;_DEBUGGER;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>OBJECK_HAS_NGHTTP2;OBJECK_HAS_WINHTTP_H3;_NO_HALT;_OBJECK_NATIVE_LIB_PATH;_NO_JIT;_DEBUGGER;_NO_JIT;_DEBUGGER;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -150,7 +150,7 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>msvcrt.lib;msvcmrt.lib;libz-static.lib;mbedtls.lib;mbedcrypto.lib;mbedx509.lib;bcrypt.lib;crypt32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>msvcrt.lib;msvcmrt.lib;libz-static.lib;mbedtls.lib;nghttp2.lib;winhttp.lib;mbedcrypto.lib;mbedx509.lib;bcrypt.lib;crypt32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/ignore:4099 /ignore:4286  /ignore:4042 /NODEFAULTLIB:LIBCMT %(AdditionalOptions)</AdditionalOptions>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
       <IgnoreSpecificDefaultLibraries>
@@ -164,7 +164,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_NO_HALT;_OBJECK_NATIVE_LIB_PATH;_NO_JIT;_DEBUGGER;_NO_JIT;_DEBUGGER;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>OBJECK_HAS_NGHTTP2;OBJECK_HAS_WINHTTP_H3;_NO_HALT;_OBJECK_NATIVE_LIB_PATH;_NO_JIT;_DEBUGGER;_NO_JIT;_DEBUGGER;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ObjectFileName>$(IntDir)</ObjectFileName>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -175,7 +175,7 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>msvcrt.lib;msvcmrt.lib;libz-static.lib;mbedtls.lib;mbedcrypto.lib;mbedx509.lib;bcrypt.lib;crypt32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>msvcrt.lib;msvcmrt.lib;libz-static.lib;mbedtls.lib;nghttp2.lib;winhttp.lib;mbedcrypto.lib;mbedx509.lib;bcrypt.lib;crypt32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/ignore:4099 /ignore:4286 /NODEFAULTLIB:LIBCMT %(AdditionalOptions)</AdditionalOptions>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>


### PR DESCRIPTION
`debugger.vcxproj` compiles the same `common.cpp` as the VM but defined **neither** `OBJECK_HAS_NGHTTP2` nor `OBJECK_HAS_WINHTTP_H3`. So every HTTP/2 and HTTP/3 request made by a program running under `obd` failed — while the identical program worked under `obr`.

Same class of defect as the `Http3Client`-on-Windows gap just merged in #614: the traps compile unconditionally, so the API is present and silently does nothing. Found because `runtime.feature.http2/http3` (added in #614) makes it detectable.

Adds both macros plus `nghttp2.lib` and `winhttp.lib` to all four configs. The headers and import libs were already reachable — no new dependency.

**Verified:** `obd.exe` now imports `nghttp2.dll` and `WINHTTP.dll` (`dumpbin /imports`). The previously shipped `obd` imported neither.

### Deliberately not changed

A review suggested fixing three projects. Two of them would have been wrong:

- **`module.vcxproj`** is a `StaticLibrary` — it does not link. Defining the macros there compiles HTTP code whose symbols the *consumer* must then provide: a downstream link break, not a fix.
- **`arm64_debugger.vcxproj`** is not an MSVC project at all. It is a **VisualGDB Raspberry Pi cross-build** (`com.visualgdb.raspberry_pi.arm64`) targeting Linux ARM64, where WinHTTP is meaningless — it would need ngtcp2, as `Makefile.arm64` now does. It is also not built in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
