### PR TITLE
ci: build the native ONNX library on linux-x64

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -616,6 +616,34 @@ jobs:
     # Regression Tests
     # ============================================
 
+    - name: Build native ONNX library (Linux x64)
+      if: matrix.platform == 'linux-x64'
+      working-directory: ./core/lib/onnx/eq
+      shell: bash
+      run: |
+        # The C++ that actually talks to ONNX Runtime was built by NO job on any
+        # platform -- CI only compiled onnx.obs -> onnx.obl. That blind spot is how
+        # ONNX came to be completely broken on Linux and MSYS2 (the CUDA arm called
+        # AppendExecutionProvider("CUDA", ...), which ORT rejects, and the catch
+        # returned without setting the session handle, so it surfaced as a silently
+        # null session rather than an error).
+        #
+        # Both arms are built deliberately: they are separate #elif branches, so a
+        # build of one proves nothing about the other. A broken CUDA branch once
+        # passed a clean Windows build for exactly that reason -- Windows compiles
+        # only the DML arm.
+        chmod +x build.sh
+        for mode in cpu cuda; do
+          echo "=== build.sh $mode ==="
+          rm -f libobjk_onnx.so
+          ./build.sh "$mode"
+          if [ ! -f libobjk_onnx.so ]; then
+            echo "::error::native ONNX build ($mode) produced no library"
+            exit 1
+          fi
+          echo "  libobjk_onnx.so: $(stat -c%s libobjk_onnx.so) bytes"
+        done
+
     - name: Run regression tests (POSIX)
       if: runner.os != 'Windows' && matrix.platform != 'windows-arm64'
       working-directory: ./programs/regression


### PR DESCRIPTION
The C++ that actually talks to ONNX Runtime was built by **no job on any platform** — CI only compiled `onnx.obs` → `onnx.obl`.

That blind spot is how ONNX came to be **completely broken on Linux and MSYS2**: the CUDA arm called `AppendExecutionProvider("CUDA", …)`, which ORT rejects outright, and the `catch` returned without setting the session handle — so a total failure surfaced as a silently null session rather than an error (#628).

## Builds both arms, deliberately

`cpu` and `cuda` are separate `#elif` branches, so **building one proves nothing about the other**. A broken CUDA branch passed a clean Windows build earlier today for exactly that reason — Windows compiles only the DML arm.

Building both would have caught the original defect *and* my first attempt at fixing it.

## Why gating rather than `continue-on-error`

It's a deterministic compile: no network, no GPU, no model downloads. `libopencv-dev` is already installed on the Linux legs (`ci-build.yml:100`) and the ONNX Runtime is vendored in-tree.

## Not covered

Windows and macOS native ONNX libs are built by deploy scripts rather than CI. Extending this there is worthwhile but needs the nuget restore and Xcode paths respectively — left as a follow-up rather than bundled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
