### PR TITLE
feat(repl): run F5 as a subprocess, and round out the editor

### DIFF
--- a/core/repl/EDITOR_DESIGN.md
+++ b/core/repl/EDITOR_DESIGN.md
@@ -1,5 +1,34 @@
 # Full-screen editor for `obi` — design
 
+> **STATUS (branch `feat/obi-editor-subprocess-and-quality`).** Phases 1–4 are
+> implemented. Two design points below are now superseded:
+>
+> - **Run is a subprocess, not in-process.** F5 saves the buffer to a temp
+>   `.obs`, compiles it with `obc`, then runs the `.obe` with `obr` — each a
+>   child process whose merged stdout/stderr the pane drains without blocking
+>   (`child_run.h`, `tui_editor.h::DoRun`). The in-process VM has main-thread
+>   affinity and would deadlock if driven off the UI thread, so "a run pane does
+>   not need a subprocess" (below) no longer holds. `io_capture.h` is retired
+>   from the F5 path (kept in tree for any other in-process capture).
+> - **Syntax highlighting is live.** The compiler's own `Scanner` (already
+>   linked) colors the buffer — keywords cyan, numbers yellow, strings green —
+>   cached per document version (`highlight.h`).
+>
+> Also landed: smart auto-indent on Enter; a modest vi round-out (`w b A I O D`
+> on top of the existing `hjkl 0 $ G gg x dd yy p u Ctrl-r i a o v`); and fixes
+> for the linewise-paste read-only bypass, `want_col` display-column tracking,
+> `Prompt` resize handling, and a `.obs` extension on editor saves.
+>
+> **Deferred, on purpose (not built):** OS clipboard integration; incremental
+> highlight caching (currently a full rescan per edit — fine for REPL-sized
+> buffers); full vi (`d{motion}` composition, `:` ex commands, `/` search,
+> counts, registers); multi-line-string and comment coloring (the scanner
+> reports a multi-line string at its closing quote and never emits comment
+> tokens, so both are left uncolored rather than guessed); char-literal coloring
+> (unreliable token position); find / goto-line; mouse.
+>
+> CI cannot exercise `/e` (no TTY); the gate is a manual terminal matrix.
+
 `obi` today edits by line. `Document`/`Line` hold the buffer and `DoInsertLine`,
 `DoDeleteLine`, `DoReplaceLine`, `DoGotoLine`, `DoList` operate on it through an
 `ed`-style command loop that reads whole lines from `std::wcin`. This note

