### PR TITLE
fix(deploy): stop shipping a DirectML.dll older than the one Windows provides

### DIFF
--- a/core/release/deploy_windows.cmd
+++ b/core/release/deploy_windows.cmd
@@ -620,8 +620,22 @@ if [%1] == [x64] (
 	) else (
 		echo Warning: OnnxRuntime.DirectML nuget packages not found - ONNX runtime unavailable
 	)
-	if exist packages\Microsoft.AI.DirectML.1.15.4\bin\x64-win\DirectML.dll (
-		copy /y packages\Microsoft.AI.DirectML.1.15.4\bin\x64-win\DirectML.dll ..\..\release\%TARGET%\bin
+	REM DirectML.dll is an OS component on Windows 10 1903+, and Windows ships a
+	REM NEWER build than the vendored package (OS 1.15.5 vs package 1.15.4 as of
+	REM 2026-08). Windows loads an app-local DLL ahead of System32, so copying the
+	REM package unconditionally DOWNGRADES a working install -- the likely cause of
+	REM GPU inference failing at a Gather node. Ship the redistributable only when
+	REM the OS does not provide one.
+	if exist "%SystemRoot%\System32\DirectML.dll" (
+		echo Using the OS DirectML.dll ^(System32^) - not shipping the older redistributable
+		if exist ..\..\release\%TARGET%\bin\DirectML.dll del /q ..\..\release\%TARGET%\bin\DirectML.dll
+	) else (
+		if exist packages\Microsoft.AI.DirectML.1.15.4\bin\x64-win\DirectML.dll (
+			echo No OS DirectML.dll - shipping the vendored redistributable
+			copy /y packages\Microsoft.AI.DirectML.1.15.4\bin\x64-win\DirectML.dll ..\..\release\%TARGET%\bin
+		) else (
+			echo Warning: no OS DirectML.dll and no vendored package - GPU inference unavailable
+		)
 	)
 )
 cd ..\..\release


### PR DESCRIPTION
`deploy_windows.cmd` copied `DirectML.dll` from the vendored `Microsoft.AI.DirectML.1.15.4` package **unconditionally**. Windows 10 1903+ ships DirectML as an OS component, and System32 here has **1.15.5** — newer. Since Windows resolves an app-local DLL ahead of System32, **the deploy downgraded a working install**.

That is very likely what produced the GPU inference failure at a `Gather` node earlier in development. The currently deployed `DirectML.dll` is 1.15.5 (identical to System32's), and with it the DML provider works:

```
available execution providers (2):
  DmlExecutionProvider
  CPUExecutionProvider
```

A fresh deploy would have replaced that with 1.15.4.

## The fix

Ship the redistributable **only when the OS does not provide one**, and remove a stale copy left by an earlier deploy.

Ordering is preserved and matters: this runs *after* the `OnnxRuntime.DirectML` `*.dll` copy, so it cleans up regardless of what that brings in — though that package in fact contains only `onnxruntime.dll` and `onnxruntime_providers_shared.dll`, making this block the sole source of `DirectML.dll` in the deploy.

## Not run here

`deploy_windows.cmd` wipes `deploy-x64` unconditionally *before* its VS-environment check, so it can't be exercised safely from a normal shell. The change is a guarded copy introducing no new commands, and the paths were verified character by character after an earlier escaping attempt mangled them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)