### PR TITLE
fix(jit/arm64): move_freg_freg addressed the general register file, clobbering X{dest}

### DIFF
--- a/core/vm/arch/jit/arm64/jit_arm_a64.cpp
+++ b/core/vm/arch/jit/arm64/jit_arm_a64.cpp
@@ -3703,7 +3703,14 @@ void JitArm64::cmp_mem_freg(long offset, Register src, Register dest) {
   RegisterHolder* holder = GetFpRegister();
   move_mem_freg(offset, src, holder->GetRegister());
   cmp_freg_freg(dest, holder->GetRegister());
-  move_freg_freg(holder->GetRegister(), dest);
+  // No move back: a compare yields flags, not a value, and dest still
+  // holds the live left-hand operand. AMD64 agrees -- cmp_mem_xreg is a
+  // bare ucomisd that never writes dest.
+  //
+  // There WAS a move_freg_freg(holder, dest) here. It was inert only
+  // because move_freg_freg addressed the general register file; once that
+  // was corrected the move became real and clobbered dest with the memory
+  // operand after every float compare-against-memory.
   ReleaseFpRegister(holder);
 }
 

--- a/core/vm/arch/jit/arm64/jit_arm_a64.cpp
+++ b/core/vm/arch/jit/arm64/jit_arm_a64.cpp
@@ -3951,20 +3951,22 @@ void JitArm64::math_mem_reg(long offset, Register reg, InstructionType type) {
 void JitArm64::move_freg_freg(Register src, Register dest) {
   if(src != dest) {
 #ifdef _DEBUG_JIT_JIT
-  std::wcout << L"  " << (++instr_count) << L": [fmov " << GetRegisterName(X10)
-        << L", " << GetRegisterName(src) << L", " << GetRegisterName(src) << L"]" << std::endl;
-#endif
-    uint32_t op_code = 0x9E67000A;
-    op_code |= src << 5;
-    AddMachineCode(op_code);
-    
-#ifdef _DEBUG_JIT_JIT
   std::wcout << L"  " << (++instr_count) << L": [fmov " << GetRegisterName(dest)
-        << L", " << GetRegisterName(src) << L", " << GetRegisterName(X19) << L"]" << std::endl;
+        << L", " << GetRegisterName(src) << L"]" << std::endl;
 #endif
-    op_code = 0x9E660140;
-    op_code |= dest;
-    AddMachineCode(op_code);
+    // fmov D{dest}, D{src}
+    //
+    // This previously bridged through a GP register pair:
+    //   fmov D10, X{src}   (0x9E67000A -- FMOV Dd,Xn, reads the GENERAL file)
+    //   fmov X{dest}, D10  (0x9E660140 -- FMOV Xd,Dn, writes the GENERAL file)
+    // Because the Register enum restarts float numbering at D0 = 0, those
+    // encodings addressed X{src}/X{dest} rather than D{src}/D{dest}. Floats
+    // genuinely live in the FP file here (move_mem_freg emits LDR Dt,
+    // cmp_freg_freg emits FCMP Dn,Dm), so the move both failed to happen AND
+    // clobbered general-purpose register X{dest} with unrelated bits. When
+    // X{dest} held a live pointer, the next use of that field followed a
+    // float bit pattern as an address.
+    AddMachineCode(0x1E604000 | ((uint32_t)src << 5) | (uint32_t)dest);
   }
 }
 

--- a/docs/VERIFY_ARM64_JIT_FLOAT_FIX.md
+++ b/docs/VERIFY_ARM64_JIT_FLOAT_FIX.md
@@ -1,0 +1,87 @@
+# Verifying the ARM64 JIT float-move fix on Apple Silicon
+
+The fix in `core/vm/arch/jit/arm64/jit_arm_a64.cpp` (`move_freg_freg`) is
+verified by disassembly and compiles on every CI leg, but the **crash it is
+believed to cause has never been reproduced in CI**. Closing the
+`investigate/jit-malloc-corruption` investigation needs one run on ARM64
+hardware.
+
+CI cannot do this, for three specific reasons:
+
+1. the repro requires a **source edit** (`YOUNG_REGION_SIZE`), which CI never makes;
+2. `programs/deploy/2d_game_13.obs` is **never run** by any CI job;
+3. it is **probabilistic** — a few failures per ~10 runs — so a single green
+   CI run proves nothing.
+
+## Step 1 — the cheap check first (2 minutes, no source edits)
+
+Before the stress repro, confirm the new deterministic guard passes natively:
+
+```sh
+cd programs/regression
+./run_regression.sh arm64          # or just: the suite runs jit_float_mem_ops
+```
+
+`jit_float_mem_ops.obs` exercises float arithmetic and comparison against
+**memory operands** — the exact shape that routes through `move_freg_freg` —
+in a loop hot enough to be JIT-compiled, asserting exact values.
+
+**This is the interesting one.** Under the bug the float move silently did not
+happen, so this test should have produced a **wrong value**, not a crash. If it
+passes on ARM64 before the fix, my analysis is incomplete and the real trigger
+is narrower than I think — that is worth knowing either way.
+
+## Step 2 — the original stress repro
+
+From the investigation handoff:
+
+1. `core/vm/arch/memory.h`: set `#define YOUNG_REGION_SIZE (32 * 1024)`
+   (normally 128 MB). This makes GC and allocation churn constant, which is
+   what makes the corruption detectable.
+2. Build the ARM64 VM (macOS uses the Xcode project,
+   `core/vm/xcode/VM.xcodeproj` — **not** `Makefile.arm64`).
+3. Run, forcing every method through the JIT:
+
+```sh
+cd programs/deploy
+for i in $(seq 1 30); do
+  OBJECK_JIT_THRESHOLD=1 ../release/deploy/bin/obr 2d_game_13.obe > /dev/null 2>&1
+  echo "run $i -> exit $?"
+done
+```
+
+4. **Restore `YOUNG_REGION_SIZE` to 128 MB afterwards.**
+
+### Reading the result
+
+- **Before the fix:** several runs abort with exit 133/134/138/139 —
+  `BUG IN CLIENT OF LIBMALLOC: memory corruption of free block`, or
+  `EXC_BAD_ACCESS`/SIGBUS with `PC = 0x3F947AE147AE147B` (the IEEE-754 bits of
+  the double `0.02`, i.e. a float being followed as a code pointer).
+- **After the fix:** all 30 runs should exit 0.
+- `OBJECK_JIT_DISABLE=1` was always clean and still should be — that is the
+  control, and it is what established the bug was JIT codegen rather than the
+  GC.
+
+30 runs matters. The original was "a few of ~10", so a clean 10 is weak
+evidence and a clean 30 is reasonable.
+
+## If it still crashes
+
+The fix is correct on its own merits — the old encoding provably addressed the
+wrong register file (capstone: `fmov d10, x3` / `fmov x5, d10` for a requested
+`D3 → D5` move) — so keep it regardless. But a remaining crash means there is
+a second source, and the handoff doc lists the other leads: any path where an
+`IMM_FLOAT`/`REG_FLOAT`/`MEM_FLOAT` working-stack entry is consumed by an
+integer or reference store without a conversion.
+
+The doc's instrumentation gotchas are worth re-reading before writing another
+validator — several traps there have already been hit once.
+
+## Related
+
+- Fix: `core/vm/arch/jit/arm64/jit_arm_a64.cpp`, `move_freg_freg`
+- Investigation: `docs/jit-malloc-corruption-investigation.md` on
+  `investigate/jit-malloc-corruption`
+- Guard: `programs/regression/jit_float_mem_ops.obs` (gating, runs on
+  linux-arm64 and macos-arm64)

--- a/programs/regression/TESTS.md
+++ b/programs/regression/TESTS.md
@@ -13,7 +13,7 @@ python gen_manifest.py
 ```
 
 
-**Total runtime tests: 188** (plus 14 debugger tests, see below).
+**Total runtime tests: 189** (plus 14 debugger tests, see below).
 
 
 ## Tests by Category
@@ -22,7 +22,7 @@ python gen_manifest.py
 |----------|-------|
 | Core Language | 38 |
 | Negative | 21 |
-| AMD64/JIT | 19 |
+| AMD64/JIT | 20 |
 | Other | 15 |
 | Bug Fix | 13 |
 | System.ML | 13 |
@@ -184,64 +184,65 @@ python gen_manifest.py
 | 128 | `jit_dispatch_native.obs` | AMD64/JIT | jit dispatch native | ✅ |
 | 129 | `jit_float_equality.obs` | AMD64/JIT | Regression test for float equality compares on array elements (2026-06). The front-end chose EQL_... | ✅ |
 | 130 | `jit_float_intensive.obs` | AMD64/JIT | jit float intensive | ✅ |
-| 131 | `jit_float_round_trig.obs` | AMD64/JIT | Exercises two JIT float-codegen bugs that only surface once a method using them is auto-JIT'd (de... | ✅ |
-| 132 | `jit_frame_trap_test.obs` | AMD64/JIT | Regression test for the JIT frame-dependent trap crash (2026-06). Traps such as SERL_INT/SERL_FLO... | ✅ |
-| 133 | `jit_func_ref_hot.obs` | AMD64/JIT | jit func ref hot | ✅ |
-| 134 | `jit_gc_stress.obs` | AMD64/JIT | JIT + GC interaction stress (2026-06). One CI run on linux-x64 failed with a JIT-to-JIT runtime e... | ✅ |
-| 135 | `jit_loop_native.obs` | AMD64/JIT | jit loop native | ✅ |
-| 136 | `jit_native_cls_fields.obs` | AMD64/JIT | JIT Native Class Fields Test Tests object reference storage in class instance fields with GC pres... | ✅ |
-| 137 | `jit_native_float_array.obs` | AMD64/JIT | JIT Native Float Array Test Tests native function with float array creation and math operations R... | ✅ |
-| 138 | `jit_native_func_ref.obs` | AMD64/JIT | JIT Native Function Reference Test Tests native functions with function reference storage in clas... | ✅ |
-| 139 | `jit_native_math.obs` | AMD64/JIT | JIT Native Math Builtins Test Tests native math functions: Factorial, Sinh/Cosh/Tanh/Log2/Cbrt, P... | ✅ |
-| 140 | `jit_string_ops.obs` | AMD64/JIT | jit string ops | ✅ |
-| 141 | `jit_tco_bare_local.obs` | AMD64/JIT | Regression for the TCO deferred-local-load miscompile (both arches). A self-recursive tail call t... | ✅ |
-| 142 | `json_build_ops.obs` | JSON | json build ops | ✅ |
-| 143 | `json_parse_ops.obs` | JSON | json parse ops | ✅ |
-| 144 | `lsp_features.obs` | LSP | lsp features | ✅ |
-| 145 | `math_float_ops.obs` | Math | math float ops | ✅ |
-| 146 | `math_log_exp.obs` | Math | math log exp | ✅ |
-| 147 | `math_random_ops.obs` | Math | math random ops | ✅ |
-| 148 | `math_rounding.obs` | Math | math rounding | ✅ |
-| 149 | `math_sqrt_ops.obs` | Math | math sqrt ops | ✅ |
-| 150 | `math_trig_funcs.obs` | Math | math trig funcs | ✅ |
-| 151 | `mcp_debug_test.obs` | MCP Server | DEBUG VERSION of mcp_server_test.obs Identical to programs/regression/mcp_server_test.obs except:... | ✅ |
-| 152 | `mcp_server_test.obs` | MCP Server | mcp server test | ✅ |
-| 153 | `minor_gc_stress.obs` | Other | Regression for generational MINOR GC: old objects holding young references. 'keep' is an object a... | ✅ |
-| 154 | `ml_adaboost_test.obs` | System.ML | Regression tests for System.ML AdaBoost (overhaul phase 3): boosting over boolean decision stumps... | ✅ |
-| 155 | `ml_api_test.obs` | System.ML | Regression tests for the System.ML estimator API consistency sweep (item 11): RandomForest Fit (r... | ✅ |
-| 156 | `ml_dbscan_test.obs` | System.ML | Regression tests for System.ML DBSCAN (overhaul phase 3): two dense blobs plus far-away outliers... | ✅ |
-| 157 | `ml_gbt_test.obs` | System.ML | Regression tests for System.ML gradient boosting (overhaul phase 3 leftover): a RegressionTree le... | ✅ |
-| 158 | `ml_gmm_test.obs` | System.ML | Regression tests for System.ML GaussianMixture (overhaul phase 3): EM on two well-separated blobs... | ✅ |
-| 159 | `ml_kdtree_test.obs` | System.ML | Regression tests for System.ML KDTree (overhaul phase 3): for several queries and k values over a... | ✅ |
-| 160 | `ml_library_test.obs` | System.ML | ml library test | ✅ |
-| 161 | `ml_linearclf_test.obs` | System.ML | Regression tests for the System.ML linear classifiers (overhaul phase 2): Perceptron (mistake-dri... | ✅ |
-| 162 | `ml_nn_test.obs` | System.ML | Regression tests for the System.ML NeuralNetwork with hidden/output bias vectors (ML overhaul ite... | ✅ |
-| 163 | `ml_pca_gnb_test.obs` | System.ML | Regression tests for System.ML PCA (power-iteration decomposition: dominant diagonal direction re... | ✅ |
-| 164 | `ml_phase1_test.obs` | System.ML | Regression tests for the System.ML correctness fixes (phase 1): seedable PRNG, DotSigmoid dimensi... | ✅ |
-| 165 | `ml_regularized_test.obs` | System.ML | Regression tests for the System.ML regularized linear models (overhaul phase 2): RidgeRegression... | ✅ |
-| 166 | `ml_trees_test.obs` | System.ML | Regression tests for the System.ML tree models: the real recursive DecisionTree (left/right child... | ✅ |
-| 167 | `nil_safe_ops.obs` | Core Language | Nil-safe operators: '??' (nil-coalesce) and '?->' (nil-safe call). Both desugar onto existing int... | ✅ |
-| 168 | `oauth_test.obs` | Networking | oauth test | ✅ |
-| 169 | `odbc_sqlite_test.obs` | ODBC | ODBC SQLite Integration Test Tests live database operations against an in-memory SQLite database.... | ✅ |
-| 170 | `primitive_receiver_order.obs` | Other | Argument order for instance-style calls on primitives. Writing `v->Pow(10)` on a primitive does n... | ✅ |
-| 171 | `regex_bench.obs` | Regex | regex bench | ✅ |
-| 172 | `regex_dfa_test.obs` | Regex | regex dfa test | ✅ |
-| 173 | `runtime_feature_test.obs` | Other | Regression tests for the "runtime.feature.*" properties, which report which optional protocol eng... | ✅ |
-| 174 | `select_dispatch_test.obs` | Control Flow | Single-case, linear (2-5 cases), jump-table (dense >=6), and binary-tree (sparse) paths | ✅ |
-| 175 | `string_find_ops.obs` | Strings | string find ops | ✅ |
-| 176 | `string_format_ops.obs` | Strings | Verifies String->Format() positional substitution. | ✅ |
-| 177 | `string_number_conv.obs` | Strings | string number conv | ✅ |
-| 178 | `string_replace_ops.obs` | Strings | string replace ops | ✅ |
-| 179 | `string_split_ops.obs` | Strings | string split ops | ✅ |
-| 180 | `task_scope.obs` | Other | Regression for a structured-concurrency nursery (TaskScope) built purely on the existing System.C... | ✅ |
-| 181 | `tco_receiver.obs` | Other | Tail-call optimization must respect the receiver. TCO used to fire on matching class-id and metho... | ✅ |
-| 182 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
-| 183 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
-| 184 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
-| 185 | `websocket_test.obs` | Networking | websocket test | ✅ |
-| 186 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
-| 187 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
-| 188 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
+| 131 | `jit_float_mem_ops.obs` | AMD64/JIT | Float arithmetic and comparison against MEMORY operands, under the JIT. IMPORTANT: must run with... | ✅ |
+| 132 | `jit_float_round_trig.obs` | AMD64/JIT | Exercises two JIT float-codegen bugs that only surface once a method using them is auto-JIT'd (de... | ✅ |
+| 133 | `jit_frame_trap_test.obs` | AMD64/JIT | Regression test for the JIT frame-dependent trap crash (2026-06). Traps such as SERL_INT/SERL_FLO... | ✅ |
+| 134 | `jit_func_ref_hot.obs` | AMD64/JIT | jit func ref hot | ✅ |
+| 135 | `jit_gc_stress.obs` | AMD64/JIT | JIT + GC interaction stress (2026-06). One CI run on linux-x64 failed with a JIT-to-JIT runtime e... | ✅ |
+| 136 | `jit_loop_native.obs` | AMD64/JIT | jit loop native | ✅ |
+| 137 | `jit_native_cls_fields.obs` | AMD64/JIT | JIT Native Class Fields Test Tests object reference storage in class instance fields with GC pres... | ✅ |
+| 138 | `jit_native_float_array.obs` | AMD64/JIT | JIT Native Float Array Test Tests native function with float array creation and math operations R... | ✅ |
+| 139 | `jit_native_func_ref.obs` | AMD64/JIT | JIT Native Function Reference Test Tests native functions with function reference storage in clas... | ✅ |
+| 140 | `jit_native_math.obs` | AMD64/JIT | JIT Native Math Builtins Test Tests native math functions: Factorial, Sinh/Cosh/Tanh/Log2/Cbrt, P... | ✅ |
+| 141 | `jit_string_ops.obs` | AMD64/JIT | jit string ops | ✅ |
+| 142 | `jit_tco_bare_local.obs` | AMD64/JIT | Regression for the TCO deferred-local-load miscompile (both arches). A self-recursive tail call t... | ✅ |
+| 143 | `json_build_ops.obs` | JSON | json build ops | ✅ |
+| 144 | `json_parse_ops.obs` | JSON | json parse ops | ✅ |
+| 145 | `lsp_features.obs` | LSP | lsp features | ✅ |
+| 146 | `math_float_ops.obs` | Math | math float ops | ✅ |
+| 147 | `math_log_exp.obs` | Math | math log exp | ✅ |
+| 148 | `math_random_ops.obs` | Math | math random ops | ✅ |
+| 149 | `math_rounding.obs` | Math | math rounding | ✅ |
+| 150 | `math_sqrt_ops.obs` | Math | math sqrt ops | ✅ |
+| 151 | `math_trig_funcs.obs` | Math | math trig funcs | ✅ |
+| 152 | `mcp_debug_test.obs` | MCP Server | DEBUG VERSION of mcp_server_test.obs Identical to programs/regression/mcp_server_test.obs except:... | ✅ |
+| 153 | `mcp_server_test.obs` | MCP Server | mcp server test | ✅ |
+| 154 | `minor_gc_stress.obs` | Other | Regression for generational MINOR GC: old objects holding young references. 'keep' is an object a... | ✅ |
+| 155 | `ml_adaboost_test.obs` | System.ML | Regression tests for System.ML AdaBoost (overhaul phase 3): boosting over boolean decision stumps... | ✅ |
+| 156 | `ml_api_test.obs` | System.ML | Regression tests for the System.ML estimator API consistency sweep (item 11): RandomForest Fit (r... | ✅ |
+| 157 | `ml_dbscan_test.obs` | System.ML | Regression tests for System.ML DBSCAN (overhaul phase 3): two dense blobs plus far-away outliers... | ✅ |
+| 158 | `ml_gbt_test.obs` | System.ML | Regression tests for System.ML gradient boosting (overhaul phase 3 leftover): a RegressionTree le... | ✅ |
+| 159 | `ml_gmm_test.obs` | System.ML | Regression tests for System.ML GaussianMixture (overhaul phase 3): EM on two well-separated blobs... | ✅ |
+| 160 | `ml_kdtree_test.obs` | System.ML | Regression tests for System.ML KDTree (overhaul phase 3): for several queries and k values over a... | ✅ |
+| 161 | `ml_library_test.obs` | System.ML | ml library test | ✅ |
+| 162 | `ml_linearclf_test.obs` | System.ML | Regression tests for the System.ML linear classifiers (overhaul phase 2): Perceptron (mistake-dri... | ✅ |
+| 163 | `ml_nn_test.obs` | System.ML | Regression tests for the System.ML NeuralNetwork with hidden/output bias vectors (ML overhaul ite... | ✅ |
+| 164 | `ml_pca_gnb_test.obs` | System.ML | Regression tests for System.ML PCA (power-iteration decomposition: dominant diagonal direction re... | ✅ |
+| 165 | `ml_phase1_test.obs` | System.ML | Regression tests for the System.ML correctness fixes (phase 1): seedable PRNG, DotSigmoid dimensi... | ✅ |
+| 166 | `ml_regularized_test.obs` | System.ML | Regression tests for the System.ML regularized linear models (overhaul phase 2): RidgeRegression... | ✅ |
+| 167 | `ml_trees_test.obs` | System.ML | Regression tests for the System.ML tree models: the real recursive DecisionTree (left/right child... | ✅ |
+| 168 | `nil_safe_ops.obs` | Core Language | Nil-safe operators: '??' (nil-coalesce) and '?->' (nil-safe call). Both desugar onto existing int... | ✅ |
+| 169 | `oauth_test.obs` | Networking | oauth test | ✅ |
+| 170 | `odbc_sqlite_test.obs` | ODBC | ODBC SQLite Integration Test Tests live database operations against an in-memory SQLite database.... | ✅ |
+| 171 | `primitive_receiver_order.obs` | Other | Argument order for instance-style calls on primitives. Writing `v->Pow(10)` on a primitive does n... | ✅ |
+| 172 | `regex_bench.obs` | Regex | regex bench | ✅ |
+| 173 | `regex_dfa_test.obs` | Regex | regex dfa test | ✅ |
+| 174 | `runtime_feature_test.obs` | Other | Regression tests for the "runtime.feature.*" properties, which report which optional protocol eng... | ✅ |
+| 175 | `select_dispatch_test.obs` | Control Flow | Single-case, linear (2-5 cases), jump-table (dense >=6), and binary-tree (sparse) paths | ✅ |
+| 176 | `string_find_ops.obs` | Strings | string find ops | ✅ |
+| 177 | `string_format_ops.obs` | Strings | Verifies String->Format() positional substitution. | ✅ |
+| 178 | `string_number_conv.obs` | Strings | string number conv | ✅ |
+| 179 | `string_replace_ops.obs` | Strings | string replace ops | ✅ |
+| 180 | `string_split_ops.obs` | Strings | string split ops | ✅ |
+| 181 | `task_scope.obs` | Other | Regression for a structured-concurrency nursery (TaskScope) built purely on the existing System.C... | ✅ |
+| 182 | `tco_receiver.obs` | Other | Tail-call optimization must respect the receiver. TCO used to fire on matching class-id and metho... | ✅ |
+| 183 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
+| 184 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
+| 185 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
+| 186 | `websocket_test.obs` | Networking | websocket test | ✅ |
+| 187 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
+| 188 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
+| 189 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
 
 ## Debugger Tests (`run_debugger_tests.sh`)
 

--- a/programs/regression/jit_float_mem_ops.obs
+++ b/programs/regression/jit_float_mem_ops.obs
@@ -1,0 +1,98 @@
+#~
+# Float arithmetic and comparison against MEMORY operands, under the JIT.
+#
+# IMPORTANT: must run with JIT ENABLED. Do NOT add a '# JIT_DISABLE' marker --
+# this test only has value once the methods below are natively compiled.
+#
+# Guards the ARM64 move_freg_freg bug: it emitted
+#     fmov d10, x{src}   /   fmov x{dest}, d10
+# which addressed the GENERAL register file rather than the FP file, because
+# the Register enum restarts float numbering at D0 = 0. Every call therefore
+# did two wrong things -- the float move never happened, AND general-purpose
+# register X{dest} was overwritten with unrelated bits. When X{dest} held a
+# live pointer, the next use of it followed a float bit pattern as an address,
+# which is the "memory corruption of free block" / PC = 0x3F947AE147AE147B
+# crash signature.
+#
+# move_freg_freg is reached from the *_mem_freg emitters -- float ops where one
+# operand lives in memory (an instance variable or an array element) rather
+# than in a register. So this exercises exactly that shape: compare, add, sub,
+# mul and div with a memory operand, in a hot loop that crosses the auto-JIT
+# threshold.
+#
+# A regression surfaces as a WRONG VALUE (the move silently not happening),
+# not necessarily as a crash -- which is the point. The original bug hid for
+# weeks precisely because it usually corrupted something unrelated instead of
+# producing a visible wrong answer. Asserting exact values catches it on the
+# first iteration.
+~#
+use System;
+
+class JitFloatMemOps {
+	@fa : Float;
+	@fb : Float;
+	@arr : Float[];
+
+	New() {
+		@fa := 2.5;
+		@fb := 0.02;      # the literal from the original crash PC
+		@arr := Float->New[4];
+		@arr[0] := 1.25;
+		@arr[1] := 4.0;
+		@arr[2] := 0.5;
+		@arr[3] := 10.0;
+	}
+
+	# Each of these mixes a REGISTER float with a MEMORY float (instance var or
+	# array element), which is what routes through the *_mem_freg emitters.
+	method : AddMem(x : Float) ~ Float { return x + @fa; }
+	method : SubMem(x : Float) ~ Float { return x - @fa; }
+	method : MulMem(x : Float) ~ Float { return x * @arr[0]; }
+	method : DivMem(x : Float) ~ Float { return x / @arr[2]; }
+	method : CmpMem(x : Float) ~ Bool  { return x < @arr[1]; }
+	method : CmpMem2(x : Float) ~ Bool { return x > @fb; }
+
+	# Interleaves float memory ops with an object reference that stays live
+	# ACROSS them. Under the bug a clobbered general register could land on
+	# this reference; dereferencing it afterwards is the crash path.
+	method : LiveRefAcross(x : Float) ~ Int {
+		holder := @arr;
+		v := x + @fa;
+		v := v * @arr[0];
+		if(v > @fb) { v := v - @fa; };
+		return holder->Size();
+	}
+
+	function : Main(args : String[]) ~ Nil {
+		t := JitFloatMemOps->New();
+		pass := true;
+
+		# Hot loop: cross the auto-JIT threshold, then keep asserting so a
+		# post-compile regression is caught, not just the interpreted path.
+		i := 0;
+		while(i < 50000) {
+			if(t->AddMem(1.5) <> 4.0)      { pass := false; };
+			if(t->SubMem(4.0) <> 1.5)      { pass := false; };
+			if(t->MulMem(4.0) <> 5.0)      { pass := false; };
+			if(t->DivMem(2.0) <> 4.0)      { pass := false; };
+			if(t->CmpMem(1.0) = false)     { pass := false; };   # 1.0 < 4.0
+			if(t->CmpMem(9.0))             { pass := false; };   # 9.0 < 4.0 is false
+			if(t->CmpMem2(1.0) = false)    { pass := false; };   # 1.0 > 0.02
+			if(t->LiveRefAcross(1.5) <> 4) { pass := false; };
+			if(pass = false) {
+				"  FAIL: wrong result at iteration {$i}"->PrintLine();
+				i := 50000;
+			};
+			i += 1;
+		};
+
+		if(pass) {
+			"PASS: JIT float memory ops"->PrintLine();
+		}
+		else {
+			"FAIL: JIT float memory ops"->PrintLine();
+			# The runners grade on EXIT CODE, never on output text.
+			Runtime->Exit(1);
+		};
+	}
+}


### PR DESCRIPTION
Very likely the **root cause** of the open *"BUG IN CLIENT OF LIBMALLOC: memory corruption of free block"* investigation. The handoff doc on `investigate/jit-malloc-corruption` named this exact function as the prime suspect after ruling out everything else.

## The bug

`move_freg_freg` bridged through a GP register pair:

```
0x9E67000A | (src << 5)   fmov d10, x{src}    <- reads the GENERAL file
0x9E660140 | dest         fmov x{dest}, d10   <- writes the GENERAL file
```

The `Register` enum restarts float numbering at **`D0 = 0`**, so these addressed `X{src}`/`X{dest}`, not `D{src}`/`D{dest}`.

Floats genuinely live in the FP file here — `move_mem_freg` emits `LDR Dt` (`0xFD400000`), `move_freg_mem` emits `STR Dt`, `cmp_freg_freg` emits `FCMP Dn,Dm`. So **every call did two wrong things**: the float move never happened, and general-purpose register `X{dest}` was overwritten with unrelated bits.

When `X{dest}` held a live pointer, the next use of that value followed a float bit pattern as an address.

## Why this matches the investigation exactly

The doc had already eliminated the GC, the write barrier, moving collection, stack overflow, and wild store bases, converging on:

> *"a valid base and a valid in-bounds offset — what is wrong is the **VALUE**"*

with a crash PC of `0x3F947AE147AE147B` — the IEEE-754 bits of the double `0.02`. A clobbered GP register produces precisely that.

## The fix

A single `fmov D{dest}, D{src}`. The encoding isn't invented here — **the same file already uses `0x1E604000 | (src << 5) | dest` at three other sites**, with matching comments.

**Verified by disassembly (capstone)**, for a requested `D3 → D5` move:

| | emitted |
|---|---|
| before | `fmov d10, x3` + `fmov x5, d10` |
| after | `fmov d5, d3` |

AMD64 is unaffected — `move_xreg_xreg` correctly emits `movsd xmm,xmm`.

## What is NOT verified

**Runtime.** This box is x64, so the SDL stress repro needs ARM64 hardware. The ARM64 VM config compiles cleanly here and in CI.

Before closing the investigation, someone on Apple Silicon should run the headless repro from the doc — `YOUNG_REGION_SIZE` 32 KB + `OBJECK_JIT_THRESHOLD=1` on `2d_game_13.obe`, which crashed within a few of ~10 runs — and confirm it's clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
