### PR TITLE
fix(repl): strings were never highlighted, and the palette read as faded

### DIFF
--- a/core/repl/highlight.h
+++ b/core/repl/highlight.h
@@ -108,7 +108,9 @@ namespace Tui {
 
     static unsigned char AttrFor(ScannerTokenType t) {
       if(IsKeyword(t)) {
-        return ATTR_CYAN;
+        // Bold as well as bright: keywords are the structure a dev scans for,
+        // so they should be the strongest thing on the line.
+        return (unsigned char)(ATTR_CYAN | ATTR_BOLD);
       }
       switch(t) {
       case TOKEN_INT_LIT:
@@ -157,14 +159,28 @@ namespace Tui {
       }
 
       if(type == TOKEN_CHAR_STRING_LIT || type == TOKEN_BAD_CHAR_STRING_LIT) {
-        // Only paint a string whose opening quote actually sits where the token
-        // claims. A multi-line string is reported at its CLOSING line with a
-        // length-derived column that is meaningless once it spans lines, so it
-        // fails this check and is left uncolored rather than mis-painted.
-        if(line[start] != L'"') {
+        // Anchor on the opening quote. The scanner derives a string's column as
+        // line_pos - length - 2 (identifiers use - length - 1), and that
+        // arithmetic lands a cell or two off in practice, so demanding the quote
+        // exactly at the reported column silently skipped every string.
+        //
+        // Search a SMALL window instead of trusting the number outright. A
+        // multi-line string is reported at its closing line with a meaningless
+        // column and still finds no quote nearby, so it stays uncolored rather
+        // than mis-painted -- the property that guard was protecting.
+        size_t quote = std::wstring::npos;
+        const size_t lo = (start > 2) ? start - 2 : 0;
+        const size_t hi = (start + 2 < line.size()) ? start + 2 : line.size() - 1;
+        for(size_t i = lo; i <= hi; ++i) {
+          if(line[i] == L'"') {
+            quote = i;
+            break;
+          }
+        }
+        if(quote == std::wstring::npos) {
           return;
         }
-        PaintString(line, attrs[li], start, attr);
+        PaintString(line, attrs[li], quote, attr);
       }
       else {
         // keyword or number: a run on this one line. Verify the anchor so a

--- a/core/repl/screen.h
+++ b/core/repl/screen.h
@@ -94,11 +94,15 @@ namespace Tui {
         seq += L";7";
       }
       switch(attr & ATTR_COLOR_MASK) {
-      case ATTR_RED: seq += L";31"; break;
-      case ATTR_GREEN: seq += L";32"; break;
-      case ATTR_YELLOW: seq += L";33"; break;
-      case ATTR_BLUE: seq += L";34"; break;
-      case ATTR_CYAN: seq += L";36"; break;
+      // BRIGHT codes (91-96), not the dim 31-36 set. The basic colours render
+      // as muddy low-contrast tones over a dark background -- syntax painted
+      // with them reads as faded rather than as structure. Gray stays 90: it
+      // marks the read-only frame and SHOULD recede.
+      case ATTR_RED: seq += L";91"; break;
+      case ATTR_GREEN: seq += L";92"; break;
+      case ATTR_YELLOW: seq += L";93"; break;
+      case ATTR_BLUE: seq += L";94"; break;
+      case ATTR_CYAN: seq += L";96"; break;
       case ATTR_GRAY: seq += L";90"; break;
       }
       return seq + L"m";


### PR DESCRIPTION
Two rendering fixes found by actually looking at the editor.

## Strings never painted

The scanner derives a string literal's column as `line_pos - length - 2` (identifiers use `- length - 1`), and in practice that lands a cell or two off. The painter demanded the opening quote **exactly** at the reported column, so **every string silently failed the check** and rendered plain — including trivial single-line ones like `"a"`, which had nothing to do with the multi-line case the guard was written for.

Now it searches a **±2 window** for the opening quote instead of trusting the number outright. That keeps the property the guard existed to protect: a multi-line string is reported at its *closing* line with a meaningless column, finds no quote nearby, and stays uncolored rather than mis-painted.

## Palette read as faded

`AttrSequence` emitted the **dim** basic ANSI set (31–36), which renders as muddy low-contrast tones over a dark background — syntax painted with it looks like decoration rather than structure. Switched to the **bright** set (91–96), and keywords now carry `ATTR_BOLD` as well, since they're what a developer scans for.

Gray stays at 90 deliberately: it marks the read-only frame and *should* recede.

## Verification

Builds clean via `core/repl/repl.sln`, deployed to `deploy-x64/bin`. The colour outcome is inherently visual and was confirmed by eye in the terminal, not by an automated check.

**Related good news:** F5-as-a-subprocess is now confirmed working on **Windows** (`Compiled 1 class` → temp `.obe` → program output in the pane), so the editor's run path and its rendering are both exercised on both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)