### PR TITLE
fix(onnx): ONNX session creation was broken on Linux and MSYS2

### DIFF
--- a/core/lib/onnx/eq/build.sh
+++ b/core/lib/onnx/eq/build.sh
@@ -33,7 +33,12 @@ case "$PROVIDER" in
 	cpu)
 		EP_DEFINE=""
 		ORT_INCLUDE="-I./cuda/lib/include"
-		ORT_LIB="-lonnxruntime"
+		# Use the VENDORED runtime, same as the cuda case. This previously said
+		# just -lonnxruntime, which requires a system-installed onnxruntime and
+		# fails to link on a machine that has none -- even though a usable
+		# runtime is sitting in cuda/lib/x64/lib. That runtime is CPU-only, so
+		# it is exactly the right one for this mode.
+		ORT_LIB="-L./cuda/lib/x64/lib -lonnxruntime"
 		;;
 	*)
 		echo "Unknown provider: $PROVIDER"

--- a/core/lib/onnx/eq/onnx.cpp
+++ b/core/lib/onnx/eq/onnx.cpp
@@ -82,6 +82,39 @@ extern "C" {
 #if defined(ONNX_EP_DML)
          const std::string compiled_ep = "dml";
 #elif defined(ONNX_EP_CUDA)
+         const std::string compiled_ep = "cuda";
+#elif defined(ONNX_EP_QNN)
+         const std::string compiled_ep = "qnn";
+#elif defined(ONNX_EP_VITIS)
+         const std::string compiled_ep = "vitisai";
+#elif defined(ONNX_EP_COREML)
+         const std::string compiled_ep = "coreml";
+#else
+         const std::string compiled_ep = "cpu";
+#endif
+
+         const bool use_cpu = (requested_ep == "cpu");
+         if(!requested_ep.empty() && !use_cpu && requested_ep != compiled_ep) {
+            std::wcerr << L">>> ONNX: execution provider '" << BytesToUnicode(requested_ep)
+                       << L"' was requested, but this build provides '"
+                       << BytesToUnicode(compiled_ep)
+                       << L"'. Use ep=" << BytesToUnicode(compiled_ep)
+                       << L" or ep=cpu. <<<" << std::endl;
+            return;
+         }
+
+         Ort::SessionOptions session_options;
+
+#if defined(ONNX_EP_DML)
+         if(provider_options.find("device_id") == provider_options.end()) {
+            provider_options["device_id"] = "0";
+         }
+         if(!use_cpu) session_options.AppendExecutionProvider("DML", provider_options);
+         session_options.SetExecutionMode(ExecutionMode::ORT_PARALLEL);
+         session_options.DisableMemPattern();
+         session_options.SetIntraOpNumThreads(std::thread::hardware_concurrency());
+
+#elif defined(ONNX_EP_CUDA)
          if(!use_cpu) {
             // Two separate traps here, both verified against the vendored
             // runtime on Linux:
@@ -125,46 +158,6 @@ extern "C" {
             cuda_options.device_id = atoi(provider_options["device_id"].c_str());
             session_options.AppendExecutionProvider_CUDA(cuda_options);
          }
-         session_options.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
-         session_options.SetExecutionMode(ExecutionMode::ORT_PARALLEL);
-         session_options.DisableMemPattern();
-
-#elif defined(ONNX_EP_QNN)
-         const std::string compiled_ep = "qnn";
-#elif defined(ONNX_EP_VITIS)
-         const std::string compiled_ep = "vitisai";
-#elif defined(ONNX_EP_COREML)
-         const std::string compiled_ep = "coreml";
-#else
-         const std::string compiled_ep = "cpu";
-#endif
-
-         const bool use_cpu = (requested_ep == "cpu");
-         if(!requested_ep.empty() && !use_cpu && requested_ep != compiled_ep) {
-            std::wcerr << L">>> ONNX: execution provider '" << BytesToUnicode(requested_ep)
-                       << L"' was requested, but this build provides '"
-                       << BytesToUnicode(compiled_ep)
-                       << L"'. Use ep=" << BytesToUnicode(compiled_ep)
-                       << L" or ep=cpu. <<<" << std::endl;
-            return;
-         }
-
-         Ort::SessionOptions session_options;
-
-#if defined(ONNX_EP_DML)
-         if(provider_options.find("device_id") == provider_options.end()) {
-            provider_options["device_id"] = "0";
-         }
-         if(!use_cpu) session_options.AppendExecutionProvider("DML", provider_options);
-         session_options.SetExecutionMode(ExecutionMode::ORT_PARALLEL);
-         session_options.DisableMemPattern();
-         session_options.SetIntraOpNumThreads(std::thread::hardware_concurrency());
-
-#elif defined(ONNX_EP_CUDA)
-         if(provider_options.find("device_id") == provider_options.end()) {
-            provider_options["device_id"] = "0";
-         }
-         if(!use_cpu) session_options.AppendExecutionProvider("CUDA", provider_options);
          session_options.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
          session_options.SetExecutionMode(ExecutionMode::ORT_PARALLEL);
          session_options.DisableMemPattern();

--- a/core/lib/onnx/eq/onnx.cpp
+++ b/core/lib/onnx/eq/onnx.cpp
@@ -82,7 +82,53 @@ extern "C" {
 #if defined(ONNX_EP_DML)
          const std::string compiled_ep = "dml";
 #elif defined(ONNX_EP_CUDA)
-         const std::string compiled_ep = "cuda";
+         if(!use_cpu) {
+            // Two separate traps here, both verified against the vendored
+            // runtime on Linux:
+            //
+            //  1. The GENERIC string form does not accept "CUDA". ORT only
+            //     recognises OPENVINO/SNPE/XNNPACK/QNN/WEBNN/AZURE there, so
+            //     AppendExecutionProvider("CUDA", ...) always threw -- and its
+            //     message does not even mention CUDA, which is why this went
+            //     unnoticed. CUDA requires the typed entry point.
+            //  2. The provider may not be compiled into the linked runtime at
+            //     all. The vendored libonnxruntime.so.1.19.0 reports only
+            //     CPUExecutionProvider despite living under cuda/lib.
+            //
+            // Check availability first so the error names the real problem, and
+            // fail rather than fall back: a session that quietly ran on CPU
+            // when CUDA was asked for is indistinguishable from success.
+            bool cuda_available = false;
+            std::string available_list;
+            const std::vector<std::string> avail = Ort::GetAvailableProviders();
+            for(size_t i = 0; i < avail.size(); ++i) {
+               if(avail[i] == "CUDAExecutionProvider") {
+                  cuda_available = true;
+               }
+               if(!available_list.empty()) {
+                  available_list += ", ";
+               }
+               available_list += avail[i];
+            }
+
+            if(!cuda_available) {
+               std::wcerr << L">>> ONNX: this build requests the CUDA execution provider, but the "
+                          << L"linked onnxruntime does not provide it. Available: "
+                          << BytesToUnicode(available_list)
+                          << L". Rebuild the native library with './build.sh cpu', or link a "
+                          << L"CUDA-enabled onnxruntime. <<<" << std::endl;
+               return;
+            }
+
+            OrtCUDAProviderOptions cuda_options;
+            memset(&cuda_options, 0, sizeof(cuda_options));
+            cuda_options.device_id = atoi(provider_options["device_id"].c_str());
+            session_options.AppendExecutionProvider_CUDA(cuda_options);
+         }
+         session_options.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
+         session_options.SetExecutionMode(ExecutionMode::ORT_PARALLEL);
+         session_options.DisableMemPattern();
+
 #elif defined(ONNX_EP_QNN)
          const std::string compiled_ep = "qnn";
 #elif defined(ONNX_EP_VITIS)

--- a/core/release/deploy_msys2-clang.sh
+++ b/core/release/deploy_msys2-clang.sh
@@ -73,7 +73,13 @@ cd ../diags
 cp diags.dll ../../release/deploy-msys2-clang/lib/native/libobjk_diags.dll
 
 cd ../onnx/eq
-CXX=clang++ ./build.sh cuda
+CXX=clang++ # The vendored libonnxruntime here is a CPU-ONLY build -- it reports only
+# CPUExecutionProvider despite living under eq/cuda/lib. Building with
+# ONNX_EP_CUDA therefore made every session creation fail, and because the
+# catch returned without setting the session handle it surfaced as a silently
+# null session rather than an error. Link a CUDA-enabled onnxruntime before
+# switching this back to cuda.
+./build.sh cpu
 cp libobjk_onnx.dll ../../../release/deploy-msys2-clang/lib/native/libobjk_onnx.dll
 
 cd ../../utils/launcher

--- a/core/release/deploy_msys2-ucrt.sh
+++ b/core/release/deploy_msys2-ucrt.sh
@@ -73,7 +73,13 @@ cd ../diags
 cp diags.dll ../../release/deploy-msys2-ucrt/lib/native/libobjk_diags.dll
 
 cd ../onnx/eq
-./build.sh cuda
+# The vendored libonnxruntime here is a CPU-ONLY build -- it reports only
+# CPUExecutionProvider despite living under eq/cuda/lib. Building with
+# ONNX_EP_CUDA therefore made every session creation fail, and because the
+# catch returned without setting the session handle it surfaced as a silently
+# null session rather than an error. Link a CUDA-enabled onnxruntime before
+# switching this back to cuda.
+./build.sh cpu
 cp libobjk_onnx.dll ../../../release/deploy-msys2-ucrt/lib/native/libobjk_onnx.dll
 
 cd ../../utils/launcher

--- a/core/release/deploy_posix.sh
+++ b/core/release/deploy_posix.sh
@@ -81,7 +81,13 @@ cd ../opencv
 cp opencv.so ../../release/deploy/lib/native/libobjk_opencv.so
 
 cd ../onnx/eq
-./build.sh cuda
+# The vendored libonnxruntime here is a CPU-ONLY build -- it reports only
+# CPUExecutionProvider despite living under eq/cuda/lib. Building with
+# ONNX_EP_CUDA therefore made every session creation fail, and because the
+# catch returned without setting the session handle it surfaced as a silently
+# null session rather than an error. Link a CUDA-enabled onnxruntime before
+# switching this back to cuda.
+./build.sh cpu
 cp libobjk_onnx.so ../../../release/deploy/lib/native/libobjk_onnx.so
 
 # copy ONNX Runtime shared libraries


### PR DESCRIPTION
Verified in WSL2 against the vendored runtime — not inferred. **Three defects compounding into one silent failure.**

### 1. `AppendExecutionProvider("CUDA", …)` always threw

ORT's generic string form doesn't accept CUDA — it recognises only OPENVINO, SNPE, XNNPACK, QNN, WEBNN and AZURE. CUDA needs the typed entry point. **The thrown message doesn't even mention CUDA**, which is why this was never diagnosed:

```
Unknown provider name. Currently supported values are 'OPENVINO', 'SNPE',
'XNNPACK', 'QNN', 'WEBNN' and 'AZURE'
```

### 2. The vendored runtime is CPU-only

Despite living under `eq/cuda/lib`, `libonnxruntime.so.1.19.0` returns exactly `CPUExecutionProvider` from `GetAvailableProviders()`. So even the typed API couldn't have worked. Meanwhile `deploy_posix.sh` and both `deploy_msys2-*.sh` built with `./build.sh cuda` → `-DONNX_EP_CUDA`, guaranteeing the throw on **every** session creation.

### 3. It failed silently

The `catch` returns without `APITools_SetIntValue`, so callers got a **null session rather than an error**. That's why a total failure of ONNX on Linux went unnoticed.

## Fixes

- CUDA branch checks `GetAvailableProviders()` **before** appending, refuses with a message naming what's actually available, and uses the **typed** `AppendExecutionProvider_CUDA`. It refuses rather than falling back — a session that quietly ran on CPU when CUDA was asked for is indistinguishable from success.
- POSIX/MSYS2 deploys build `./build.sh cpu`, matching the CPU-only runtime they ship.
- `build.sh`'s **cpu mode linked a bare `-lonnxruntime` with no `-L`**, requiring a system-installed runtime and failing to link without one — even though a usable runtime sits in `cuda/lib/x64/lib`. Now uses the vendored one.

## Verified in WSL2 (Ubuntu 24.04)

| | result |
| --- | --- |
| **old** | THREW: *Unknown provider name. Currently supported values are 'OPENVINO', 'SNPE', 'XNNPACK', 'QNN', 'WEBNN' and 'AZURE'* |
| **new** | *CUDA requested but linked onnxruntime does not provide it. Available: CPUExecutionProvider* |

**Not verified:** a full native Linux build — `onnx.cpp` needs OpenCV headers, absent from this WSL2. The provider logic was exercised standalone against the real runtime; the Windows DML build compiles clean.

Note `libonnxruntime.so` / `.so.1` are checked out as 19- and 24-byte text files rather than symlinks (NTFS artifact) — harmless on a native Linux clone, but it breaks a WSL2 build over `/mnt/c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
