### PR TITLE
revert(repl): F5 worker thread deadlocked — restore synchronous run

### DIFF
--- a/core/repl/tui_editor.h
+++ b/core/repl/tui_editor.h
@@ -13,9 +13,6 @@
 #include "screen.h"
 #include "keymap.h"
 #include <functional>
-#include <thread>
-#include <atomic>
-#include <memory>
 #include <vector>
 #include <cwctype>
 
@@ -48,10 +45,6 @@ namespace Tui {
     bool dirty;
     bool quit_armed;     // set by a first Ctrl+Q with unsaved changes
     std::wstring status; // transient message; cleared by the next key
-    // Set once a run has been abandoned. The worker cannot be killed mid-VM,
-    // only detached, and it still holds the process-wide fd redirect -- so a
-    // second run would corrupt both the screen and the captured output.
-    bool run_abandoned = false;
 
     // run pane: compile-and-execute output, shown below the text area
     std::function<bool(std::wstring&)> runner;
@@ -748,66 +741,24 @@ namespace Tui {
         status = L"running is not available here";
         return;
       }
-      if(run_abandoned) {
-        status = L"an abandoned run is still going -- restart obi to run again";
-        return;
-      }
 
-      // The capture inside `runner` redirects fd 1 and 2 PROCESS-WIDE, so the
-      // screen must not be painted while it is active: a repaint would land in
-      // the capture file, and the captured output would fill with escape
-      // sequences. Paint the notice first, then stay quiet until it finishes.
-      status = L"running...  Esc abandons";
-      Draw();
+      // Reverted to a synchronous call. Moving the run to a worker thread
+      // deadlocked even a trivial program: the in-process VM has main-thread
+      // affinity (process-global Loader/MemoryManager/StackInterpreter state
+      // plus its own GC threads), so it cannot be driven off the UI thread.
+      // A looping program still freezes obi here -- the real fix is running
+      // the program as a SUBPROCESS (docs/OBI_EDITOR_RUN_PLAN.md). What IS
+      // kept: the console-capture fix in io_capture.h (so output reaches the
+      // pane on Windows) and the screen invalidation below (so the editor
+      // repaints instead of appearing frozen after a run).
+      std::wstring output;
+      const bool ok = runner(output);
 
-      // Shared state is heap-allocated on purpose. If the user abandons the
-      // run we detach the worker, and a detached thread writing into this
-      // frame's locals would be a use-after-scope.
-      struct RunState {
-        std::wstring output;
-        bool ok = false;
-        std::atomic<bool> finished{false};
-      };
-      auto state = std::make_shared<RunState>();
-      auto fn = runner;
-      std::thread worker([state, fn]() {
-        state->ok = fn(state->output);
-        state->finished.store(true, std::memory_order_release);
-      });
-
-      // ReadKey already returns a KEY_NONE tick on a ~100 ms timeout on both
-      // platforms (Windows WaitForSingleObject; POSIX VMIN=0/VTIME=1), so this
-      // stays responsive without any terminal-layer change.
-      bool abandoned = false;
-      while(!state->finished.load(std::memory_order_acquire)) {
-        const Key key = term.ReadKey();
-        if(key.code == KEY_ESC) {
-          abandoned = true;
-          break;
-        }
-      }
-
-      if(abandoned) {
-        worker.detach();
-        run_abandoned = true;
-        status = L"run abandoned; it continues in the background";
-        return;
-      }
-
-      worker.join();
-
-      // The program may have written straight to the terminal behind the
-      // diff's back -- on Windows the VM prints via
-      // WinWriteWide(GetStdHandle(STD_OUTPUT_HANDLE), ...) (common.cpp:3381),
-      // which a CRT fd redirect cannot intercept. `front` then still describes
-      // an editor that is no longer on screen and the next Flush emits almost
-      // nothing, which reads as a frozen UI. Forget the front buffer and
-      // repaint everything.
+      // The program may have written to the terminal behind the diff's back;
+      // forget the front buffer and repaint everything.
       term.Clear();
       screen.Invalidate();
 
-      std::wstring& output = state->output;
-      const bool ok = state->ok;
 
       // split into pane lines; diagnostics look like 'name:(line,col): text'
       pane.clear();


### PR DESCRIPTION
**Urgent — master currently hangs obi on any F5 run.** #630 merged the worker-thread F5 change; it wedges obi on *any* program, including a trivial `7->PrintLine()`. CI passed because it can't drive a TTY, so a merge armed on green approved a change green CI could not validate.

**Root cause:** the in-process VM has **main-thread affinity** — process-global `Loader`/`MemoryManager`/`StackInterpreter` state plus its own GC threads — so it cannot be run off the UI thread at all. A worker was the wrong tool.

## This change

- `DoRun()` restored to a **synchronous** `runner()` call; `<thread>/<atomic>/<memory>` and `run_abandoned` removed.
- **Keeps** the two genuinely-correct fixes from #630, which are independent: `Screen::Invalidate()` after a run (editor repaints instead of appearing frozen) and the `io_capture.h` `SetStdHandle` capture (program output reaches the pane on Windows).

## Interim behavior

Normal programs run and show output. A **looping** program still freezes the editor — the original limitation — until F5 is reworked as a **subprocess**, which the main-thread-affinity finding makes mandatory (designed in `docs/OBI_EDITOR_RUN_PLAN.md`; full plan approved). This revert is strictly better than the merged regression, which hung even trivial input.

**Verified:** `obi.exe` builds clean via `core/repl/repl.sln`.

⚠️ **Do not arm a CI-green auto-merge for obi F5 changes** — that is exactly what put the regression on master. This needs manual TTY sign-off; merge it directly once you've confirmed `7->PrintLine()` no longer hangs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)