--- a/core/repl/child_run.h
+++ b/core/repl/child_run.h
@@ -1,0 +1,427 @@
+/***************************************************************************
+ * Spawns and drains a child process for the editor's run pane (editor
+ * phase 4).
+ *
+ * Copyright (c) 2026, Randy Hollines
+ * All rights reserved.
+ ***************************************************************************/
+
+#ifndef __TUI_CHILD_RUN_H__
+#define __TUI_CHILD_RUN_H__
+
+#include <string>
+#include <vector>
+#include <utility>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <cerrno>
+#endif
+
+// The in-process VM has main-thread affinity (process-global Loader/
+// MemoryManager/StackInterpreter plus its own GC threads), so a program run
+// on a worker thread deadlocks even trivial code. F5 therefore compiles and
+// runs the buffer as a real child process instead: its stdout and stderr are
+// merged into a pipe the editor drains without blocking, so the UI stays live,
+// Esc can kill a runaway loop, and the child gets its own console/JIT that obi
+// itself (built _NO_JIT) lacks.
+//
+// The program path and arguments come from a user buffer, so the child is
+// spawned from an explicit argument vector with NO shell (mirroring obu's
+// RunArgv): nothing in argv is ever reinterpreted, which is the whole defense
+// against a filename or argument carrying shell metacharacters.
+
+namespace Tui {
+
+  // narrow a wide string to UTF-8 by hand -- the C locale must not get a say
+  // (this repo has been bitten by locale-dependent conversions before)
+  inline std::string ChildToUtf8(const std::wstring& text) {
+    std::string bytes;
+    bytes.reserve(text.size() * 2);
+    for(const wchar_t wc : text) {
+      const unsigned int cp = (unsigned int)wc;
+      if(cp < 0x80) {
+        bytes += (char)cp;
+      }
+      else if(cp < 0x800) {
+        bytes += (char)(0xC0 | (cp >> 6));
+        bytes += (char)(0x80 | (cp & 0x3F));
+      }
+      else if(cp < 0x10000) {
+        bytes += (char)(0xE0 | (cp >> 12));
+        bytes += (char)(0x80 | ((cp >> 6) & 0x3F));
+        bytes += (char)(0x80 | (cp & 0x3F));
+      }
+      else {
+        bytes += (char)(0xF0 | (cp >> 18));
+        bytes += (char)(0x80 | ((cp >> 12) & 0x3F));
+        bytes += (char)(0x80 | ((cp >> 6) & 0x3F));
+        bytes += (char)(0x80 | (cp & 0x3F));
+      }
+    }
+    return bytes;
+  }
+
+  class Child {
+    bool running;
+    int exit_code;
+#ifdef _WIN32
+    HANDLE proc;
+    HANDLE read_pipe;   // our (non-inheritable) read end of the child's output
+#else
+    pid_t pid;
+    int read_fd;        // our non-blocking read end of the child's output
+#endif
+
+#ifdef _WIN32
+    // CreateProcess wants one command line, not an argv, so each argument is
+    // requoted per the CRT's parsing rules (backslashes only matter before a
+    // quote). Without this a temp path with a space would split into two args.
+    static std::wstring QuoteArg(const std::wstring& arg) {
+      if(!arg.empty() && arg.find_first_of(L" \t\"") == std::wstring::npos) {
+        return arg;
+      }
+      std::wstring out = L"\"";
+      for(size_t i = 0; i < arg.size(); ++i) {
+        size_t slashes = 0;
+        while(i < arg.size() && arg[i] == L'\\') {
+          ++slashes;
+          ++i;
+        }
+        if(i == arg.size()) {
+          out.append(slashes * 2, L'\\');   // trailing: double so the closing " stays literal
+          break;
+        }
+        if(arg[i] == L'"') {
+          out.append(slashes * 2 + 1, L'\\');
+          out += L'"';
+        }
+        else {
+          out.append(slashes, L'\\');
+          out += arg[i];
+        }
+      }
+      out += L'"';
+      return out;
+    }
+
+    // Build a fresh environment block from the parent's, overriding (or adding)
+    // the requested names. Done as a copy rather than SetEnvironmentVariable so
+    // obi's own environment -- which its in-process paths also read -- is left
+    // untouched.
+    static std::vector<wchar_t> BuildEnvBlock(const std::vector<std::pair<std::wstring, std::wstring>>& overrides) {
+      std::vector<wchar_t> block;
+      const wchar_t* parent = GetEnvironmentStringsW();
+      if(parent) {
+        for(const wchar_t* p = parent; *p; ) {
+          const std::wstring entry(p);
+          p += entry.size() + 1;
+          const size_t eq = entry.find(L'=');
+          const std::wstring name = (eq == std::wstring::npos) ? entry : entry.substr(0, eq);
+          bool overridden = false;
+          for(const auto& over : overrides) {
+            if(_wcsicmp(name.c_str(), over.first.c_str()) == 0) {
+              overridden = true;
+              break;
+            }
+          }
+          // keep everything not overridden -- including the legacy "=X:" drive
+          // current-directory entries, whose name is empty and must survive
+          if(!overridden) {
+            block.insert(block.end(), entry.begin(), entry.end());
+            block.push_back(L'\0');
+          }
+        }
+        FreeEnvironmentStringsW(const_cast<wchar_t*>(parent));
+      }
+      for(const auto& over : overrides) {
+        const std::wstring entry = over.first + L'=' + over.second;
+        block.insert(block.end(), entry.begin(), entry.end());
+        block.push_back(L'\0');
+      }
+      block.push_back(L'\0');   // block terminator
+      return block;
+    }
+#endif
+
+  public:
+    Child() : running(false), exit_code(-1) {
+#ifdef _WIN32
+      proc = INVALID_HANDLE_VALUE;
+      read_pipe = INVALID_HANDLE_VALUE;
+#else
+      pid = -1;
+      read_fd = -1;
+#endif
+    }
+
+    ~Child() {
+      Close();
+    }
+
+    // non-copyable: it owns OS handles
+    Child(const Child&) = delete;
+    Child& operator=(const Child&) = delete;
+
+    bool IsRunning() {
+      if(!running) {
+        return false;
+      }
+#ifdef _WIN32
+      if(WaitForSingleObject(proc, 0) == WAIT_OBJECT_0) {
+        DWORD code = 0;
+        GetExitCodeProcess(proc, &code);
+        exit_code = (int)code;
+        running = false;
+      }
+#else
+      int status = 0;
+      const pid_t got = waitpid(pid, &status, WNOHANG);
+      if(got == pid) {
+        exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : 128;
+        running = false;
+      }
+      else if(got < 0) {
+        running = false;
+      }
+#endif
+      return running;
+    }
+
+    int ExitCode() const {
+      return exit_code;
+    }
+
+    // Append whatever output is waiting, without blocking. Returns false only
+    // when the pipe is gone; an empty read is a normal "nothing yet".
+    bool Drain(std::string& out) {
+#ifdef _WIN32
+      if(read_pipe == INVALID_HANDLE_VALUE) {
+        return false;
+      }
+      for(;;) {
+        DWORD avail = 0;
+        if(!PeekNamedPipe(read_pipe, nullptr, 0, nullptr, &avail, nullptr)) {
+          return false;   // child closed the write end
+        }
+        if(avail == 0) {
+          break;
+        }
+        char buffer[4096];
+        const DWORD want = avail < sizeof(buffer) ? avail : (DWORD)sizeof(buffer);
+        DWORD got = 0;
+        if(!ReadFile(read_pipe, buffer, want, &got, nullptr) || got == 0) {
+          return false;
+        }
+        out.append(buffer, got);
+      }
+      return true;
+#else
+      if(read_fd < 0) {
+        return false;
+      }
+      char buffer[4096];
+      for(;;) {
+        const ssize_t got = read(read_fd, buffer, sizeof(buffer));
+        if(got > 0) {
+          out.append(buffer, (size_t)got);
+          continue;
+        }
+        if(got == 0) {
+          break;   // EOF: child closed the write end
+        }
+        if(errno == EINTR) {
+          continue;
+        }
+        break;     // EAGAIN/EWOULDBLOCK: nothing more for now
+      }
+      return true;
+#endif
+    }
+
+    // SIGTERM (then SIGKILL) on POSIX, TerminateProcess on Windows; reaps so no
+    // zombie is left behind. Used when the user presses Esc on a running loop.
+    void Kill() {
+      if(!running) {
+        return;
+      }
+#ifdef _WIN32
+      TerminateProcess(proc, 1);
+      WaitForSingleObject(proc, INFINITE);
+      DWORD code = 0;
+      GetExitCodeProcess(proc, &code);
+      exit_code = (int)code;
+      running = false;
+#else
+      kill(pid, SIGTERM);
+      for(int i = 0; i < 50; ++i) {
+        int status = 0;
+        if(waitpid(pid, &status, WNOHANG) == pid) {
+          exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : 128;
+          running = false;
+          return;
+        }
+        usleep(2000);   // 2ms; a well-behaved child dies on SIGTERM at once
+      }
+      kill(pid, SIGKILL);
+      int status = 0;
+      waitpid(pid, &status, 0);
+      exit_code = 128;
+      running = false;
+#endif
+    }
+
+    // Launches argv[0] with the given arguments and environment overrides. The
+    // child's stdin is the null device so a program that reads input sees EOF
+    // rather than stealing the editor's key bytes.
+    bool Start(const std::vector<std::wstring>& argv,
+               const std::vector<std::pair<std::wstring, std::wstring>>& env) {
+      if(argv.empty()) {
+        return false;
+      }
+#ifdef _WIN32
+      SECURITY_ATTRIBUTES sa;
+      sa.nLength = sizeof(sa);
+      sa.bInheritHandle = TRUE;
+      sa.lpSecurityDescriptor = nullptr;
+
+      HANDLE write_pipe = INVALID_HANDLE_VALUE;
+      if(!CreatePipe(&read_pipe, &write_pipe, &sa, 0)) {
+        read_pipe = INVALID_HANDLE_VALUE;
+        return false;
+      }
+      // the child must not inherit our read end, or the pipe never reports EOF
+      SetHandleInformation(read_pipe, HANDLE_FLAG_INHERIT, 0);
+
+      HANDLE nul = CreateFileW(L"NUL", GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                               &sa, OPEN_EXISTING, 0, nullptr);
+
+      STARTUPINFOW si;
+      ZeroMemory(&si, sizeof(si));
+      si.cb = sizeof(si);
+      si.dwFlags = STARTF_USESTDHANDLES;
+      si.hStdOutput = write_pipe;
+      si.hStdError = write_pipe;
+      si.hStdInput = nul;
+
+      std::wstring command;
+      for(size_t i = 0; i < argv.size(); ++i) {
+        if(i) {
+          command += L' ';
+        }
+        command += QuoteArg(argv[i]);
+      }
+      std::vector<wchar_t> cmd_buffer(command.begin(), command.end());
+      cmd_buffer.push_back(L'\0');
+
+      std::vector<wchar_t> env_block = BuildEnvBlock(env);
+
+      PROCESS_INFORMATION pi;
+      ZeroMemory(&pi, sizeof(pi));
+      const BOOL ok = CreateProcessW(nullptr, cmd_buffer.data(), nullptr, nullptr, TRUE,
+                                     CREATE_UNICODE_ENVIRONMENT | CREATE_NO_WINDOW,
+                                     env_block.data(), nullptr, &si, &pi);
+      // our copies of the child-side handles are done regardless of outcome
+      if(write_pipe != INVALID_HANDLE_VALUE) {
+        CloseHandle(write_pipe);
+      }
+      if(nul != INVALID_HANDLE_VALUE) {
+        CloseHandle(nul);
+      }
+      if(!ok) {
+        CloseHandle(read_pipe);
+        read_pipe = INVALID_HANDLE_VALUE;
+        return false;
+      }
+      CloseHandle(pi.hThread);
+      proc = pi.hProcess;
+      running = true;
+      return true;
+#else
+      int pipe_fds[2];
+      if(pipe(pipe_fds) != 0) {
+        return false;
+      }
+
+      // build the child-side argv (UTF-8) before forking; after fork only
+      // async-signal-safe work is allowed
+      std::vector<std::string> narrow;
+      narrow.reserve(argv.size());
+      for(const std::wstring& a : argv) {
+        narrow.push_back(ChildToUtf8(a));
+      }
+      std::vector<char*> c_argv;
+      c_argv.reserve(narrow.size() + 1);
+      for(std::string& a : narrow) {
+        c_argv.push_back(&a[0]);
+      }
+      c_argv.push_back(nullptr);
+
+      std::vector<std::pair<std::string, std::string>> narrow_env;
+      narrow_env.reserve(env.size());
+      for(const auto& e : env) {
+        narrow_env.push_back({ ChildToUtf8(e.first), ChildToUtf8(e.second) });
+      }
+
+      pid = fork();
+      if(pid < 0) {
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
+        return false;
+      }
+      if(pid == 0) {
+        close(pipe_fds[0]);
+        dup2(pipe_fds[1], STDOUT_FILENO);
+        dup2(pipe_fds[1], STDERR_FILENO);
+        close(pipe_fds[1]);
+        const int null_in = open("/dev/null", O_RDONLY);
+        if(null_in >= 0) {
+          dup2(null_in, STDIN_FILENO);
+          close(null_in);
+        }
+        for(const auto& e : narrow_env) {
+          setenv(e.first.c_str(), e.second.c_str(), 1);
+        }
+        execvp(c_argv[0], c_argv.data());
+        _exit(127);
+      }
+
+      close(pipe_fds[1]);
+      read_fd = pipe_fds[0];
+      const int flags = fcntl(read_fd, F_GETFL, 0);
+      fcntl(read_fd, F_SETFL, flags | O_NONBLOCK);
+      running = true;
+      return true;
+#endif
+    }
+
+  private:
+    void Close() {
+      if(running) {
+        Kill();
+      }
+#ifdef _WIN32
+      if(read_pipe != INVALID_HANDLE_VALUE) {
+        CloseHandle(read_pipe);
+        read_pipe = INVALID_HANDLE_VALUE;
+      }
+      if(proc != INVALID_HANDLE_VALUE) {
+        CloseHandle(proc);
+        proc = INVALID_HANDLE_VALUE;
+      }
+#else
+      if(read_fd >= 0) {
+        close(read_fd);
+        read_fd = -1;
+      }
+#endif
+    }
+  };
+}
+
+#endif

--- a/core/repl/editor.cpp
+++ b/core/repl/editor.cpp
@@ -40,8 +40,13 @@
 #include "term.h"
 #include "screen.h"
 #include "tui_editor.h"
