### PR TITLE
security(vm): reject CR/LF in caller-supplied content types (header injection)

### DIFF
--- a/core/vm/common.cpp
+++ b/core/vm/common.cpp
@@ -38,6 +38,66 @@
 #include "common.h"
 #include "loader.h"
 
+// --- HTTP header field validation -------------------------------------------
+//
+// Caller-supplied header content must never be able to add a header line of
+// its own. On Windows this is a live request-splitting vector: WinHTTP's
+// AddRequestHeaders takes a CRLF-SEPARATED BLOCK, so a CR/LF inside a value is
+// the API's own separator, not a parse error. On the ngtcp2 path the framing
+// is length-prefixed so it does not split there, but nghttp3 performs no
+// validation on submit (the check_header_* helpers exist precisely because it
+// is the caller's job), and an h3->h1.1 gateway downstream will happily turn a
+// CR/LF-bearing value into a split at the origin.
+//
+// Octets per RFC 9110 5.1/5.5 as tightened by RFC 9113 8.2.1 (adopted by
+// RFC 9114 4.3). Validated on the UTF-8 bytes, since that is what goes on the
+// wire.
+static bool h3_valid_header_value(const std::string& v)
+{
+  for(size_t i = 0; i < v.size(); ++i) {
+    const unsigned char c = (unsigned char)v[i];
+    // reject CR, LF, NUL, DEL and every other C0 control; SP and HTAB are ok
+    if(c == 0x7F || (c < 0x20 && c != 0x09)) {
+      return false;
+    }
+  }
+  // leading/trailing whitespace makes the field malformed
+  if(!v.empty()) {
+    const unsigned char f = (unsigned char)v.front(), b = (unsigned char)v.back();
+    if(f == 0x20 || f == 0x09 || b == 0x20 || b == 0x09) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static bool h3_valid_header_name(const std::string& n)
+{
+  if(n.empty()) {
+    return false;
+  }
+  // A caller must never supply a pseudo-header: both backends build :method,
+  // :path, :scheme and :authority themselves, and a duplicate is malformed
+  // (RFC 9114 4.3.1) -- the classic smuggling / cache-poisoning primitive.
+  if(n[0] == ':') {
+    return false;
+  }
+  for(size_t i = 0; i < n.size(); ++i) {
+    const unsigned char c = (unsigned char)n[i];
+    const bool tchar = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+                       c == '!' || c == '#' || c == '$' || c == '%' || c == '&' ||
+                       c == 0x27 /* apostrophe */ || c == '*' || c == '+' ||
+                       c == '-' || c == '.' ||
+                       c == '^' || c == '_' || c == '`' || c == '|' || c == '~';
+    // uppercase is rejected rather than folded: HTTP/2/3 require lowercase and
+    // nghttp3 does not lower-case for us
+    if(!tchar) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // Which HTTP/3 backend owns instance[0]. Derived ONCE so Connect, Request and
 // Close cannot disagree -- picking the wrong type in Close is a wrong-type
 // delete (heap corruption), not a compile error.
@@ -6818,8 +6878,15 @@ bool TrapProcessor::Http2Request(StackProgram* program, size_t* inst, size_t*& o
 
     if(ctype_array) {
       ctype_array = (size_t*)ctype_array[0];
+      const std::string ctype_val = UnicodeToBytes((wchar_t*)(ctype_array + 3));
+      // Caller-supplied: refuse anything that could add a header line of its
+      // own, or that a downstream h2/h3 -> HTTP/1.1 gateway would re-emit as
+      // one. Both libraries validate nothing on submit.
+      if(!h3_valid_header_value(ctype_val)) {
+        PushInt(0, op_stack, stack_pos); return true;
+      }
       hdr_keys.push_back("content-type");
-      hdr_vals.push_back(UnicodeToBytes((wchar_t*)(ctype_array + 3)));
+      hdr_vals.push_back(ctype_val);
     }
 
     struct BodyCtx { const uint8_t* data; size_t len; size_t pos; };
@@ -7425,8 +7492,15 @@ bool TrapProcessor::Http3Request(StackProgram* program, size_t* inst, size_t*& o
     body_data.assign(bptr, bptr + blen);
     if(ctype_array) {
       ctype_array = (size_t*)ctype_array[0];
+      const std::string ctype_val = UnicodeToBytes((wchar_t*)(ctype_array + 3));
+      // Caller-supplied: refuse anything that could add a header line of its
+      // own, or that a downstream h2/h3 -> HTTP/1.1 gateway would re-emit as
+      // one. Both libraries validate nothing on submit.
+      if(!h3_valid_header_value(ctype_val)) {
+        PushInt(0, op_stack, stack_pos); return true;
+      }
       hdr_keys.push_back("content-type");
-      hdr_vals.push_back(UnicodeToBytes((wchar_t*)(ctype_array + 3)));
+      hdr_vals.push_back(ctype_val);
     }
   }
 
@@ -7525,6 +7599,11 @@ bool TrapProcessor::Http3Request(StackProgram* program, size_t* inst, size_t*& o
     if(ctype_array) {
       ctype_array = (size_t*)ctype_array[0];
       ctype = UnicodeToBytes((wchar_t*)(ctype_array + 3));
+      // WinHttpAddRequestHeaders takes a CRLF-SEPARATED BLOCK, so a CR/LF here
+      // is the API's own separator -- request splitting, not a parse error.
+      if(!h3_valid_header_value(ctype)) {
+        PushInt(0, op_stack, stack_pos); return true;
+      }
     }
   }
 

--- a/core/vm/win_http3.h
+++ b/core/vm/win_http3.h
@@ -151,8 +151,13 @@ static bool h3win_request(Http3WinCtx* ctx,
     headers += BytesToUnicode(it->first) + L": " + BytesToUnicode(it->second) + L"\r\n";
   }
   if(!headers.empty()) {
-    WinHttpAddRequestHeaders(request, headers.c_str(), (DWORD)-1,
-                             WINHTTP_ADDREQ_FLAG_ADD | WINHTTP_ADDREQ_FLAG_REPLACE);
+    // Fail the request if the block is rejected. Discarding this made a
+    // rejected header block indistinguishable from a sent one -- the same
+    // silently-does-nothing failure this backend exists to eliminate.
+    if(!WinHttpAddRequestHeaders(request, headers.c_str(), (DWORD)-1,
+                                 WINHTTP_ADDREQ_FLAG_ADD | WINHTTP_ADDREQ_FLAG_REPLACE)) {
+      return false;
+    }
   }
 
   const BOOL sent = WinHttpSendRequest(request, WINHTTP_NO_ADDITIONAL_HEADERS, 0,

--- a/programs/tests/http3_downgrade_test.obs
+++ b/programs/tests/http3_downgrade_test.obs
@@ -1,5 +1,9 @@
 #~
-HTTP/3 downgrade test -- the assertion the other HTTP/3 tests do not make.
+HTTP/3 "must refuse" tests -- the assertions the other HTTP/3 tests do not make.
+
+Two things the client must REFUSE rather than quietly accept:
+  1. a connection that is not actually HTTP/3 (silent downgrade)
+  2. a caller-supplied content type carrying CR/LF (header injection)
 
 Lives in programs/tests/ and runs from the NON-GATING network step, not the
 gating regression suite. Two reasons, both learned the hard way:
@@ -78,6 +82,31 @@ class Http3DowngradeTest {
 			"  info: non-HTTP/3 host refused at connect"->PrintLine();
 		};
 		plain->Close();
+
+		# --- header injection: CR/LF in a caller-supplied content type ----
+		# WinHttpAddRequestHeaders takes a CRLF-SEPARATED BLOCK, so a CR/LF in
+		# a value is the API's own separator -- it appends a header line rather
+		# than failing to parse. This was accepted (status 200) until the
+		# validator landed. The ngtcp2 path transmits the raw octets, which a
+		# downstream h3->HTTP/1.1 gateway can re-emit as a split.
+		inj := Http3Client->New("cloudflare-quic.com");
+		if(inj->IsConnected()) {
+			payload := "x"->ToByteArray();
+			evil := inj->Post("/", payload, "text/plain
+X-Injected: pwned");
+			if(evil <> Nil) {
+				ec := evil->GetCode();
+				pass := false;
+				"  FAIL: CR/LF content type accepted (status={$ec}) -- header injection"->PrintLine();
+			}
+			else {
+				"  info: CR/LF content type correctly refused"->PrintLine();
+			};
+		}
+		else {
+			"  SKIP: no HTTP/3 connection for the injection check"->PrintLine();
+		};
+		inj->Close();
 
 		if(pass) {
 			"PASS: HTTP/3 downgrade test"->PrintLine();


### PR DESCRIPTION
A security review of the **AddHeader plan** found a live vulnerability in already-merged code.

## The bug

`Http3Client->Post/Put/Patch` pass the caller's content type straight into the header serializer. On Windows that builds one CRLF-delimited string for `WinHttpAddRequestHeaders` — whose documented input **is a CRLF-separated header block**, not a single header. So CR/LF in a value isn't a parse error, it's the API's own separator, and the injected line is syntactically valid:

```objeck
client->Post("/", body, "text/plain\r\nX-Injected: pwned")
```

**Demonstrated against a live host before the fix: `status=200`, accepted.**

With `WINHTTP_ADDREQ_FLAG_REPLACE` also set, an injected line can *replace* a header the library set — `content-length` or `transfer-encoding` gives request smuggling on any HTTP/1.1 leg downstream.

The ngtcp2 path isn't a split (HTTP/3 framing is length-prefixed) but isn't clean either: nghttp3 and nghttp2 validate nothing on submit — their `check_header_*` helpers exist precisely because it's the caller's job — so invalid octets reach the wire and an h3/h2 → HTTP/1.1 gateway can re-emit them as a split at the origin.

**HTTP/2 has the identical unvalidated path** and is fixed here too.

## The fix

`h3_valid_header_value` / `h3_valid_header_name`, shared by all arms, per RFC 9110 §5.1/§5.5 as tightened by RFC 9113 §8.2.1 (adopted by RFC 9114 §4.3): rejects CR, LF, NUL, DEL and C0 controls (SP/HTAB allowed), plus leading/trailing whitespace.

The name validator also rejects any field starting with `:` — both backends build `:method`/`:path`/`:scheme`/`:authority` themselves, and a duplicate pseudo-header is malformed (RFC 9114 §4.3.1): the classic smuggling / cache-poisoning primitive. It's unused until `AddHeader` is wired, but lands with its sibling so the policy lives in one place.

Also checks `WinHttpAddRequestHeaders`' return, which was discarded — a rejected header block was indistinguishable from a sent one, the same silently-does-nothing failure this backend exists to eliminate.

## Verification

| check | result |
| --- | --- |
| injection that returned 200 | **now refused** |
| legitimate content type POST | 200, unchanged |
| session reuse + close | unchanged |
| downgrade guard (HTTP/1.1-only hosts) | still refuses |

Regression test extended with the injection case — **it fails against the previous build**, which is the standard this branch now holds itself to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
