### PR TITLE
perf: move instead of copy in the REPL and compiler entry points

### DIFF
--- a/core/compiler/posix_main.cpp
+++ b/core/compiler/posix_main.cpp
@@ -39,6 +39,7 @@
 #include <string>
 #include <exception>
 #include <new>
+#include <utility>
 #include <list>
 #include <map>
 
@@ -127,7 +128,9 @@ static int objeck_main(int argc, const char* argv[])
 
     // compile source with options
     try {
-      status = OptionsCompile(cmd_options, argument_optionals, usage);
+      // moved: the other use of 'usage' is in the else branch below, which is
+      // mutually exclusive with this one -- verified before moving
+      status = OptionsCompile(cmd_options, argument_optionals, std::move(usage));
     }
     catch(const std::bad_alloc&) {
       std::wcerr << L"internal error: out of memory" << std::endl;

--- a/core/repl/repl.cpp
+++ b/core/repl/repl.cpp
@@ -33,6 +33,7 @@
 #include <codecvt>
 #include <exception>
 #include <new>
+#include <utility>
 
 /****************************
 * Program start
@@ -76,7 +77,7 @@ static int objeck_main(int argc, const char* argv[])
     // Check for file input (support --file, -file, -f)
     std::wstring file_value = GetCommandLineArgumentWithAliases(arguments, {L"file", L"f"});
     if(!file_value.empty()) {
-      input = file_value;
+      input = std::move(file_value);
       mode = 1;
       arguments.erase(L"file");
       arguments.erase(L"f");
@@ -85,7 +86,7 @@ static int objeck_main(int argc, const char* argv[])
     // Check for inline code (support --inline, -inline, -i)
     std::wstring inline_value = GetCommandLineArgumentWithAliases(arguments, {L"inline", L"i"});
     if(!inline_value.empty()) {
-      input = inline_value;
+      input = std::move(inline_value);
       mode = 2;
       arguments.erase(L"inline");
       arguments.erase(L"i");
@@ -101,7 +102,7 @@ static int objeck_main(int argc, const char* argv[])
     // Check for libraries (support --library, -lib, -l)
     std::wstring lib_value = GetCommandLineArgumentWithAliases(arguments, {L"library", L"lib", L"l"});
     if(!lib_value.empty()) {
-      libs = lib_value;
+      libs = std::move(lib_value);
       arguments.erase(L"library");
       arguments.erase(L"lib");
       arguments.erase(L"l");
@@ -110,7 +111,7 @@ static int objeck_main(int argc, const char* argv[])
     // Check for optimization level (support --optimize, -opt, -o)
     std::wstring opt_value = GetCommandLineArgumentWithAliases(arguments, {L"optimize", L"opt", L"o"});
     if(!opt_value.empty()) {
-      opt = opt_value;
+      opt = std::move(opt_value);
       arguments.erase(L"optimize");
       arguments.erase(L"opt");
       arguments.erase(L"o");
@@ -123,7 +124,9 @@ static int objeck_main(int argc, const char* argv[])
     // Start REPL loop
     else {
       Editor editor;
-      editor.Edit(input, libs, opt, mode, is_exit);
+      // moved: line 126 is the last use of all three, and Edit takes each
+      // std::wstring by value
+      editor.Edit(std::move(input), std::move(libs), std::move(opt), mode, is_exit);
     }
   }
 


### PR DESCRIPTION
Clears the 8 `COPY_INSTEAD_OF_MOVE` findings (CIDs 1677362–1677369) from the 2026-08-18 Linux scan.

## These are not regressions

Every flagged line is **pre-existing code this session did not modify**. The diff to `repl.cpp` added only includes, the `main` → `objeck_main` rename, a `return`, and the try/catch wrapper.

They appeared as "new" because **Coverity keys a CID partly by the enclosing function** — renaming `main` retired the old CIDs and reissued identical findings against `objeck_main`. The same re-keying is what inflates the **"145 defects fixed"** figure in that report; it is not 145 genuine repairs.

## Honest about the payoff

These run **once at startup on short strings**, so the runtime saving is nil. The value is a clean baseline, so a real defect in these files stands out in the next report instead of sitting among known noise.

## Each move was checked, not applied mechanically

- `file_value` / `inline_value` / `lib_value` / `opt_value` — dead after the assignment that consumes them.
- `input` / `libs` / `opt` — no use after the `Edit` call, and `Edit` takes all three `std::wstring` parameters **by value**, so these genuinely were copies.
- **`usage` in `compiler/posix_main.cpp` looked unsafe** — it appears again 22 lines later. It isn't: that second use is in the `else` branch of the enclosing `if`, mutually exclusive with the `try` holding the moved call. Applying the checker's advice mechanically would have needed exactly this check to be safe.

## Verification

Windows x64: **regression 190/190, DAP 20/20**, plus direct exercise of every moved path — `obi -f` (input), `obi -lib/-opt` (libs/opt), `obc` with arguments (the moved `usage`), and `obc` with **no** arguments, which is the branch that *prints* `usage` and would show an empty banner if the move were wrong. It prints in full.

**Also built and ran on Linux under WSL before pushing**, since the previous change in this area passed every Windows check and still segfaulted on POSIX. `obc` and `obr` rebuild clean, and the failing CI sequence (compile `hello_0.obs`, run `hello_0.obe`) succeeds.

## Investigated and dismissed

`obi -lib json` fails with *"Unable to resolve external library class: 'Collection.Stack'"*. That's a library dependency, not this change — `json.obl` needs `gen_collect`, `-lib` replaces the default set, and `-lib json,gen_collect` works. Reaching json's *dependency* proves `libs` arrived intact through the move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