-#include "io_capture.h"
+#include "child_run.h"
 #include <deque>
+#include <filesystem>
+
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#endif
 
 //
 // Document
@@ -551,6 +556,43 @@ void Editor::Edit(std::wstring input, std::wstring libs, std::wstring opt, int m
   std::wcout << "Goodbye." << std::endl;
 }
 
+namespace {
+  namespace fs = std::filesystem;
+
+  /****************************
+   * Directory of the running obi executable. obc/obr are its siblings in the
+   * same bin/ dir, so F5 finds them here rather than trusting PATH or argv[0]
+   * -- resolved from the OS so a PATH-launched obi still finds its own tools.
+   ****************************/
+  fs::path ExecutableDir()
+  {
+#if defined(_WIN32)
+    wchar_t buffer[MAX_PATH];
+    const DWORD len = GetModuleFileNameW(nullptr, buffer, MAX_PATH);
+    if(len == 0 || len == MAX_PATH) {
+      return fs::path();
+    }
+    return fs::path(std::wstring(buffer, len)).parent_path();
+#elif defined(__APPLE__)
+    char buffer[4096];
+    uint32_t size = sizeof(buffer);
+    if(_NSGetExecutablePath(buffer, &size) != 0) {
+      return fs::path();
+    }
+    std::error_code ec;
+    const fs::path resolved = fs::canonical(fs::path(buffer), ec);
+    return (ec ? fs::path(buffer) : resolved).parent_path();
+#else
+    std::error_code ec;
+    const fs::path self = fs::read_symlink("/proc/self/exe", ec);
+    if(ec) {
+      return fs::path();
+    }
+    return self.parent_path();
+#endif
+  }
+}
+
 /****************************
  * Opens the full-screen editor over the REPL buffer. Everything the line
  * commands can see, the editor edits in place, so '/l' and '/s' keep
@@ -569,18 +611,75 @@ void Editor::DoEdit()
     return;
   }
 
-  // F5 compiles and runs the buffer in-process; the capture keeps the
-  // program's output (and the VM's) off the raw-mode screen and hands it to
-  // the pane instead
-  auto run_program = [this](std::wstring& output) -> bool {
-    Tui::IoCapture capture;
-    if(!capture.Start()) {
-      output = L"unable to capture program output";
-      return false;
+  // F5 compiles the buffer with obc and runs the .obe with obr, each a child
+  // process. The in-process VM has main-thread affinity (it would deadlock if
+  // driven off the UI thread), and a child brings its own console plus the JIT
+  // this _NO_JIT build lacks. The editor view owns the responsive drain/cancel
+  // loop; here we only assemble the plan it runs.
+  auto run_program = [this]() -> Tui::RunPlan {
+    Tui::RunPlan plan;
+
+    const fs::path bin = ExecutableDir();
+    if(bin.empty()) {
+      plan.error = L"cannot locate obi's own directory";
+      return plan;
     }
-    const bool ok = DoExecute();
-    capture.Finish(output);
-    return ok;
+#ifdef _WIN32
+    const std::wstring exe = L".exe";
+#else
+    const std::wstring exe = L"";
+#endif
+    const std::wstring obc = (bin / (L"obc" + exe)).wstring();
+    const std::wstring obr = (bin / (L"obr" + exe)).wstring();
+
+    // a per-process temp pair, overwritten on each run rather than accumulating
+    std::error_code ec;
+    const fs::path temp_dir = fs::temp_directory_path(ec);
+    if(ec) {
+      plan.error = L"cannot find a temp directory for the run";
+      return plan;
+    }
+#ifdef _WIN32
+    const std::wstring tag = std::to_wstring(GetCurrentProcessId());
+#else
+    const std::wstring tag = std::to_wstring((long)getpid());
+#endif
+    const std::wstring temp_obs = (temp_dir / (L"obi-run-" + tag + L".obs")).wstring();
+    const std::wstring temp_obe = (temp_dir / (L"obi-run-" + tag + L".obe")).wstring();
+
+    if(!doc.Save(temp_obs)) {
+      plan.error = L"unable to write the temporary source file";
+      return plan;
+    }
+
+    // compile: obc -src <obs> -dest <obe> [-lib <libs>] [-opt <level>]. lang/
+    // collect are NOT prepended -- the compiler filters them out and supplies
+    // them from the system path itself; -lib/-opt are omitted when unset.
+    plan.compile_argv = { obc, L"-src", temp_obs, L"-dest", temp_obe };
+    if(!compiler_libs.empty()) {
+      plan.compile_argv.push_back(L"-lib");
+      plan.compile_argv.push_back(compiler_libs);
+    }
+    if(!compiler_opt_level.empty()) {
+      plan.compile_argv.push_back(L"-opt");
+      plan.compile_argv.push_back(compiler_opt_level);
+    }
+
+    // run: obr <obe> <cmd_args...>, split on whitespace (arguments with embedded
+    // spaces are not supported here, matching how the REPL stores cmd_args)
+    plan.run_argv = { obr, temp_obe };
+    std::wstringstream args(cmd_args);
+    std::wstring arg;
+    while(args >> arg) {
+      plan.run_argv.push_back(arg);
+    }
+
+    // the child needs the same library path obi would resolve in-process, or
+    // obc finds a stale system lang.obl and the run fails with a version error
+    plan.env.push_back({ L"OBJECK_LIB_PATH", GetLibraryPath() });
+
+    plan.ok = true;
+    return plan;
   };
 
   Tui::EditorView view(doc, term, run_program);

--- a/core/repl/highlight.h
+++ b/core/repl/highlight.h
@@ -1,0 +1,214 @@
+/***************************************************************************
+ * Syntax coloring for the full-screen editor, driven by the compiler's own
+ * Scanner (editor phase 4).
+ *
+ * Copyright (c) 2026, Randy Hollines
+ * All rights reserved.
+ ***************************************************************************/
+
+#ifndef __TUI_HIGHLIGHT_H__
+#define __TUI_HIGHLIGHT_H__
+
+#include "editor.h"                 // Document
+#include "screen.h"                 // Attr colors
+#include "../compiler/scanner.h"    // the compiler Scanner, already linked into obi
+#include <vector>
+#include <string>
+
+namespace Tui {
+
+  // 0xFF is not a real attribute (Cell uses it as its repaint sentinel), so it
+  // doubles here as "no syntax color for this cell" -- the Draw loop then falls
+  // back to the line's default/gray attribute.
+  static const unsigned char HL_NONE = 0xFF;
+
+  // Colors the buffer using the language's real Scanner (linked from the
+  // compiler) so the keyword set and number grammar can never drift from the
+  // compiler itself. The whole document is scanned in one pass, which is what
+  // lets the interior of a multi-line string be skipped over rather than
+  // mis-read as code on the lines it spans.
+  //
+  // Colored: reserved words -> cyan, integer/float literals -> yellow, string
+  // literals -> green. Deliberately left alone (see the class comment cases
+  // below) rather than guessed at: comments, char literals, and multi-line
+  // strings. Rescans on every document change; incremental caching is a later
+  // optimization noted in EDITOR_DESIGN.md.
+  class Highlighter {
+  public:
+    // Returns one attribute per character per line (HL_NONE where uncolored).
+    std::vector<std::vector<unsigned char>> Scan(Document& doc) {
+      const size_t line_count = doc.Size();
+
+      std::vector<std::wstring> lines;
+      lines.reserve(line_count);
+      for(size_t i = 0; i < line_count; ++i) {
+        lines.push_back(doc.GetLine(i));
+      }
+
+      std::vector<std::vector<unsigned char>> attrs(line_count);
+      for(size_t i = 0; i < line_count; ++i) {
+        attrs[i].assign(lines[i].size(), HL_NONE);
+      }
+      if(line_count == 0) {
+        return attrs;
+      }
+
+      // rejoin with '\n' so each token's line/column maps straight back into
+      // `lines` (the scanner counts newlines exactly as the document splits on)
+      std::wstring source;
+      for(size_t i = 0; i < line_count; ++i) {
+        source += lines[i];
+        source += L'\n';
+      }
+
+      try {
+        Scanner scanner(L"repl://highlight", false, source);
+        // a token is always at least one buffer character, so this bound can
+        // never truncate real output yet guarantees we stop even if a future
+        // scanner change forgot to emit end-of-stream
+        const size_t limit = source.size() + 16;
+        for(size_t n = 0; n < limit; ++n) {
+          scanner.NextToken();
+          Token* token = scanner.GetToken();
+          if(!token) {
+            break;
+          }
+          const ScannerTokenType type = token->GetType();
+          if(type == TOKEN_END_OF_STREAM || type == TOKEN_NO_INPUT) {
+            break;
+          }
+          Paint(lines, attrs, token);
+        }
+      }
+      catch(...) {
+        // a half-typed buffer must never take the editor down; whatever was
+        // painted before the throw is fine to keep
+      }
+
+      return attrs;
+    }
+
+  private:
+    // reserved words occupy one contiguous enum range (in a non-_SYSTEM build,
+    // as obi is), plus the four word-operators that live in the factor range
+    static bool IsKeyword(ScannerTokenType t) {
+      if(t >= TOKEN_NATIVE_ID && t <= TOKEN_CRITICAL_ID) {
+        return true;
+      }
+      switch(t) {
+      case TOKEN_AND_ID:
+      case TOKEN_OR_ID:
+      case TOKEN_XOR_ID:
+      case TOKEN_NOT_ID:
+        return true;
+      default:
+        return false;
+      }
+    }
+
+    static unsigned char AttrFor(ScannerTokenType t) {
+      if(IsKeyword(t)) {
+        return ATTR_CYAN;
+      }
+      switch(t) {
+      case TOKEN_INT_LIT:
+      case TOKEN_FLOAT_LIT:
+        return ATTR_YELLOW;
+      case TOKEN_CHAR_STRING_LIT:
+      case TOKEN_BAD_CHAR_STRING_LIT:
+        return ATTR_GREEN;
+      // TOKEN_CHAR_LIT is intentionally absent: several of the scanner's char
+      // paths never set a line position, so its anchor is not trustworthy.
+      default:
+        return HL_NONE;
+      }
+    }
+
+    static bool IsIdentChar(wchar_t c) {
+      return (c >= L'a' && c <= L'z') || (c >= L'A' && c <= L'Z') ||
+             (c >= L'0' && c <= L'9') || c == L'_' || c == L'@';
+    }
+
+    // the character class the number scanner accepts (digits, radix markers,
+    // hex digits, grouping '_', and the unsigned suffix)
+    static bool IsNumberChar(wchar_t c) {
+      return (c >= L'0' && c <= L'9') || (c >= L'a' && c <= L'f') || (c >= L'A' && c <= L'F') ||
+             c == L'.' || c == L'_' || c == L'x' || c == L'X' || c == L'u' || c == L'U';
+    }
+
+    static void Paint(const std::vector<std::wstring>& lines,
+                      std::vector<std::vector<unsigned char>>& attrs, Token* token) {
+      const ScannerTokenType type = token->GetType();
+      const unsigned char attr = AttrFor(type);
+      if(attr == HL_NONE) {
+        return;
+      }
+
+      const int line_nbr = token->GetLineNumber();    // 1-based
+      const int line_col = token->GetLinePosition();  // 1-based start column
+      if(line_nbr < 1 || (size_t)line_nbr > lines.size() || line_col < 1) {
+        return;
+      }
+      const size_t li = (size_t)(line_nbr - 1);
+      const size_t start = (size_t)(line_col - 1);
+      const std::wstring& line = lines[li];
+      if(start >= line.size()) {
+        return;
+      }
+
+      if(type == TOKEN_CHAR_STRING_LIT || type == TOKEN_BAD_CHAR_STRING_LIT) {
+        // Only paint a string whose opening quote actually sits where the token
+        // claims. A multi-line string is reported at its CLOSING line with a
+        // length-derived column that is meaningless once it spans lines, so it
+        // fails this check and is left uncolored rather than mis-painted.
+        if(line[start] != L'"') {
+          return;
+        }
+        PaintString(line, attrs[li], start, attr);
+      }
+      else {
+        // keyword or number: a run on this one line. Verify the anchor so a
+        // stray position can never paint the wrong cells.
+        const bool numeric = (type == TOKEN_INT_LIT || type == TOKEN_FLOAT_LIT);
+        if(numeric ? !IsNumberChar(line[start]) : !IsIdentChar(line[start])) {
+          return;
+        }
+        size_t end = start;
+        while(end < line.size() && (numeric ? IsNumberChar(line[end]) : IsIdentChar(line[end]))) {
+          ++end;
+        }
+        for(size_t i = start; i < end; ++i) {
+          attrs[li][i] = attr;
+        }
+      }
+    }
+
+    // Paints a single-line string from its opening quote through the matching
+    // close, treating the char after a '\' as literal exactly as the scanner
+    // does (so an escaped quote never ends the run early).
+    static void PaintString(const std::wstring& line, std::vector<unsigned char>& row,
+                            size_t start, unsigned char attr) {
+      size_t i = start;
+      row[i] = attr;   // opening quote
+      ++i;
+      while(i < line.size()) {
+        const wchar_t c = line[i];
+        row[i] = attr;
+        if(c == L'\\') {
+          ++i;
+          if(i < line.size()) {
+            row[i] = attr;
+            ++i;
+          }
+          continue;
+        }
+        if(c == L'"') {
+          return;   // closing quote painted
+        }
+        ++i;
+      }
+    }
+  };
+}
+
+#endif

--- a/core/repl/keymap.h
+++ b/core/repl/keymap.h
@@ -59,7 +59,13 @@ namespace Tui {
     ACT_OPEN_BELOW,       // 'o': new line below, insert mode
     ACT_MODE_NORMAL,      // Esc
     ACT_MODE_VISUAL,      // 'v'
-    ACT_TOGGLE_PROFILE    // F2 flips simple <-> vi
+    ACT_TOGGLE_PROFILE,   // F2 flips simple <-> vi
+    ACT_WORD_NEXT,        // 'w': start of the next word
+    ACT_WORD_PREV,        // 'b': start of the previous word
+    ACT_APPEND_EOL,       // 'A': insert at end of line
+    ACT_INSERT_BOL,       // 'I': insert at first non-blank
+    ACT_OPEN_ABOVE,       // 'O': new line above, insert mode
+    ACT_DELETE_EOL        // 'D': delete to end of line
   };
 
   enum Profile {
@@ -179,6 +185,18 @@ namespace Tui {
       { KEY_CHAR, L'i', false, false, false, ACT_MODE_INSERT },
       { KEY_CHAR, L'a', false, false, false, ACT_MODE_APPEND },
       { KEY_CHAR, L'o', false, false, false, ACT_OPEN_BELOW },
+      { KEY_CHAR, L'w', false, false, false, ACT_WORD_NEXT },
+      { KEY_CHAR, L'b', false, false, false, ACT_WORD_PREV },
+      // capitals arrive with shift set on Windows but not on POSIX, so -- as
+      // with 'G' and '$' above -- both variants are bound
+      { KEY_CHAR, L'A', false, false, true, ACT_APPEND_EOL },
+      { KEY_CHAR, L'A', false, false, false, ACT_APPEND_EOL },
+      { KEY_CHAR, L'I', false, false, true, ACT_INSERT_BOL },
+      { KEY_CHAR, L'I', false, false, false, ACT_INSERT_BOL },
+      { KEY_CHAR, L'O', false, false, true, ACT_OPEN_ABOVE },
+      { KEY_CHAR, L'O', false, false, false, ACT_OPEN_ABOVE },
+      { KEY_CHAR, L'D', false, false, true, ACT_DELETE_EOL },
+      { KEY_CHAR, L'D', false, false, false, ACT_DELETE_EOL },
       { KEY_CHAR, L'v', false, false, false, ACT_MODE_VISUAL },
       { KEY_ESC, 0, false, false, false, ACT_MODE_NORMAL },
       { KEY_PGUP, 0, false, false, false, ACT_PAGE_UP },

--- a/core/repl/tui_editor.h
+++ b/core/repl/tui_editor.h
@@ -13,9 +13,6 @@
 #include "screen.h"
 #include "keymap.h"
 #include <functional>
-#include <thread>
-#include <atomic>
-#include <memory>
 #include <vector>
 #include <cwctype>
 
@@ -48,10 +45,6 @@ namespace Tui {
     bool dirty;
     bool quit_armed;     // set by a first Ctrl+Q with unsaved changes
     std::wstring status; // transient message; cleared by the next key
-    // Set once a run has been abandoned. The worker cannot be killed mid-VM,
-    // only detached, and it still holds the process-wide fd redirect -- so a
-    // second run would corrupt both the screen and the captured output.
-    bool run_abandoned = false;
 
     // run pane: compile-and-execute output, shown below the text area
     std::function<bool(std::wstring&)> runner;
@@ -748,66 +741,24 @@ namespace Tui {
         status = L"running is not available here";
         return;
       }
-      if(run_abandoned) {
-        status = L"an abandoned run is still going -- restart obi to run again";
-        return;
-      }
 
-      // The capture inside `runner` redirects fd 1 and 2 PROCESS-WIDE, so the
-      // screen must not be painted while it is active: a repaint would land in
-      // the capture file, and the captured output would fill with escape
-      // sequences. Paint the notice first, then stay quiet until it finishes.
-      status = L"running...  Esc abandons";
-      Draw();
+      // Reverted to a synchronous call. Moving the run to a worker thread
+      // deadlocked even a trivial program: the in-process VM has main-thread
+      // affinity (process-global Loader/MemoryManager/StackInterpreter state
+      // plus its own GC threads), so it cannot be driven off the UI thread.
+      // A looping program still freezes obi here -- the real fix is running
+      // the program as a SUBPROCESS (docs/OBI_EDITOR_RUN_PLAN.md). What IS
+      // kept: the console-capture fix in io_capture.h (so output reaches the
+      // pane on Windows) and the screen invalidation below (so the editor
+      // repaints instead of appearing frozen after a run).
+      std::wstring output;
+      const bool ok = runner(output);
 
-      // Shared state is heap-allocated on purpose. If the user abandons the
-      // run we detach the worker, and a detached thread writing into this
-      // frame's locals would be a use-after-scope.
-      struct RunState {
-        std::wstring output;
-        bool ok = false;
-        std::atomic<bool> finished{false};
-      };
-      auto state = std::make_shared<RunState>();
-      auto fn = runner;
-      std::thread worker([state, fn]() {
-        state->ok = fn(state->output);
-        state->finished.store(true, std::memory_order_release);
-      });
-
-      // ReadKey already returns a KEY_NONE tick on a ~100 ms timeout on both
-      // platforms (Windows WaitForSingleObject; POSIX VMIN=0/VTIME=1), so this
-      // stays responsive without any terminal-layer change.
-      bool abandoned = false;
-      while(!state->finished.load(std::memory_order_acquire)) {
-        const Key key = term.ReadKey();
-        if(key.code == KEY_ESC) {
-          abandoned = true;
-          break;
-        }
-      }
-
-      if(abandoned) {
-        worker.detach();
-        run_abandoned = true;
-        status = L"run abandoned; it continues in the background";
-        return;
-      }
-
-      worker.join();
-
-      // The program may have written straight to the terminal behind the
-      // diff's back -- on Windows the VM prints via
-      // WinWriteWide(GetStdHandle(STD_OUTPUT_HANDLE), ...) (common.cpp:3381),
-      // which a CRT fd redirect cannot intercept. `front` then still describes
-      // an editor that is no longer on screen and the next Flush emits almost
-      // nothing, which reads as a frozen UI. Forget the front buffer and
-      // repaint everything.
+      // The program may have written to the terminal behind the diff's back;
+      // forget the front buffer and repaint everything.
       term.Clear();
       screen.Invalidate();
 
-      std::wstring& output = state->output;
-      const bool ok = state->ok;
 
       // split into pane lines; diagnostics look like 'name:(line,col): text'
       pane.clear();

--- a/core/repl/tui_editor.h
+++ b/core/repl/tui_editor.h
@@ -12,8 +12,12 @@
 #include "term.h"
 #include "screen.h"
 #include "keymap.h"
+#include "child_run.h"
+#include "highlight.h"
 #include <functional>
 #include <vector>
+#include <string>
+#include <utility>
 #include <cwctype>
 
 // A viewport over Document -- the same buffer the line commands edit, so
@@ -29,6 +33,21 @@
 // fullwidth text stay aligned.
 
 namespace Tui {
+
+  // Everything F5 needs to compile and run the buffer as child processes. The
+  // editor view owns the responsive drain/cancel loop; the REPL owns the
+  // knowledge of where obc/obr live, which libraries and optimization level to
+  // pass, and the command-line arguments -- so it hands back a fully-built plan
+  // rather than a callback the view would have to parameterize. A failed save
+  // or a missing bin directory comes back as ok=false plus a message.
+  struct RunPlan {
+    bool ok = false;
+    std::wstring error;
+    std::vector<std::wstring> compile_argv;   // obc -src ... -dest ...
+    std::vector<std::wstring> run_argv;       // obr <obe> <args...>
+    std::vector<std::pair<std::wstring, std::wstring>> env;   // OBJECK_LIB_PATH
+  };
+  using RunProvider = std::function<RunPlan()>;
 
   class EditorView {
     Document& doc;
@@ -47,7 +66,7 @@ namespace Tui {
     std::wstring status; // transient message; cleared by the next key
 
     // run pane: compile-and-execute output, shown below the text area
-    std::function<bool(std::wstring&)> runner;
+    RunProvider runner;
     std::vector<std::wstring> pane;
     size_t pane_top;
     bool pane_visible;
@@ -84,7 +103,28 @@ namespace Tui {
     // binding profile and vi mode; simple/insert unless the user opts in
     KeymapState keys;
 
+    // syntax highlighting cache: one attribute per character per line, rebuilt
+    // only when the document actually changes. content_version bumps on every
+    // mutation; hl_version records what the cache was last built for.
+    size_t content_version;
+    size_t hl_version;
+    Highlighter highlighter;
+    std::vector<std::vector<unsigned char>> hl_attr;
+
     static const int TAB_STOP = 3;
+
+    // every document mutation goes through the Op* helpers (and undo/redo), so
+    // bumping here is enough to invalidate the highlight cache
+    void TouchDoc() {
+      ++content_version;
+    }
+
+    void EnsureHighlight() {
+      if(content_version != hl_version) {
+        hl_attr = highlighter.Scan(doc);
+        hl_version = content_version;
+      }
+    }
 
     // display column of character index `col`, honoring tabs and wide chars
     static int DisplayX(const std::wstring& line, size_t col) {
@@ -98,6 +138,29 @@ namespace Tui {
         }
       }
       return x;
+    }
+
+    // Inverse of DisplayX: the character index in `line` whose display column
+    // is at (or just left of) target_x. want_col is a *display* column, so
+    // Up/Down land under the same on-screen x even across tabs and wide chars
+    // -- a plain character index would drift on lines that contain them.
+    static size_t ColForDisplayX(const std::wstring& line, int target_x) {
+      int x = 0;
+      size_t col = 0;
+      while(col < line.size()) {
+        const int width = (line[col] == L'\t') ? (TAB_STOP - (x % TAB_STOP)) : CharWidth(line[col]);
+        if(x + width > target_x) {
+          break;
+        }
+        x += width;
+        ++col;
+      }
+      return col;
+    }
+
+    // remember the cursor's display column for the next vertical move
+    void SyncWantCol() {
+      want_col = (size_t)DisplayX(doc.GetLine(cur_row), cur_col);
     }
 
     bool IsReadOnly(size_t row) {
@@ -165,6 +228,7 @@ namespace Tui {
     }
 
     void Draw() {
+      EnsureHighlight();
       screen.Clear();
 
       // title bar: name, modified marker, dimensions
@@ -209,8 +273,16 @@ namespace Tui {
             width = CharWidth(line[i]);
           }
 
+          // syntax color sits UNDER selection: an editable cell takes its
+          // highlighter attribute when it has one, then selection reverses on
+          // top so a highlighted-and-selected span still reads as selected
+          unsigned char base_attr = text_attr;
+          if(!read_only && row < hl_attr.size() && i < hl_attr[row].size() &&
+             hl_attr[row][i] != HL_NONE) {
+            base_attr = hl_attr[row][i];
+          }
           const unsigned char cell_attr =
-            InSelection(row, i) ? (unsigned char)(text_attr | ATTR_REVERSE) : text_attr;
+            InSelection(row, i) ? (unsigned char)(base_attr | ATTR_REVERSE) : base_attr;
 
           if(x + width > left_x) {
             const int screen_x = gutter + (x - left_x);
@@ -279,6 +351,13 @@ namespace Tui {
         if(key.code == KEY_NONE) {
           continue;
         }
+        if(key.code == KEY_RESIZE) {
+          // a resize mid-prompt must re-query the terminal and rebuild the back
+          // buffer, or the next Flush indexes a grid of the old dimensions
+          term.Size(rows, cols);
+          screen.Resize(rows, cols);
+          continue;
+        }
         if(key.code == KEY_ENTER) {
           return input;
         }
@@ -303,6 +382,12 @@ namespace Tui {
         if(name.empty()) {
           status = L"save cancelled";
           return;
+        }
+        // The buffer is Objeck source, so a new save carries the .obs extension
+        // even if the user left it off -- aligning with line-mode '/s', which
+        // only accepts a '.obs' name.
+        if(name.size() < 4 || name.compare(name.size() - 4, 4, L".obs") != 0) {
+          name += L".obs";
         }
       }
 
@@ -333,6 +418,7 @@ namespace Tui {
       op.before = doc.GetLine(row);
       op.after = after;
       doc.SetLine(row, after);
+      TouchDoc();
       group.ops.push_back(op);
     }
 
@@ -342,6 +428,7 @@ namespace Tui {
       op.row = row;
       op.after = text;
       doc.InsertLine(row, text);
+      TouchDoc();
       group.ops.push_back(op);
     }
 
@@ -351,6 +438,7 @@ namespace Tui {
       op.row = row;
       op.before = doc.GetLine(row);
       doc.DeleteLine(row);
+      TouchDoc();
       group.ops.push_back(op);
     }
 
@@ -406,6 +494,7 @@ namespace Tui {
       redo_stack.push_back(group);
       typing_run = false;
       dirty = true;
+      TouchDoc();
     }
 
     void DoRedo() {
@@ -432,6 +521,7 @@ namespace Tui {
       undo_stack.push_back(group);
       typing_run = false;
       dirty = true;
+      TouchDoc();
     }
 
     // ----- selection -----
@@ -577,6 +667,13 @@ namespace Tui {
       }
 
       if(clip_linewise) {
+        // Same read-only guard the charwise branch has below: without it a
+        // linewise paste would inject editable lines straight into the
+        // class/function frame the buffer is meant to keep intact.
+        if(IsReadOnly(cur_row)) {
+          status = L"read-only shell line";
+          return;
+        }
         // whole lines land above the cursor's line, cursor staying put
         for(size_t i = 0; i < clip.size(); ++i) {
           OpIns(group, cur_row + i, clip[i]);
@@ -642,10 +739,31 @@ namespace Tui {
       }
 
       const std::wstring line = doc.GetLine(cur_row);
-      OpSet(group, cur_row, line.substr(0, cur_col));
-      OpIns(group, cur_row + 1, line.substr(cur_col));
+      const std::wstring head = line.substr(0, cur_col);
+
+      // Smart return: the new line starts under the previous line's indent, one
+      // TAB_STOP deeper when that line opens a block with '{'. This mirrors the
+      // brace-depth indentation Document::Save emits, so editing and saving
+      // agree instead of the cursor snapping back to column zero every time.
+      std::wstring indent;
+      for(const wchar_t ch : head) {
+        if(ch == L' ' || ch == L'\t') {
+          indent += ch;
+        }
+        else {
+          break;
+        }
+      }
+      std::wstring trimmed = head;
+      Editor::RightTrim(trimmed);
+      if(!trimmed.empty() && trimmed.back() == L'{') {
+        indent += L'\t';   // the Tab key inserts '\t' too, so this stays uniform
+      }
+
+      OpSet(group, cur_row, head);
+      OpIns(group, cur_row + 1, indent + line.substr(cur_col));
       ++cur_row;
-      cur_col = 0;
+      cur_col = indent.size();
       Commit(group);
     }
 
@@ -736,31 +854,41 @@ namespace Tui {
       return out;
     }
 
-    void DoRun() {
-      if(!runner) {
-        status = L"running is not available here";
-        return;
+    // decode UTF-8 bytes by hand -- the locale must not get a say (this repo
+    // has been bitten by locale-dependent conversions before). Called on the
+    // whole accumulated buffer each drain, so a multi-byte sequence split
+    // across a read boundary is simply left for the next pass.
+    static std::wstring DecodeUtf8(const std::string& bytes) {
+      std::wstring out;
+      out.reserve(bytes.size());
+      for(size_t i = 0; i < bytes.size();) {
+        const unsigned char lead = (unsigned char)bytes[i];
+        unsigned int cp;
+        int extra;
+        if(lead < 0x80) { cp = lead; extra = 0; }
+        else if(lead >= 0xF0) { cp = lead & 0x07; extra = 3; }
+        else if(lead >= 0xE0) { cp = lead & 0x0F; extra = 2; }
+        else if(lead >= 0xC0) { cp = lead & 0x1F; extra = 1; }
+        else { ++i; continue; }   // stray continuation byte
+        if(i + (size_t)extra >= bytes.size()) {
+          break;   // sequence continues past what has been drained so far
+        }
+        bool valid = true;
+        for(int k = 1; k <= extra; ++k) {
+          const unsigned char cont = (unsigned char)bytes[i + k];
+          if((cont & 0xC0) != 0x80) { valid = false; break; }
+          cp = (cp << 6) | (cont & 0x3F);
+        }
+        if(!valid) { ++i; continue; }
+        i += (size_t)extra + 1;
+        out += (wchar_t)cp;
       }
+      return out;
+    }
 
-      // Reverted to a synchronous call. Moving the run to a worker thread
-      // deadlocked even a trivial program: the in-process VM has main-thread
-      // affinity (process-global Loader/MemoryManager/StackInterpreter state
-      // plus its own GC threads), so it cannot be driven off the UI thread.
-      // A looping program still freezes obi here -- the real fix is running
-      // the program as a SUBPROCESS (docs/OBI_EDITOR_RUN_PLAN.md). What IS
-      // kept: the console-capture fix in io_capture.h (so output reaches the
-      // pane on Windows) and the screen invalidation below (so the editor
-      // repaints instead of appearing frozen after a run).
-      std::wstring output;
-      const bool ok = runner(output);
-
-      // The program may have written to the terminal behind the diff's back;
-      // forget the front buffer and repaint everything.
-      term.Clear();
-      screen.Invalidate();
-
-
-      // split into pane lines; diagnostics look like 'name:(line,col): text'
+    // split program/compiler output into pane lines; diagnostics look like
+    // 'name:(line,col): text', and their line number drives F8 error jumping
+    void SetPaneFromOutput(const std::wstring& output) {
       pane.clear();
       error_lines.clear();
       std::wstring line;
@@ -786,20 +914,122 @@ namespace Tui {
       while(!pane.empty() && pane.back().empty()) {
         pane.pop_back();
       }
+    }
 
+    // park the pane on its last lines so streaming output stays in view
+    void ScrollPaneToBottom() {
+      const int visible = PaneRows() - 1;   // minus the label rule
+      pane_top = (visible > 0 && (int)pane.size() > visible) ? pane.size() - visible : 0;
+    }
+
+    // Streams a child's output into the pane while staying responsive: ReadKey
+    // already ticks ~100ms (WaitForSingleObject / VMIN=0,VTIME=1), so the loop
+    // drains, repaints and watches for Esc without a second thread. Returns
+    // true if the user cancelled the run.
+    bool PumpChild(Child& child, std::string& raw) {
+      for(;;) {
+        child.Drain(raw);
+        SetPaneFromOutput(DecodeUtf8(raw));
+        ScrollPaneToBottom();
+        term.HideCursor();
+        Draw();
+
+        const Key key = term.ReadKey();
+        if(key.code == KEY_ESC) {
+          child.Kill();
+          child.Drain(raw);
+          return true;
+        }
+        if(key.code == KEY_RESIZE) {
+          term.Size(rows, cols);
+          screen.Resize(rows, cols);
+        }
+        if(!child.IsRunning()) {
+          child.Drain(raw);   // flush whatever was buffered as the child exited
+          return false;
+        }
+      }
+    }
+
+    void DoRun() {
+      if(!runner) {
+        status = L"running is not available here";
+        return;
+      }
+
+      // The REPL builds the plan: it saves the buffer to a temp .obs and hands
+      // back the obc/obr argument vectors and the library-path env. Running the
+      // program as a child process (rather than the in-process, main-thread-
+      // affine, _NO_JIT VM) is what makes F5 both correct and cancellable.
+      const RunPlan plan = runner();
+      if(!plan.ok) {
+        status = plan.error.empty() ? L"unable to prepare the run" : plan.error;
+        return;
+      }
+
+      pane.clear();
+      error_lines.clear();
       pane_visible = true;
       pane_top = 0;
       error_index = 0;
-      if(ok) {
+      status = L"running... Esc cancels";
+
+      std::string raw;
+      bool cancelled = false;
+      int compile_exit = 0;
+      int run_exit = 0;
+
+      // phase 1: compile with obc -- its diagnostics (on stdout) fill the pane
+      {
+        Child compile;
+        if(!compile.Start(plan.compile_argv, plan.env)) {
+          status = L"unable to launch the compiler";
+          return;
+        }
+        cancelled = PumpChild(compile, raw);
+        compile_exit = compile.ExitCode();
+      }
+
+      // phase 2: run with obr, only if the compile produced a .obe
+      if(!cancelled && compile_exit == 0 && !plan.run_argv.empty()) {
+        Child run;
+        if(!run.Start(plan.run_argv, plan.env)) {
+          status = L"unable to launch the program";
+          return;
+        }
+        cancelled = PumpChild(run, raw);
+        run_exit = run.ExitCode();
+      }
+
+      // The child had its own pipes, so nothing wrote to the terminal behind
+      // the diff's back this time; a full invalidate still keeps the same
+      // clean-repaint guarantee and costs a single frame.
+      term.Clear();
+      screen.Invalidate();
+
+      SetPaneFromOutput(DecodeUtf8(raw));
+      pane_visible = true;
+      error_index = 0;
+
+      const bool ok = (compile_exit == 0 && run_exit == 0);
+      if(cancelled) {
+        status = L"run cancelled · editor intact";
+        ScrollPaneToBottom();
+      }
+      else if(ok) {
         status = L"program finished · " + std::to_wstring(pane.size()) + L" line(s) of output";
+        ScrollPaneToBottom();
+      }
+      else if(!error_lines.empty()) {
+        status = std::to_wstring(error_lines.size()) + L" error(s) · F8 jumps to the next one";
+        pane_top = 0;   // the first diagnostics are the interesting ones
+        cur_row = error_lines[0] > 0 ? error_lines[0] - 1 : 0;
+        ClampCursor();
+        cur_col = 0;
       }
       else {
-        status = std::to_wstring(error_lines.size()) + L" error(s) · F8 jumps to the next one";
-        if(!error_lines.empty()) {
-          cur_row = error_lines[0] > 0 ? error_lines[0] - 1 : 0;
-          ClampCursor();
-          cur_col = 0;
-        }
+        status = L"program reported errors · see the output pane";
+        pane_top = 0;
       }
     }
 
@@ -827,9 +1057,128 @@ namespace Tui {
       Commit(group);
     }
 
+    // ----- vi word motions and line edits (a modest round-out, not full vi) --
+
+    // three classes vi's 'w'/'b' care about: whitespace, word characters, and
+    // runs of punctuation. This is the plain 'w' notion, not 'W'.
+    static int WordClass(wchar_t c) {
+      if(c == L' ' || c == L'\t') {
+        return 0;
+      }
+      if((c >= L'a' && c <= L'z') || (c >= L'A' && c <= L'Z') ||
+         (c >= L'0' && c <= L'9') || c == L'_') {
+        return 1;
+      }
+      return 2;
+    }
+
+    // 'w': to the start of the next word, crossing line ends
+    void DoWordNext() {
+      size_t row = cur_row, col = cur_col;
+      std::wstring line = doc.GetLine(row);
+      if(col < line.size()) {
+        const int cls = WordClass(line[col]);
+        if(cls != 0) {
+          while(col < line.size() && WordClass(line[col]) == cls) {
+            ++col;
+          }
+        }
+      }
+      for(;;) {
+        line = doc.GetLine(row);
+        while(col < line.size() && WordClass(line[col]) == 0) {
+          ++col;
+        }
+        if(col < line.size()) {
+          break;   // landed on the next word
+        }
+        if(row + 1 >= doc.Size()) {
+          col = line.size();
+          break;   // end of buffer
+        }
+        ++row;
+        col = 0;
+      }
+      cur_row = row;
+      cur_col = col;
+    }
+
+    // 'b': back to the start of the current or previous word
+    void DoWordPrev() {
+      size_t row = cur_row, col = cur_col;
+      for(;;) {
+        if(col == 0) {
+          if(row == 0) {
+            break;
+          }
+          --row;
+          col = doc.GetLine(row).size();
+          continue;   // step onto the previous line, then re-test
+        }
+        --col;
+        const std::wstring line = doc.GetLine(row);
+        if(col >= line.size() || WordClass(line[col]) == 0) {
+          continue;   // still in trailing space / past an empty line
+        }
+        const int cls = WordClass(line[col]);
+        while(col > 0 && WordClass(line[col - 1]) == cls) {
+          --col;
+        }
+        break;
+      }
+      cur_row = row;
+      cur_col = col;
+    }
+
+    // 'A': jump to end of line and start inserting
+    void DoAppendEol() {
+      cur_col = doc.GetLine(cur_row).size();
+      keys.mode = MODE_INSERT;
+      sel_active = false;
+    }
+
+    // 'I': jump to the first non-blank character and start inserting
+    void DoInsertBol() {
+      const std::wstring line = doc.GetLine(cur_row);
+      size_t col = 0;
+      while(col < line.size() && (line[col] == L' ' || line[col] == L'\t')) {
+        ++col;
+      }
+      cur_col = col;
+      keys.mode = MODE_INSERT;
+      sel_active = false;
+    }
+
+    // 'O': open a fresh line above the cursor and start inserting. Inserting at
+    // cur_row pushes the current line (read-only or not) down, so this also
+    // works against the class/function frame the way DoNewline does.
+    void DoOpenAbove() {
+      EditGroup group = Begin();
+      OpIns(group, cur_row, L"");
+      cur_col = 0;
+      Commit(group);
+      keys.mode = MODE_INSERT;
+      sel_active = false;
+    }
+
+    // 'D': delete from the cursor to the end of the line
+    void DoDeleteEol() {
+      if(IsReadOnly(cur_row)) {
+        status = L"read-only shell line";
+        return;
+      }
+      const std::wstring line = doc.GetLine(cur_row);
+      if(cur_col >= line.size()) {
+        return;
+      }
+      EditGroup group = Begin();
+      OpSet(group, cur_row, line.substr(0, cur_col));
+      Commit(group);
+    }
+
   public:
     EditorView(Document& document, Term& terminal,
-               std::function<bool(std::wstring&)> run_program = nullptr)
+               RunProvider run_program = nullptr)
       : doc(document), term(terminal), runner(run_program) {
       rows = 24;
       cols = 80;
@@ -845,6 +1194,8 @@ namespace Tui {
       sel_active = false;
       sel_row = sel_col = 0;
       clip_linewise = false;
+      content_version = 1;   // ahead of hl_version, so the first Draw scans once
+      hl_version = 0;
     }
 
     // returns the cursor's document line, so the REPL can keep its own
@@ -856,7 +1207,7 @@ namespace Tui {
       cur_row = start_row;
       ClampCursor();
       cur_col = doc.GetLine(cur_row).size();
-      want_col = cur_col;
+      SyncWantCol();
 
       for(;;) {
         ScrollToCursor();
@@ -886,6 +1237,7 @@ namespace Tui {
         case ACT_LEFT: case ACT_RIGHT: case ACT_UP: case ACT_DOWN:
         case ACT_LINE_START: case ACT_LINE_END: case ACT_PAGE_UP:
         case ACT_PAGE_DOWN: case ACT_DOC_START: case ACT_DOC_END:
+        case ACT_WORD_NEXT: case ACT_WORD_PREV:
           if(keys.mode == MODE_VISUAL) {
             SelAnchor();
           }
@@ -911,7 +1263,7 @@ namespace Tui {
             --cur_row;
             cur_col = doc.GetLine(cur_row).size();
           }
-          want_col = cur_col;
+          SyncWantCol();
           break;
 
         case ACT_SEL_RIGHT:
@@ -923,14 +1275,14 @@ namespace Tui {
             ++cur_row;
             cur_col = 0;
           }
-          want_col = cur_col;
+          SyncWantCol();
           break;
 
         case ACT_SEL_UP:
         case ACT_UP:
           if(cur_row > 0) {
             --cur_row;
-            cur_col = want_col;
+            cur_col = ColForDisplayX(doc.GetLine(cur_row), (int)want_col);
             ClampCursor();
           }
           break;
@@ -939,7 +1291,7 @@ namespace Tui {
         case ACT_DOWN:
           if(cur_row + 1 < doc.Size()) {
             ++cur_row;
-            cur_col = want_col;
+            cur_col = ColForDisplayX(doc.GetLine(cur_row), (int)want_col);
             ClampCursor();
           }
           break;
@@ -951,18 +1303,19 @@ namespace Tui {
 
         case ACT_SEL_END:
         case ACT_LINE_END:
-          cur_col = want_col = doc.GetLine(cur_row).size();
+          cur_col = doc.GetLine(cur_row).size();
+          SyncWantCol();
           break;
 
         case ACT_PAGE_UP:
           cur_row = (cur_row > (size_t)TextRows()) ? cur_row - TextRows() : 0;
-          cur_col = want_col;
+          cur_col = ColForDisplayX(doc.GetLine(cur_row), (int)want_col);
           ClampCursor();
           break;
 
         case ACT_PAGE_DOWN:
           cur_row += TextRows();
-          cur_col = want_col;
+          cur_col = ColForDisplayX(doc.GetLine(cur_row), (int)want_col);
           ClampCursor();
           break;
 
@@ -973,17 +1326,18 @@ namespace Tui {
 
         case ACT_DOC_END:
           cur_row = doc.Size() ? doc.Size() - 1 : 0;
-          cur_col = want_col = doc.GetLine(cur_row).size();
+          cur_col = doc.GetLine(cur_row).size();
+          SyncWantCol();
           break;
 
         case ACT_NEWLINE:
           DoNewline();
-          want_col = cur_col;
+          SyncWantCol();
           break;
 
         case ACT_BACKSPACE:
           DoBackspace();
-          want_col = cur_col;
+          SyncWantCol();
           break;
 
         case ACT_DELETE:
@@ -992,17 +1346,17 @@ namespace Tui {
 
         case ACT_DELETE_LINE:
           DoDeleteLine();
-          want_col = cur_col;
+          SyncWantCol();
           break;
 
         case ACT_TAB:
           InsertChar(L'\t');
-          want_col = cur_col;
+          SyncWantCol();
           break;
 
         case ACT_INSERT_CHAR:
           InsertChar(key.ch);
-          want_col = cur_col;
+          SyncWantCol();
           break;
 
         case ACT_SAVE:
@@ -1036,12 +1390,12 @@ namespace Tui {
 
         case ACT_UNDO:
           DoUndo();
-          want_col = cur_col;
+          SyncWantCol();
           break;
 
         case ACT_REDO:
           DoRedo();
-          want_col = cur_col;
+          SyncWantCol();
           break;
 
         case ACT_COPY:
@@ -1053,7 +1407,7 @@ namespace Tui {
 
         case ACT_CUT:
           DoCut();
-          want_col = cur_col;
+          SyncWantCol();
           if(keys.mode == MODE_VISUAL) {
             keys.mode = MODE_NORMAL;
           }
@@ -1061,7 +1415,7 @@ namespace Tui {
 
         case ACT_PASTE:
           DoPaste();
-          want_col = cur_col;
+          SyncWantCol();
           break;
 
         case ACT_MODE_INSERT:
@@ -1075,7 +1429,7 @@ namespace Tui {
           if(cur_col < doc.GetLine(cur_row).size()) {
             ++cur_col;
           }
-          want_col = cur_col;
+          SyncWantCol();
           break;
 
         case ACT_OPEN_BELOW: {
@@ -1088,6 +1442,36 @@ namespace Tui {
           sel_active = false;
           break;
         }
+
+        case ACT_WORD_NEXT:
+          DoWordNext();
+          SyncWantCol();
+          break;
+
+        case ACT_WORD_PREV:
+          DoWordPrev();
+          SyncWantCol();
+          break;
+
+        case ACT_APPEND_EOL:
+          DoAppendEol();
+          SyncWantCol();
+          break;
+
+        case ACT_INSERT_BOL:
+          DoInsertBol();
+          SyncWantCol();
+          break;
+
+        case ACT_OPEN_ABOVE:
+          DoOpenAbove();
+          SyncWantCol();
+          break;
+
+        case ACT_DELETE_EOL:
+          DoDeleteEol();
+          SyncWantCol();
+          break;
 
         case ACT_MODE_NORMAL:
           keys.mode = MODE_NORMAL;

--- a/docs/OBI_EDITOR_RUN_PLAN.md
+++ b/docs/OBI_EDITOR_RUN_PLAN.md
@@ -1,5 +1,19 @@
 # F5 freezes obi — design for a responsive run
 
+> **IMPLEMENTED — branch `feat/obi-editor-subprocess-and-quality`.** Option B
+> (subprocess) below is the design that shipped. The worker-thread attempt that
+> the two banners under this one debate was reverted (it deadlocked even a
+> trivial program: the in-process VM has main-thread affinity). F5 now compiles
+> the buffer with `obc` and runs the `.obe` with `obr` as child processes,
+> draining their merged output into the pane while `ReadKey`'s ~100 ms tick
+> keeps Esc live; Esc kills the child (`core/repl/child_run.h`,
+> `core/repl/tui_editor.h::DoRun`, plan built in `core/repl/editor.cpp`).
+> `IoCapture` is dropped from the F5 path. Built clean via `core/repl/repl.sln`;
+> **NOT interactively verified** — `/e` needs a real TTY, so the manual matrix at
+> the end of this note is still the gate before this is trusted.
+
+# F5 freezes obi — design for a responsive run
+
 > **UPDATE — branch `fix/obi-f5-blocks-ui-thread` now addresses ALL THREE**
 > **defects on the in-process path; the earlier "do not merge" is resolved.**
 >


### PR DESCRIPTION
Implements the approved plan (`.claude/plans/eventual-floating-crane.md`). Branched off the #631 revert, so it does **not** inherit the worker thread.

## Part A — F5 as a subprocess

F5 ran in-process on the UI thread, so any loop froze obi. A worker thread was *worse* — it hung even `7->PrintLine()`, because the in-process VM has **main-thread affinity** (process-global `Loader`/`MemoryManager`/`StackInterpreter` plus its own GC threads). It can't leave the UI thread, so the run had to leave the **process**.

- **`child_run.h`** (new) — `Tui::Child`. Windows: `CreateProcessW` + `CreatePipe` + `PeekNamedPipe` + `TerminateProcess`. POSIX: `fork`/`execvp`/`pipe`, `O_NONBLOCK`, `SIGTERM`→`SIGKILL`. Argv vectors, **no shell** — deliberate, since the path originates in a user buffer.
- **`editor.cpp`** — `ExecutableDir()` resolves `obc`/`obr` as siblings of obi. F5 now returns a `RunPlan` (argv + `OBJECK_LIB_PATH`): buffer → temp `.obs`, then `obc`, then `obr`. `-lib` gets `compiler_libs` **bare** — prepending `lang.obl,` is right for `ObjeckLang` and wrong for `obc`, which filters `lang`/`collect` itself.
- **`DoRun`** — two-phase pump: drain child → pane, `Draw()`, `ReadKey()` each ~100 ms tick. **Esc kills the child.** No terminal change needed; `ReadKey` already timed out on both platforms.
- **`IoCapture` dropped from F5.** The child owns its pipes, and a pipe fails `GetConsoleMode`, so the VM falls back to `wcout` instead of `WriteConsoleW` — the Windows console bypass that swallowed output is fixed **by construction**.

## Part B — editor quality

| item | before → after |
|---|---|
| Smart return | no auto-indent at all → inherits indent, +1 level after `{` |
| Highlighting | none → keyword/number/string via the **already-linked** compiler `Scanner`, cached, composed *under* selection |
| vi mode | confirmed present (F2) → adds `w` `b` `A` `I` `O` `D` |
| Linewise paste | **bypassed the read-only guard** — could inject lines into the class/function frame → guarded |
| `want_col` | character index → display column (cursor no longer drifts over tabs/wide chars) |
| `Prompt` resize, `DoSave` `.obs` | ignored / unenforced → handled |

## Verified

Builds clean via `core/repl/repl.sln` (the single vcxproj fails on `objeck.lib`). I independently rebuilt and hand-reviewed the spawn paths, argv construction, and selection/highlight compositing.

## ⚠️ NOT verified — please read before merging

- **No interactive testing.** `/e` needs a real TTY; none of this has been exercised by a human yet.
- **The POSIX half of `child_run.h` has never been compiled** — this is a Windows box. It mirrors `obu.cpp`'s proven pattern, but needs a Linux/macOS build.
- **Do not auto-merge on CI green.** CI cannot exercise any of this. That is precisely how the worker-thread regression reached master.

**Manual test matrix:** `7->PrintLine()` → output in pane · compile error → F8 jumps · `while(true){};` + **Esc** → cancels, obi alive · Enter after `{` → indents · keywords/strings colored · F2 vi → `w`/`A`/`D` · linewise paste onto a frame line → refused.

## Deliberately skipped (documented in `EDITOR_DESIGN.md`)

Multi-line-string and comment coloring — the scanner reports those at the closing quote, so they're left **uncolored rather than mis-colored**. Also char literals, incremental highlight caching, full vi, OS clipboard, find/goto-line, mouse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
