### PR TITLE
build: track header dependencies in the POSIX makefiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Objeck build outputs
 *.o
 *.a
+# gcc/clang -MMD -MP depfiles: how the POSIX makefiles learn header deps
+*.d
 *.obe
 *.obm
 

--- a/core/compiler/Makefile
+++ b/core/compiler/Makefile
@@ -1,4 +1,4 @@
-ARGS=-O3 -flto=auto -Wall -D_X64 -std=c++20 -mavx2 -Wno-unused-function -Wno-sequence-point
+ARGS=-O3 -flto=auto -Wall -D_X64 -std=c++20 -mavx2 -Wno-unused-function -Wno-sequence-point -MMD -MP
 SRC=types.o tree.o scanner.o parser.o linker.o context.o intermediate.o optimization.o emit.o compiler.o posix_main.o
 OBJ_LIBS=sys.a
 LOGGER_PATH=../shared
@@ -16,6 +16,11 @@ $(EXE): $(SRC) $(OBJ_LIBS)
 sys.a:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.amd64
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.amd64 clean
-	rm -f $(EXE) *.o *~
+	rm -f $(EXE) *.o *.d *~

--- a/core/compiler/make/Makefile.amd64
+++ b/core/compiler/make/Makefile.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -flto=auto -Wall -D_X64 -std=c++20 -mavx2 -Wno-unused-function -Wno-sequence-point
+ARGS=-O3 -flto=auto -Wall -D_X64 -std=c++20 -mavx2 -Wno-unused-function -Wno-sequence-point -MMD -MP
 SRC=types.o tree.o scanner.o parser.o linker.o context.o intermediate.o optimization.o emit.o compiler.o posix_main.o
 OBJ_LIBS=sys.a
 LOGGER_PATH=../shared
@@ -16,6 +16,11 @@ $(EXE): $(SRC) $(OBJ_LIBS)
 sys.a:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.amd64
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.amd64 clean
-	rm -f $(EXE) *.o *~
+	rm -f $(EXE) *.o *.d *~

--- a/core/compiler/make/Makefile.amd64.mod
+++ b/core/compiler/make/Makefile.amd64.mod
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -D_MODULE -std=c++20 -mavx2 -Wno-unused-function -Wno-sequence-point
+ARGS=-O3 -Wall -D_MODULE -std=c++20 -mavx2 -Wno-unused-function -Wno-sequence-point -MMD -MP
 SRC=types.o tree.o scanner.o parser.o linker.o context.o intermediate.o optimization.o emit.o compiler.o 
 OBJ_LIBS=sys.a
 LOGGER_PATH=../shared
@@ -18,6 +18,11 @@ $(LIB): $(SRC) $(OBJ_LIBS)
 sys.a:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.amd64
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.amd64 clean
-	rm -f $(LIB) *.o *~
+	rm -f $(LIB) *.o *.d *~

--- a/core/compiler/make/Makefile.arm64
+++ b/core/compiler/make/Makefile.arm64
@@ -1,4 +1,4 @@
-ARGS=-O3 -flto=auto -mcpu=native -Wall -D_ARM64 -std=c++20 -Wno-unused-function -Wno-sequence-point
+ARGS=-O3 -flto=auto -mcpu=native -Wall -D_ARM64 -std=c++20 -Wno-unused-function -Wno-sequence-point -MMD -MP
 SRC=types.o tree.o scanner.o parser.o linker.o context.o intermediate.o optimization.o emit.o compiler.o posix_main.o
 OBJ_LIBS=sys.a
 LOGGER_PATH=../shared
@@ -16,6 +16,11 @@ $(EXE): $(SRC) $(OBJ_LIBS)
 sys.a:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.arm64
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.arm64 clean
-	rm -f $(EXE) *.o *~
+	rm -f $(EXE) *.o *.d *~

--- a/core/compiler/make/Makefile.arm64.mod
+++ b/core/compiler/make/Makefile.arm64.mod
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++20 -D_MODULE -D_ARM64 -Wno-unused-function -Wno-sequence-point
+ARGS=-O3 -Wall -std=c++20 -D_MODULE -D_ARM64 -Wno-unused-function -Wno-sequence-point -MMD -MP
 SRC=types.o tree.o scanner.o parser.o linker.o context.o intermediate.o optimization.o emit.o compiler.o 
 LOGGER_PATH=../shared
 OBJ_LIBS=sys.a
@@ -18,6 +18,11 @@ $(LIB): $(SRC) $(OBJ_LIBS)
 sys.a:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.arm64
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.arm64 clean
-	rm -f $(LIB) *.o *~
+	rm -f $(LIB) *.o *.d *~

--- a/core/compiler/make/Makefile.msys2-clang.amd64
+++ b/core/compiler/make/Makefile.msys2-clang.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -Wno-unused-function -D_X64 -D_MSYS2_CLANG -std=c++20 -mavx2 -Wno-sequence-point
+ARGS=-O3 -Wall -Wno-unused-function -D_X64 -D_MSYS2_CLANG -std=c++20 -mavx2 -Wno-sequence-point -MMD -MP
 
 SRC=types.o tree.o scanner.o parser.o linker.o context.o intermediate.o optimization.o emit.o compiler.o posix_main.o
 OBJ_LIBS=sys.a objeck.res
@@ -20,6 +20,11 @@ sys.a:
 objeck.res:
 	windres vs/objeck.rc -O coff -o objeck.res -D_MSYS2_CLANG
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.msys2-clang.amd64 clean
-	rm -f $(EXE) *.o *.res *~
+	rm -f $(EXE) *.o *.d *.res *~

--- a/core/compiler/make/Makefile.msys2-clang.amd64.mod
+++ b/core/compiler/make/Makefile.msys2-clang.amd64.mod
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -D_MODULE -std=c++20 -mavx2 -Wno-unused-function -Wno-sequence-point
+ARGS=-O3 -Wall -D_MODULE -std=c++20 -mavx2 -Wno-unused-function -Wno-sequence-point -MMD -MP
 SRC=types.o tree.o scanner.o parser.o linker.o context.o intermediate.o optimization.o emit.o compiler.o 
 OBJ_LIBS=sys.a
 LOGGER_PATH=../shared
@@ -18,6 +18,11 @@ $(LIB): $(SRC) $(OBJ_LIBS)
 sys.a:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.amd64
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.amd64 clean
-	rm -f $(LIB) *.o *~
+	rm -f $(LIB) *.o *.d *~

--- a/core/compiler/make/Makefile.msys2-ucrt.amd64
+++ b/core/compiler/make/Makefile.msys2-ucrt.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -Wno-unused-function -D_X64 -std=c++20 -mavx2 -Wno-sequence-point
+ARGS=-O3 -Wall -Wno-unused-function -D_X64 -std=c++20 -mavx2 -Wno-sequence-point -MMD -MP
 
 SRC=types.o tree.o scanner.o parser.o linker.o context.o intermediate.o optimization.o emit.o compiler.o posix_main.o
 OBJ_LIBS=sys.a objeck.res
@@ -20,6 +20,11 @@ sys.a:
 objeck.res:
 	windres vs/objeck.rc -O coff -o objeck.res -D_MSYS2_CLANG
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.msys2-ucrt.amd64 clean
-	rm -f $(EXE) $(EXE).exe *.o *.res *~
+	rm -f $(EXE) $(EXE).exe *.o *.d *.res *~

--- a/core/compiler/make/Makefile.msys2-ucrt.amd64.mod
+++ b/core/compiler/make/Makefile.msys2-ucrt.amd64.mod
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -D_MODULE -std=c++20 -mavx2 -Wno-unused-function -Wno-sequence-point
+ARGS=-O3 -Wall -D_MODULE -std=c++20 -mavx2 -Wno-unused-function -Wno-sequence-point -MMD -MP
 SRC=types.o tree.o scanner.o parser.o linker.o context.o intermediate.o optimization.o emit.o compiler.o 
 OBJ_LIBS=sys.a
 LOGGER_PATH=../shared
@@ -18,6 +18,11 @@ $(LIB): $(SRC) $(OBJ_LIBS)
 sys.a:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.amd64
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.amd64 clean
-	rm -f $(LIB) *.o *~
+	rm -f $(LIB) *.o *.d *~

--- a/core/compiler/make/Makefile.sys.amd64
+++ b/core/compiler/make/Makefile.sys.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -flto=auto -D_SYSTEM -Wall -std=c++20 -mavx2 -Wno-sequence-point -Wno-unused-function
+ARGS=-O3 -flto=auto -D_SYSTEM -Wall -std=c++20 -mavx2 -Wno-sequence-point -Wno-unused-function -MMD -MP
 SRC=types.o tree.o scanner.o parser.o linker.o context.o intermediate.o optimization.o emit.o compiler.o posix_main.o
 OBJ_LIBS=sys.a
 LOGGER_PATH=../shared
@@ -16,6 +16,11 @@ $(EXE): $(SRC) $(OBJ_LIBS)
 sys.a:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.amd64
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(LOGGER_PATH); $(MAKE) clean -f make/Makefile.amd64
-	rm -f $(EXE)  $(EXE).exe *.o *~
+	rm -f $(EXE)  $(EXE).exe *.o *.d *~

--- a/core/compiler/make/Makefile.sys.arm64
+++ b/core/compiler/make/Makefile.sys.arm64
@@ -1,4 +1,4 @@
-ARGS=-O3 -flto=auto -mcpu=native -D_SYSTEM -Wall -std=c++20 -Wno-sequence-point -Wno-unused-function
+ARGS=-O3 -flto=auto -mcpu=native -D_SYSTEM -Wall -std=c++20 -Wno-sequence-point -Wno-unused-function -MMD -MP
 SRC=types.o tree.o scanner.o parser.o linker.o context.o intermediate.o optimization.o emit.o compiler.o posix_main.o
 OBJ_LIBS=sys.a
 LOGGER_PATH=../shared
@@ -16,6 +16,11 @@ $(EXE): $(SRC) $(OBJ_LIBS)
 sys.a:
 	cd $(LOGGER_PATH); $(MAKE) -f make/Makefile.arm64
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(LOGGER_PATH); $(MAKE) clean -f make/Makefile.arm64
-	rm -f $(EXE)  $(EXE).exe *.o *~
+	rm -f $(EXE)  $(EXE).exe *.o *.d *~

--- a/core/debugger/make/Makefile.amd64
+++ b/core/debugger/make/Makefile.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++20 -mavx2 -D_X64 -D_OBJECK_NATIVE_LIB_PATH -D_DEBUGGER -Wint-to-pointer-cast -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast
+ARGS=-O3 -Wall -std=c++20 -mavx2 -D_X64 -D_OBJECK_NATIVE_LIB_PATH -D_DEBUGGER -Wint-to-pointer-cast -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast -MMD -MP
 
 SRC=tree.o scanner.o parser.o debugger.o dap.o
 OBJ_LIBS=../vm/vm.a ../vm/jit_amd_lp64.a ../vm/memory.a
@@ -22,6 +22,11 @@ $(EXE): $(SRC) $(OBJ_LIBS)
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(VM_PATH); $(MAKE) -f make/Makefile.amd64.obd clean
-	rm -f $(EXE) *.o *~
+	rm -f $(EXE) *.o *.d *~

--- a/core/debugger/make/Makefile.arm64
+++ b/core/debugger/make/Makefile.arm64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -Wall -std=c++20 -D_ARM64 -D_OBJECK_NATIVE_LIB_PATH -D_DEBUGGER -Wno-int-to-pointer-cast -Wno-unused-function -Wno-unused-variable -Wno-strict-overflow
+ARGS=-O3 -Wall -Wall -std=c++20 -D_ARM64 -D_OBJECK_NATIVE_LIB_PATH -D_DEBUGGER -Wno-int-to-pointer-cast -Wno-unused-function -Wno-unused-variable -Wno-strict-overflow -MMD -MP
 
 SRC=tree.o scanner.o parser.o debugger.o dap.o
 OBJ_LIBS=../vm/vm.a ../vm/jit_arm_a64.a ../vm/memory.a
@@ -22,6 +22,11 @@ $(EXE): $(SRC) $(OBJ_LIBS)
 %.o: %.cpp
 	$(CXX) $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(VM_PATH); $(MAKE) -f make/Makefile.arm64.obd clean
-	rm -f $(EXE) *.o *~
+	rm -f $(EXE) *.o *.d *~

--- a/core/debugger/make/Makefile.msys2-clang.amd64
+++ b/core/debugger/make/Makefile.msys2-clang.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++20 -mavx2 -Wno-strict-overflow -pthread -D_X64 -D_MSYS2 -D_MSYS2_CLANG -D_OBJECK_NATIVE_LIB_PATH -D_DEBUGGER -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast
+ARGS=-O3 -Wall -std=c++20 -mavx2 -Wno-strict-overflow -pthread -D_X64 -D_MSYS2 -D_MSYS2_CLANG -D_OBJECK_NATIVE_LIB_PATH -D_DEBUGGER -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -MMD -MP
 
 SRC=tree.o scanner.o parser.o debugger.o dap.o
 OBJ_LIBS=../vm/vm.a ../vm/jit_amd_lp64.a ../vm/memory.a ../vm/win32.a objeck.res
@@ -29,9 +29,14 @@ objeck.res:
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(WIN32_PATH); $(MAKE) -f make/Makefile.msys2-clang.amd64 clean
 	cd $(JIT_PATH); $(MAKE) -f make/Makefile.msys2-clang.amd64 clean
 	cd $(MEM_PATH); $(MAKE) -f make/Makefile.msys2-clang.amd64 clean
 	cd $(VM_PATH); $(MAKE) -f make/Makefile.msys2-clang.amd64.obd clean
-	rm -f $(EXE) $(EXE).exe *.o *~ *.res
+	rm -f $(EXE) $(EXE).exe *.o *.d *~ *.res

--- a/core/debugger/make/Makefile.msys2-ucrt.amd64
+++ b/core/debugger/make/Makefile.msys2-ucrt.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++20 -mavx2 -Wno-strict-overflow -pthread -D_X64 -D_MSYS2 -D_OBJECK_NATIVE_LIB_PATH -D_DEBUGGER -Wno-dangling-pointer -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas
+ARGS=-O3 -Wall -std=c++20 -mavx2 -Wno-strict-overflow -pthread -D_X64 -D_MSYS2 -D_OBJECK_NATIVE_LIB_PATH -D_DEBUGGER -Wno-dangling-pointer -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas -MMD -MP
 
 SRC=tree.o scanner.o parser.o debugger.o dap.o
 OBJ_LIBS=../vm/vm.a ../vm/jit_amd_lp64.a ../vm/memory.a ../vm/win32.a ../vm/sys.a objeck.res
@@ -32,9 +32,14 @@ objeck.res:
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(WIN32_PATH); $(MAKE) -f make/Makefile.msys2-ucrt.amd64 clean
 	cd $(JIT_PATH); $(MAKE) -f make/Makefile.msys2-ucrt.amd64 clean
 	cd $(MEM_PATH); $(MAKE) -f make/Makefile.msys2-ucrt.amd64 clean
 	cd $(VM_PATH); $(MAKE) -f make/Makefile.msys2-ucrt.amd64.obd clean
-	rm -f $(EXE) $(EXE).exe *.o *~ *.res
+	rm -f $(EXE) $(EXE).exe *.o *.d *~ *.res

--- a/core/module/make/Makefile.amd64
+++ b/core/module/make/Makefile.amd64
@@ -2,7 +2,7 @@
 # TODO: get working
 #
 
-ARGS=-O3 -Wall -std=c++20 -mavx2 -D_SANITIZE -D_X64 -D_OBJECK_NATIVE_LIB_PATH -D_MODULE -Wint-to-pointer-cast -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast
+ARGS=-O3 -Wall -std=c++20 -mavx2 -D_SANITIZE -D_X64 -D_OBJECK_NATIVE_LIB_PATH -D_MODULE -Wint-to-pointer-cast -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast -MMD -MP
 
 SRC=lang.o
 OBJ_LIBS=../shared/sys.cpp ../compiler/compiler.a ../vm/vm.a
@@ -25,8 +25,13 @@ $(LIB): $(SRC) $(OBJ_LIBS)
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(COMPILER_PATH); $(MAKE) -f make/Makefile.amd64.mod clean
 	cd $(VM_PATH); $(MAKE) -f make/Makefile.amd64.mod clean
-	rm -f $(LIB) *.o *~
+	rm -f $(LIB) *.o *.d *~
 

--- a/core/module/make/Makefile.arm64
+++ b/core/module/make/Makefile.arm64
@@ -2,7 +2,7 @@
 # TODO: get working
 #
 
-ARGS=-O3 -Wall -std=c++20 -D_SANITIZE -D_X64 -D_OBJECK_NATIVE_LIB_PATH -D_MODULE -Wint-to-pointer-cast -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast
+ARGS=-O3 -Wall -std=c++20 -D_SANITIZE -D_X64 -D_OBJECK_NATIVE_LIB_PATH -D_MODULE -Wint-to-pointer-cast -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast -MMD -MP
 
 SRC=lang.o
 OBJ_LIBS=../shared/sys.cpp ../compiler/compiler.a ../vm/vm.a
@@ -25,8 +25,13 @@ $(LIB): $(SRC) $(OBJ_LIBS)
 %.o: %.cpp
 	$(CXX) $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(COMPILER_PATH); $(MAKE) -f make/Makefile.arm64.mod clean
 	cd $(VM_PATH); $(MAKE) -f make/Makefile.arm64.mod clean
-	rm -f $(LIB) *.o *~
+	rm -f $(LIB) *.o *.d *~
 

--- a/core/module/make/Makefile.msys2-clang.amd64
+++ b/core/module/make/Makefile.msys2-clang.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++20 -mavx2 -D_SANITIZE -D_X64 -D_OBJECK_NATIVE_LIB_PATH -D_MSYS2_CLANG -D_MODULE -Wint-to-pointer-cast -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast
+ARGS=-O3 -Wall -std=c++20 -mavx2 -D_SANITIZE -D_X64 -D_OBJECK_NATIVE_LIB_PATH -D_MSYS2_CLANG -D_MODULE -Wint-to-pointer-cast -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast -MMD -MP
 
 CXX=clang++
 SRC=lang.o
@@ -22,7 +22,12 @@ $(LIB): $(SRC) $(OBJ_LIBS)
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(COMPILER_PATH); $(MAKE) -f make/Makefile.msys2-clang.amd64.mod clean
 	cd $(VM_PATH); $(MAKE) -f make/Makefile.msys2-clang.amd64.mod clean
-	rm -f $(LIB) *.o *~
+	rm -f $(LIB) *.o *.d *~

--- a/core/module/make/Makefile.msys2-ucrt.amd64
+++ b/core/module/make/Makefile.msys2-ucrt.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++20 -mavx2 -D_SANITIZE -D_X64 -D_OBJECK_NATIVE_LIB_PATH -D_MODULE -Wint-to-pointer-cast -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast
+ARGS=-O3 -Wall -std=c++20 -mavx2 -D_SANITIZE -D_X64 -D_OBJECK_NATIVE_LIB_PATH -D_MODULE -Wint-to-pointer-cast -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast -MMD -MP
 
 SRC=lang.o
 OBJ_LIBS=../shared/sys.cpp ../compiler/compiler.a ../vm/vm.a
@@ -21,8 +21,13 @@ $(LIB): $(SRC) $(OBJ_LIBS)
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(COMPILER_PATH); $(MAKE) -f make/Makefile.msys2-ucrt.amd64.mod clean
 	cd $(VM_PATH); $(MAKE) -f make/Makefile.msys2-ucrt.amd64.mod clean
-	rm -f $(LIB) *.o *~
+	rm -f $(LIB) *.o *.d *~
 

--- a/core/repl/make/Makefile.amd64
+++ b/core/repl/make/Makefile.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++20 -mavx2 -D_NO_HALT -D_X64 -D_OBJECK_NATIVE_LIB_PATH -Wno-unused-function
+ARGS=-O3 -Wall -std=c++20 -mavx2 -D_NO_HALT -D_X64 -D_OBJECK_NATIVE_LIB_PATH -Wno-unused-function -MMD -MP
 SRC=editor.o repl.o
 OBJ_LIBS=../module/module.a
 MODULE_PATH=../module
@@ -13,6 +13,11 @@ $(EXE): $(SRC) $(OBJ_LIBS)
 ../module/module.a:
 	cd $(MODULE_PATH); $(MAKE) -f make/Makefile.amd64
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(MODULE_PATH); $(MAKE) -f make/Makefile.amd64 clean
-	rm -f $(EXE) *.a *.o *~
+	rm -f $(EXE) *.a *.o *.d *~

--- a/core/repl/make/Makefile.arm64
+++ b/core/repl/make/Makefile.arm64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++20 -D_ARM64 -D_OBJECK_NATIVE_LIB_PATH -Wno-unused-function
+ARGS=-O3 -Wall -std=c++20 -D_ARM64 -D_OBJECK_NATIVE_LIB_PATH -Wno-unused-function -MMD -MP
 SRC=editor.o repl.o
 OBJ_LIBS=../module/module.a
 MODULE_PATH=../module
@@ -13,6 +13,11 @@ $(EXE): $(SRC) $(OBJ_LIBS)
 ../module/module.a:
 	cd $(MODULE_PATH); $(MAKE) -f make/Makefile.arm64
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(MODULE_PATH); $(MAKE) -f make/Makefile.arm64 clean
-	rm -f $(EXE) *.a *.o *~
+	rm -f $(EXE) *.a *.o *.d *~

--- a/core/repl/make/Makefile.msys2-clang.amd64
+++ b/core/repl/make/Makefile.msys2-clang.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++20 -mavx2 -D_NO_HALT -D_MSYS2 -D_MSYS2_CLANG -D_WIN32 -D_X64 -D_OBJECK_NATIVE_LIB_PATH -Wno-unused-function -Wno-deprecated-declarations
+ARGS=-O3 -Wall -std=c++20 -mavx2 -D_NO_HALT -D_MSYS2 -D_MSYS2_CLANG -D_WIN32 -D_X64 -D_OBJECK_NATIVE_LIB_PATH -Wno-unused-function -Wno-deprecated-declarations -MMD -MP
 SRC=editor.o repl.o
 OBJ_LIBS=../module/module.a objeck.res
 MODULE_PATH=../module
@@ -16,6 +16,11 @@ $(EXE): $(SRC) $(OBJ_LIBS)
 objeck.res:
 	windres vs/objeck.rc -O coff -o objeck.res -D_MSYS2_CLANG
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(MODULE_PATH); $(MAKE) -f make/Makefile.msys2-clang.amd64 clean
-	rm -f $(EXE) *.a *.o *~
+	rm -f $(EXE) *.a *.o *.d *~

--- a/core/repl/make/Makefile.msys2-ucrt.amd64
+++ b/core/repl/make/Makefile.msys2-ucrt.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++20 -mavx2 -D_X64 -D_NO_HALT -D_OBJECK_NATIVE_LIB_PATH -Wno-unused-function 
+ARGS=-O3 -Wall -std=c++20 -mavx2 -D_X64 -D_NO_HALT -D_OBJECK_NATIVE_LIB_PATH -Wno-unused-function -MMD -MP
 SRC=editor.o repl.o
 OBJ_LIBS=../module/module.a objeck.res
 MODULE_PATH=../module
@@ -16,6 +16,11 @@ $(EXE): $(SRC) $(OBJ_LIBS)
 objeck.res:
 	windres vs/objeck.rc -O coff -o objeck.res -D_MSYS2_CLANG
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(MODULE_PATH); $(MAKE) -f make/Makefile.msys2-ucrt.amd64 clean
-	rm -f $(EXE) *.a *.o *~
+	rm -f $(EXE) *.a *.o *.d *~

--- a/core/shared/make/Makefile.amd64
+++ b/core/shared/make/Makefile.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -flto=auto -Wall -Wno-unused-function -std=c++20 -mavx2
+ARGS=-O3 -flto=auto -Wall -Wno-unused-function -std=c++20 -mavx2 -MMD -MP
 
 AR=ar
 SRC=logger.o sys.o
@@ -11,5 +11,10 @@ $(LIB): $(SRC)
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/shared/make/Makefile.arm64
+++ b/core/shared/make/Makefile.arm64
@@ -1,4 +1,4 @@
-ARGS=-O3 -flto=auto -mcpu=native -Wall -Wno-unused-function -std=c++20
+ARGS=-O3 -flto=auto -mcpu=native -Wall -Wno-unused-function -std=c++20 -MMD -MP
 
 AR=ar
 SRC=logger.o sys.o
@@ -10,5 +10,10 @@ $(LIB): $(SRC)
 %.o: %.cpp
 	$(CXX) $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/shared/make/Makefile.msys2-clang.amd64
+++ b/core/shared/make/Makefile.msys2-clang.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -mavx2
+ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -mavx2 -MMD -MP
 
 AR=ar
 SRC=logger.o sys.o
@@ -11,5 +11,10 @@ $(LIB): $(SRC)
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/shared/make/Makefile.msys2-ucrt.amd64
+++ b/core/shared/make/Makefile.msys2-ucrt.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -mavx2
+ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -mavx2 -MMD -MP
 
 AR=ar
 SRC=logger.o sys.o
@@ -11,5 +11,10 @@ $(LIB): $(SRC)
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/utils/launcher/make/Makefile.obb.amd64
+++ b/core/utils/launcher/make/Makefile.obb.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -mavx2
+ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -mavx2 -MMD -MP
 
 SRC=builder.o
 EXE=obb
@@ -10,5 +10,10 @@ $(EXE): $(OBJ_LIBS) $(SRC)
 	$(CXX) -m64 $(ARGS) -c $< 
 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f $(EXE) *.o *~
+	rm -f $(EXE) *.o *.d *~

--- a/core/utils/launcher/make/Makefile.obb.arm64
+++ b/core/utils/launcher/make/Makefile.obb.arm64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -Wno-unused-function -std=c++20
+ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -MMD -MP
 
 SRC=builder.o
 EXE=obb
@@ -10,5 +10,10 @@ $(EXE): $(OBJ_LIBS) $(SRC)
 	$(CXX) $(ARGS) -c $< 
 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f $(EXE) *.o *~
+	rm -f $(EXE) *.o *.d *~

--- a/core/utils/launcher/make/Makefile.obb.msys2-clang.amd64
+++ b/core/utils/launcher/make/Makefile.obb.msys2-clang.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++20 -mavx2 -Wno-unused-function
+ARGS=-O3 -Wall -std=c++20 -mavx2 -Wno-unused-function -MMD -MP
 
 SRC=builder.o
 OBJ_LIBS=objeck.res
@@ -13,5 +13,10 @@ $(EXE): $(SRC) $(OBJ_LIBS)
 objeck.res:
 	windres vs/builder/objeck.rc -O coff -o objeck.res
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f $(EXE) *.o *~ *.res
+	rm -f $(EXE) *.o *.d *~ *.res

--- a/core/utils/launcher/make/Makefile.obb.msys2-ucrt.amd64
+++ b/core/utils/launcher/make/Makefile.obb.msys2-ucrt.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -mavx2
+ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -mavx2 -MMD -MP
 
 SRC=builder.o
 OBJ_LIBS=objeck.res
@@ -13,5 +13,10 @@ $(EXE): $(SRC) $(OBJ_LIBS)
 objeck.res:
 	windres vs/builder/objeck.rc -O coff -o objeck.res
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f $(EXE) *.o *~ *.res
+	rm -f $(EXE) *.o *.d *~ *.res

--- a/core/utils/launcher/make/Makefile.obn.amd64
+++ b/core/utils/launcher/make/Makefile.obn.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -mavx2
+ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -mavx2 -MMD -MP
 
 SRC=launcher.o
 EXE=obn
@@ -10,5 +10,10 @@ $(EXE): $(OBJ_LIBS) $(SRC)
 	$(CXX) -m64 $(ARGS) -c $< 
 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f $(EXE) *.o *~
+	rm -f $(EXE) *.o *.d *~

--- a/core/utils/launcher/make/Makefile.obn.arm64
+++ b/core/utils/launcher/make/Makefile.obn.arm64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -Wno-unused-function -std=c++20
+ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -MMD -MP
 
 SRC=launcher.o
 EXE=obn
@@ -10,5 +10,10 @@ $(EXE): $(OBJ_LIBS) $(SRC)
 	$(CXX) $(ARGS) -c $< 
 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f $(EXE) *.o *~
+	rm -f $(EXE) *.o *.d *~

--- a/core/utils/launcher/make/Makefile.obn.msys2-clang.amd64
+++ b/core/utils/launcher/make/Makefile.obn.msys2-clang.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -D_MSYS2 -Wall -D_MSYS2 -Wno-unused-function -std=c++20 -mavx2
+ARGS=-O3 -D_MSYS2 -Wall -D_MSYS2 -Wno-unused-function -std=c++20 -mavx2 -MMD -MP
 
 SRC=launcher.o
 EXE=obn
@@ -10,5 +10,10 @@ $(EXE): $(OBJ_LIBS) $(SRC)
 	$(CXX) -m64 $(ARGS) -c $< 
 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f $(EXE) *.o *~
+	rm -f $(EXE) *.o *.d *~

--- a/core/utils/launcher/make/Makefile.obn.msys2-ucrt.amd64
+++ b/core/utils/launcher/make/Makefile.obn.msys2-ucrt.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -D_MSYS2 -Wall -Wno-unused-function -std=c++20 -mavx2
+ARGS=-O3 -D_MSYS2 -Wall -Wno-unused-function -std=c++20 -mavx2 -MMD -MP
 
 SRC=launcher.o
 EXE=obn
@@ -10,5 +10,10 @@ $(EXE): $(OBJ_LIBS) $(SRC)
 	$(CXX) -m64 $(ARGS) -c $< 
 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f $(EXE) *.o *~
+	rm -f $(EXE) *.o *.d *~

--- a/core/utils/updater/make/Makefile.amd64
+++ b/core/utils/updater/make/Makefile.amd64
@@ -21,7 +21,7 @@ ifeq ($(shell command -v $(firstword $(CXX)) >/dev/null 2>&1 && echo ok),)
 CXX := c++
 endif
 
-ARGS=-O3 -Wall -Wno-unused-function -std=c++17 -mavx2
+ARGS=-O3 -Wall -Wno-unused-function -std=c++17 -mavx2 -MMD -MP
 
 SRC=obu.o
 EXE=obu
@@ -32,5 +32,10 @@ $(EXE): $(SRC)
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $<
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f $(EXE) *.o *~
+	rm -f $(EXE) *.o *.d *~

--- a/core/utils/updater/make/Makefile.arm64
+++ b/core/utils/updater/make/Makefile.arm64
@@ -21,7 +21,7 @@ ifeq ($(shell command -v $(firstword $(CXX)) >/dev/null 2>&1 && echo ok),)
 CXX := c++
 endif
 
-ARGS=-O3 -Wall -Wno-unused-function -std=c++17
+ARGS=-O3 -Wall -Wno-unused-function -std=c++17 -MMD -MP
 
 SRC=obu.o
 EXE=obu
@@ -32,5 +32,10 @@ $(EXE): $(SRC)
 %.o: %.cpp
 	$(CXX) $(ARGS) -c $<
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f $(EXE) *.o *~
+	rm -f $(EXE) *.o *.d *~

--- a/core/vm/Makefile
+++ b/core/vm/Makefile
@@ -1,4 +1,4 @@
-ARGS=-O3 -flto=auto -Wall -pthread -D_X64 -D_OBJECK_NATIVE_LIB_PATH -DOBJECK_HAS_NGHTTP2 -DOBJECK_HAS_NGTCP2 -std=c++20 -mavx2 -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast -Wno-unused-result
+ARGS=-O3 -flto=auto -Wall -pthread -D_X64 -D_OBJECK_NATIVE_LIB_PATH -DOBJECK_HAS_NGHTTP2 -DOBJECK_HAS_NGTCP2 -std=c++20 -mavx2 -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast -Wno-unused-result -MMD -MP
 
 SRC=common.o dispatch.o interpreter.o loader.o vm.o posix_main.o 
 OBJ_LIBS=jit_amd_lp64.a memory.a
@@ -21,7 +21,12 @@ jit_amd_lp64.a:
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(MEM_PATH); $(MAKE) clean -f make/Makefile.amd64
 	cd $(JIT_PATH); $(MAKE) clean -f make/Makefile.amd64
-	rm -f $(EXE).exe $(EXE) *.exe *.o *~
+	rm -f $(EXE).exe $(EXE) *.exe *.o *.d *~

--- a/core/vm/arch/jit/amd64/make/Makefile.amd64
+++ b/core/vm/arch/jit/amd64/make/Makefile.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -flto=auto -D_X64 -Wall -Wno-unused-function -std=c++20 -mavx2 -Wno-deprecated-declarations -Wunused-variable -fno-sanitize-recover
+ARGS=-O3 -flto=auto -D_X64 -Wall -Wno-unused-function -std=c++20 -mavx2 -Wno-deprecated-declarations -Wunused-variable -fno-sanitize-recover -MMD -MP
 
 AR=gcc-ar
 COMMON_LIBS=jit_common.a
@@ -15,6 +15,11 @@ jit_common.a:
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(COMMON_PATH); $(MAKE) -f make/Makefile.amd64 clean
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/vm/arch/jit/amd64/make/Makefile.msys2-clang.amd64
+++ b/core/vm/arch/jit/amd64/make/Makefile.msys2-clang.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -D_X64 -Wall -Wno-unused-function -std=c++20 -mavx2 -Wno-deprecated-declarations -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast
+ARGS=-O3 -D_X64 -Wall -Wno-unused-function -std=c++20 -mavx2 -Wno-deprecated-declarations -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -MMD -MP
 
 AR=ar
 COMMON_LIBS=jit_common.a
@@ -15,6 +15,11 @@ jit_common.a:
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(COMMON_PATH); $(MAKE) -f make/Makefile.msys2-clang.amd64 clean
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/vm/arch/jit/amd64/make/Makefile.msys2-ucrt.amd64
+++ b/core/vm/arch/jit/amd64/make/Makefile.msys2-ucrt.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -D_X64 -Wall -Wno-unused-function -std=c++20 -mavx2 -Wno-deprecated-declarations -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-maybe-uninitialized
+ARGS=-O3 -D_X64 -Wall -Wno-unused-function -std=c++20 -mavx2 -Wno-deprecated-declarations -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-maybe-uninitialized -MMD -MP
 
 AR=ar
 COMMON_LIBS=jit_common.a
@@ -15,6 +15,11 @@ jit_common.a:
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(COMMON_PATH); $(MAKE) -f make/Makefile.msys2-ucrt.amd64 clean
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/vm/arch/jit/arm64/make/Makefile.arm64
+++ b/core/vm/arch/jit/arm64/make/Makefile.arm64
@@ -1,4 +1,4 @@
-ARGS=-O3 -flto=auto -mcpu=native -D_ARM64 -Wall -Wno-unused-function -std=c++20 -Wno-deprecated-declarations
+ARGS=-O3 -flto=auto -mcpu=native -D_ARM64 -Wall -Wno-unused-function -std=c++20 -Wno-deprecated-declarations -MMD -MP
 
 AR=gcc-ar
 COMMON_LIBS=jit_common.a
@@ -15,6 +15,11 @@ jit_common.a:
 %.o: %.cpp
 	$(CXX) $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(COMMON_PATH); $(MAKE) -f make/Makefile.arm64 clean
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/vm/arch/jit/make/Makefile.amd64
+++ b/core/vm/arch/jit/make/Makefile.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -flto=auto -Wall -std=c++20 -mavx2 -D_X64 -Wno-unused-function -Wno-unused-variable
+ARGS=-O3 -flto=auto -Wall -std=c++20 -mavx2 -D_X64 -Wno-unused-function -Wno-unused-variable -MMD -MP
 
 AR=gcc-ar
 SRC=jit_common.o
@@ -10,5 +10,10 @@ $(LIB): $(SRC)
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/vm/arch/jit/make/Makefile.arm64
+++ b/core/vm/arch/jit/make/Makefile.arm64
@@ -1,6 +1,6 @@
 # -D_ARM64 must match the other VM TUs: NativeCode's layout in common.h
 # depends on it, and a mismatch is an ODR violation under LTO (-Wodr).
-ARGS=-O3 -flto=auto -mcpu=native -Wall -D_ARM64 -Wno-unused-function -std=c++20 -Wno-unused-variable
+ARGS=-O3 -flto=auto -mcpu=native -Wall -D_ARM64 -Wno-unused-function -std=c++20 -Wno-unused-variable -MMD -MP
 
 AR=gcc-ar
 SRC=jit_common.o
@@ -12,5 +12,10 @@ $(LIB): $(SRC)
 %.o: %.cpp
 	$(CXX) $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/vm/arch/jit/make/Makefile.msys2-clang.amd64
+++ b/core/vm/arch/jit/make/Makefile.msys2-clang.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++20 -mavx2 -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unused-but-set-variable
+ARGS=-O3 -Wall -std=c++20 -mavx2 -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unused-but-set-variable -MMD -MP
 
 AR=ar
 SRC=jit_common.o
@@ -10,5 +10,10 @@ $(LIB): $(SRC)
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/vm/arch/jit/make/Makefile.msys2-ucrt.amd64
+++ b/core/vm/arch/jit/make/Makefile.msys2-ucrt.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -mavx2 -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-maybe-uninitialized
+ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -mavx2 -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-maybe-uninitialized -MMD -MP
 
 AR=ar
 SRC=jit_common.o
@@ -10,5 +10,10 @@ $(LIB): $(SRC)
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/vm/arch/make/Makefile.amd64
+++ b/core/vm/arch/make/Makefile.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -flto=auto -Wall -D_X64 -Wno-unused-function -std=c++20 -mavx2 -fno-sanitize-recover
+ARGS=-O3 -flto=auto -Wall -D_X64 -Wno-unused-function -std=c++20 -mavx2 -fno-sanitize-recover -MMD -MP
 
 AR=gcc-ar
 SRC=memory.o
@@ -10,5 +10,10 @@ $(LIB): $(SRC)
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/vm/arch/make/Makefile.arm64
+++ b/core/vm/arch/make/Makefile.arm64
@@ -1,4 +1,4 @@
-ARGS=-O3 -flto=auto -mcpu=native -Wall -D_ARM64 -D_RPI4 -Wno-unused-function -std=c++20
+ARGS=-O3 -flto=auto -mcpu=native -Wall -D_ARM64 -D_RPI4 -Wno-unused-function -std=c++20 -MMD -MP
 
 AR=gcc-ar
 SRC=memory.o
@@ -10,5 +10,10 @@ $(LIB): $(SRC)
 %.o: %.cpp
 	$(CXX) $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/vm/arch/make/Makefile.msys2-clang.amd64
+++ b/core/vm/arch/make/Makefile.msys2-clang.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -D_X64 -D_MSYS2 -std=c++20 -mavx2 -Wno-unused-command-line-argument -Wno-unused-function 
+ARGS=-O3 -Wall -D_X64 -D_MSYS2 -std=c++20 -mavx2 -Wno-unused-command-line-argument -Wno-unused-function -MMD -MP
 
 AR=ar
 SRC=memory.o 
@@ -10,5 +10,10 @@ $(LIB): $(SRC)
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/vm/arch/make/Makefile.msys2-ucrt.amd64
+++ b/core/vm/arch/make/Makefile.msys2-ucrt.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -D_X64 -D_MSYS2 -std=c++20 -mavx2 -Wno-unknown-pragmas -Wno-unused-function -Wno-maybe-uninitialized
+ARGS=-O3 -Wall -D_X64 -D_MSYS2 -std=c++20 -mavx2 -Wno-unknown-pragmas -Wno-unused-function -Wno-maybe-uninitialized -MMD -MP
 
 AR=ar
 SRC=memory.o 
@@ -10,5 +10,10 @@ $(LIB): $(SRC)
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/vm/arch/win32/make/Makefile.msys2-clang.amd64
+++ b/core/vm/arch/win32/make/Makefile.msys2-clang.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -mavx2 -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast 
+ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -mavx2 -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -MMD -MP
 
 SRC=win32.o
 LIB=../../win32.a
@@ -9,5 +9,10 @@ $(LIB): $(SRC)
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/vm/arch/win32/make/Makefile.msys2-ucrt.amd64
+++ b/core/vm/arch/win32/make/Makefile.msys2-ucrt.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -mavx2 -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-dangling-pointer -Wno-int-to-pointer-cast 
+ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -mavx2 -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-dangling-pointer -Wno-int-to-pointer-cast -MMD -MP
 
 AR=ar
 SRC=win32.o
@@ -10,5 +10,10 @@ $(LIB): $(SRC)
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
-	rm -f *.o *~ $(LIB)
+	rm -f *.o *.d *~ $(LIB)

--- a/core/vm/make/Makefile.amd64
+++ b/core/vm/make/Makefile.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -flto=auto -Wall -pthread -D_X64 -D_OBJECK_NATIVE_LIB_PATH -DOBJECK_HAS_NGHTTP2 -DOBJECK_HAS_NGTCP2 -std=c++20 -mavx2 -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast -Wno-unused-result
+ARGS=-O3 -flto=auto -Wall -pthread -D_X64 -D_OBJECK_NATIVE_LIB_PATH -DOBJECK_HAS_NGHTTP2 -DOBJECK_HAS_NGTCP2 -std=c++20 -mavx2 -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast -Wno-unused-result -MMD -MP
 
 SRC=common.o dispatch.o interpreter.o loader.o vm.o posix_main.o 
 OBJ_LIBS=jit_amd_lp64.a memory.a
@@ -21,7 +21,12 @@ jit_amd_lp64.a:
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(MEM_PATH); $(MAKE) clean -f make/Makefile.amd64
 	cd $(JIT_PATH); $(MAKE) clean -f make/Makefile.amd64
-	rm -f $(EXE).exe $(EXE) *.exe *.o *~
+	rm -f $(EXE).exe $(EXE) *.exe *.o *.d *~

--- a/core/vm/make/Makefile.amd64.mod
+++ b/core/vm/make/Makefile.amd64.mod
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -D_MODULE -D_X64 -D_OBJECK_NATIVE_LIB_PATH -std=c++20 -mavx2 -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast -Wno-unused-result
+ARGS=-O3 -Wall -D_MODULE -D_X64 -D_OBJECK_NATIVE_LIB_PATH -std=c++20 -mavx2 -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast -Wno-unused-result -MMD -MP
 
 SRC=common.o dispatch.o interpreter.o loader.o vm.o posix_main.o 
 OBJ_LIBS=jit_amd_lp64.a memory.a
@@ -23,7 +23,12 @@ jit_amd_lp64.a:
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(MEM_PATH); $(MAKE) clean -f make/Makefile.amd64
 	cd $(JIT_PATH); $(MAKE) clean -f make/Makefile.amd64
-	rm -f $(LIB) *.o *~
+	rm -f $(LIB) *.o *.d *~

--- a/core/vm/make/Makefile.amd64.obd
+++ b/core/vm/make/Makefile.amd64.obd
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -D_DEBUGGER -D_OBJECK_NATIVE_LIB_PATH -D_NO_JIT -std=c++20 -mavx2 -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast -Wno-unused-result
+ARGS=-O3 -Wall -D_DEBUGGER -D_OBJECK_NATIVE_LIB_PATH -D_NO_JIT -std=c++20 -mavx2 -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast -Wno-unused-result -MMD -MP
 
 SRC=common.o dispatch.o interpreter.o loader.o vm.o posix_main.o 
 OBJ_LIBS=jit_amd_lp64.a memory.a
@@ -18,7 +18,12 @@ jit_amd_lp64.a:
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(MEM_PATH); $(MAKE) clean -f make/Makefile.amd64
 	cd $(JIT_PATH); $(MAKE) clean -f make/Makefile.amd64
-	rm -f $(LIB) *.o *~
+	rm -f $(LIB) *.o *.d *~

--- a/core/vm/make/Makefile.arm64
+++ b/core/vm/make/Makefile.arm64
@@ -1,4 +1,4 @@
-ARGS=-O3 -flto=auto -mcpu=native -Wall -std=c++20 -D_ARM64 -D_OBJECK_NATIVE_LIB_PATH -DOBJECK_HAS_NGHTTP2 -DOBJECK_HAS_NGTCP2 -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast -Wno-unused-variable
+ARGS=-O3 -flto=auto -mcpu=native -Wall -std=c++20 -D_ARM64 -D_OBJECK_NATIVE_LIB_PATH -DOBJECK_HAS_NGHTTP2 -DOBJECK_HAS_NGTCP2 -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast -Wno-unused-variable -MMD -MP
 
 SRC=common.o dispatch.o interpreter.o loader.o vm.o posix_main.o 
 OBJ_LIBS= jit_arm_a64.a memory.a
@@ -21,7 +21,12 @@ jit_arm_a64.a:
 %.o: %.cpp
 	$(CXX) $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(MEM_PATH); $(MAKE) clean -f make/Makefile.arm64
 	cd $(JIT_PATH); $(MAKE) clean -f make/Makefile.arm64
-	rm -f $(EXE).exe $(EXE) *.exe *.o *~
+	rm -f $(EXE).exe $(EXE) *.exe *.o *.d *~

--- a/core/vm/make/Makefile.arm64.mod
+++ b/core/vm/make/Makefile.arm64.mod
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++20 -D_ARM64 -D_OBJECK_NATIVE_LIB_PATH -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast
+ARGS=-O3 -Wall -std=c++20 -D_ARM64 -D_OBJECK_NATIVE_LIB_PATH -Wno-unused-variable -Wno-unused-function -Wno-int-to-pointer-cast -MMD -MP
 
 SRC=common.o dispatch.o interpreter.o loader.o vm.o posix_main.o 
 OBJ_LIBS=jit_arm_a64.a memory.a
@@ -23,7 +23,12 @@ jit_arm_a64.a:
 %.o: %.cpp
 	$(CXX) $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(MEM_PATH); $(MAKE) clean -f make/Makefile.arm64
 	cd $(JIT_PATH); $(MAKE) clean -f make/Makefile.arm64
-	rm -f $(LIB) *.o *~
+	rm -f $(LIB) *.o *.d *~

--- a/core/vm/make/Makefile.arm64.obd
+++ b/core/vm/make/Makefile.arm64.obd
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -Wno-strict-overflow -pthread -Wall -D_DEBUGGER -D_OBJECK_NATIVE_LIB_PATH -D_NO_JIT -Wno-int-to-pointer-cast -Wno-unused-variable
+ARGS=-O3 -Wall -Wno-unused-function -std=c++20 -Wno-strict-overflow -pthread -Wall -D_DEBUGGER -D_OBJECK_NATIVE_LIB_PATH -D_NO_JIT -Wno-int-to-pointer-cast -Wno-unused-variable -MMD -MP
 
 SRC=common.o dispatch.o interpreter.o loader.o vm.o posix_main.o 
 OBJ_LIBS=jit_arm_a64.a memory.a
@@ -18,7 +18,12 @@ jit_arm_a64.a:
 %.o: %.cpp
 	$(CXX) $(ARGS) -c $<
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(MEM_PATH); $(MAKE) clean -f make/Makefile.arm64
 	cd $(JIT_PATH); $(MAKE) clean -f make/Makefile.arm64
-	rm -f $(LIB) *.o *~
+	rm -f $(LIB) *.o *.d *~

--- a/core/vm/make/Makefile.msys2-clang.amd64
+++ b/core/vm/make/Makefile.msys2-clang.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++20 -mavx2 -pthread -D_MSYS2 -D_MSYS2_CLANG -D_X64 -D_WIN32 -D_OBJECK_NATIVE_LIB_PATH -DOBJECK_HAS_NGHTTP2 -Wno-uninitialized -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas -Wno-unused-but-set-variable -Wno-deprecated-declarations
+ARGS=-O3 -Wall -std=c++20 -mavx2 -pthread -D_MSYS2 -D_MSYS2_CLANG -D_X64 -D_WIN32 -D_OBJECK_NATIVE_LIB_PATH -DOBJECK_HAS_NGHTTP2 -Wno-uninitialized -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas -Wno-unused-but-set-variable -Wno-deprecated-declarations -MMD -MP
 
 SRC=common.o dispatch.o interpreter.o loader.o vm.o win_main.o
 OBJ_LIBS=win32.a jit_amd_lp64.a memory.a objeck.res
@@ -28,8 +28,13 @@ objeck.res:
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(MEM_PATH); $(MAKE) -f make/Makefile.msys2-clang.amd64 clean
 	cd $(JIT_PATH); $(MAKE) -f make/Makefile.msys2-clang.amd64 clean
 	cd $(WIN32_PATH); $(MAKE) -f make/Makefile.msys2-clang.amd64 clean
-	rm -f $(EXE).exe $(EXE) *.exe *.dll *.o *~ *.res
+	rm -f $(EXE).exe $(EXE) *.exe *.dll *.o *.d *~ *.res

--- a/core/vm/make/Makefile.msys2-clang.amd64.mod
+++ b/core/vm/make/Makefile.msys2-clang.amd64.mod
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -D_MODULE -D_X64 -D_OBJECK_NATIVE_LIB_PATH -D_MSYS2 -D_MSYS2_CLANG -std=c++20 -mavx2 -Wno-uninitialized -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas -Wno-unused-but-set-variable
+ARGS=-O3 -Wall -D_MODULE -D_X64 -D_OBJECK_NATIVE_LIB_PATH -D_MSYS2 -D_MSYS2_CLANG -std=c++20 -mavx2 -Wno-uninitialized -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas -Wno-unused-but-set-variable -MMD -MP
 
 SRC=common.o dispatch.o interpreter.o loader.o vm.o posix_main.o 
 OBJ_LIBS=win32.a jit_amd_lp64.a memory.a
@@ -27,8 +27,13 @@ win32.a:
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(MEM_PATH); $(MAKE) clean -f make/Makefile.msys2-clang.amd64
 	cd $(JIT_PATH); $(MAKE) clean -f make/Makefile.msys2-clang.amd64
 	cd $(WIN32_PATH); $(MAKE) clean -f make/Makefile.msys2-clang.amd64
-	rm -f $(LIB) *.o *~
+	rm -f $(LIB) *.o *.d *~

--- a/core/vm/make/Makefile.msys2-clang.amd64.obd
+++ b/core/vm/make/Makefile.msys2-clang.amd64.obd
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++20 -mavx2 -Wno-strict-overflow -pthread -Wall -D_WIN32 -D_MSYS2 -D_MSYS2_CLANG -D_X64 -D_DEBUGGER -D_OBJECK_NATIVE_LIB_PATH -D_NO_JIT -Wno-uninitialized -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas -Wno-unused-but-set-variable
+ARGS=-O3 -Wall -std=c++20 -mavx2 -Wno-strict-overflow -pthread -Wall -D_WIN32 -D_MSYS2 -D_MSYS2_CLANG -D_X64 -D_DEBUGGER -D_OBJECK_NATIVE_LIB_PATH -D_NO_JIT -Wno-uninitialized -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas -Wno-unused-but-set-variable -MMD -MP
 
 SRC=common.o dispatch.o interpreter.o loader.o vm.o posix_main.o 
 OBJ_LIBS=jit_amd_lp64.a memory.a
@@ -18,7 +18,12 @@ jit_amd_lp64.a:
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(MEM_PATH); $(MAKE) clean -f make/Makefile.msys2-clang.amd64
 	cd $(JIT_PATH); $(MAKE) clean -f make/Makefile.msys2-clang.amd64
-	rm -f $(LIB) *.o *~
+	rm -f $(LIB) *.o *.d *~

--- a/core/vm/make/Makefile.msys2-ucrt.amd64
+++ b/core/vm/make/Makefile.msys2-ucrt.amd64
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++20 -mavx2 -pthread -D_MSYS2 -D_X64 -D_WIN32 -D_OBJECK_NATIVE_LIB_PATH -DOBJECK_HAS_NGHTTP2 -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unused-but-set-variable -Wno-dangling-pointer
+ARGS=-O3 -Wall -std=c++20 -mavx2 -pthread -D_MSYS2 -D_X64 -D_WIN32 -D_OBJECK_NATIVE_LIB_PATH -DOBJECK_HAS_NGHTTP2 -Wno-uninitialized -Wno-unknown-pragmas -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unused-but-set-variable -Wno-dangling-pointer -MMD -MP
 
 SRC=common.o dispatch.o interpreter.o loader.o vm.o win_main.o
 OBJ_LIBS=win32.a jit_amd_lp64.a memory.a objeck.res
@@ -28,8 +28,13 @@ objeck.res:
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(MEM_PATH); $(MAKE) -f make/Makefile.msys2-ucrt.amd64 clean
 	cd $(JIT_PATH); $(MAKE) -f make/Makefile.msys2-ucrt.amd64 clean
 	cd $(WIN32_PATH); $(MAKE) -f make/Makefile.msys2-ucrt.amd64 clean
-	rm -f $(EXE).exe $(EXE) *.exe *.dll *.o *~ *.res
+	rm -f $(EXE).exe $(EXE) *.exe *.dll *.o *.d *~ *.res

--- a/core/vm/make/Makefile.msys2-ucrt.amd64.mod
+++ b/core/vm/make/Makefile.msys2-ucrt.amd64.mod
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -D_MODULE  -D_MSYS2 -D_X64 -D_OBJECK_NATIVE_LIB_PATH -std=c++20 -mavx2 -Wno-uninitialized -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas -Wno-unused-but-set-variable -Wno-dangling-pointer 
+ARGS=-O3 -Wall -D_MODULE  -D_MSYS2 -D_X64 -D_OBJECK_NATIVE_LIB_PATH -std=c++20 -mavx2 -Wno-uninitialized -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas -Wno-unused-but-set-variable -Wno-dangling-pointer -MMD -MP
 
 SRC=common.o dispatch.o interpreter.o loader.o vm.o posix_main.o 
 OBJ_LIBS=win32.a jit_amd_lp64.a memory.a
@@ -27,8 +27,13 @@ win32.a:
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(MEM_PATH); $(MAKE) clean -f make/Makefile.msys2-ucrt.amd64
 	cd $(JIT_PATH); $(MAKE) clean -f make/Makefile.msys2-ucrt.amd64
 	cd $(WIN32_PATH); $(MAKE) clean -f make/Makefile.msys2-ucrt.amd64
-	rm -f $(LIB) *.o *~
+	rm -f $(LIB) *.o *.d *~

--- a/core/vm/make/Makefile.msys2-ucrt.amd64.obd
+++ b/core/vm/make/Makefile.msys2-ucrt.amd64.obd
@@ -1,4 +1,4 @@
-ARGS=-O3 -Wall -std=c++20 -mavx2 -Wno-strict-overflow -pthread -Wall -D_WIN32 -D_MSYS2 -D_X64 -D_DEBUGGER -D_OBJECK_NATIVE_LIB_PATH -D_NO_JIT -Wno-dangling-pointer -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas  -Wno-maybe-uninitialized
+ARGS=-O3 -Wall -std=c++20 -mavx2 -Wno-strict-overflow -pthread -Wall -D_WIN32 -D_MSYS2 -D_X64 -D_DEBUGGER -D_OBJECK_NATIVE_LIB_PATH -D_NO_JIT -Wno-dangling-pointer -Wno-unused-function -Wno-unused-variable -Wno-int-to-pointer-cast -Wno-unknown-pragmas  -Wno-maybe-uninitialized -MMD -MP
 
 SRC=common.o dispatch.o interpreter.o loader.o vm.o posix_main.o 
 OBJ_LIBS=jit_amd_lp64.a memory.a
@@ -18,7 +18,12 @@ jit_amd_lp64.a:
 %.o: %.cpp
 	$(CXX) -m64 $(ARGS) -c $< 
 
+# Auto-generated header dependencies (see -MMD -MP in ARGS). Without these make
+# never learned that the objects include ../shared/version.h and friends, so a
+# header edit silently relinked stale .o files -- 'make clean' was mandatory.
+-include $(wildcard *.d)
+
 clean:
 	cd $(MEM_PATH); $(MAKE) clean -f make/Makefile.msys2-ucrt.amd64
 	cd $(JIT_PATH); $(MAKE) clean -f make/Makefile.msys2-ucrt.amd64
-	rm -f $(LIB) *.o *~
+	rm -f $(LIB) *.o *.d *~


### PR DESCRIPTION
Split out of the SDL/OpenGL branch — it is independent of that work and worth reviewing on its own.

## The bug

**None of the 82 hand-written makefiles under `core/` tracked header dependencies.** No `-MMD`, no `depend` target, not one explicit `.o: header.h` rule. So editing a header rebuilt nothing that included it, and `make` relinked stale objects.

The sharpest form: after a version bump, `make -f make/Makefile.amd64` in `core/vm` produces an `obr` that rejects freshly compiled programs with

```
This executable appears to be invalid or compiled with an incompatible version of the tool chain.
```

because `obc` got the new `VER_NUM` and the relinked `obr` kept the old one. It reads like a corrupt `.obe`. `make clean` was mandatory and undocumented — it cost real debugging time on this branch.

Reproduced before the fix, and it's worse than a stale relink — make doesn't even relink:

```
=== BEFORE: touch core/shared/version.h, then make ===
make: 'obr' is up to date.
```

## The fix

`-MMD -MP` in `ARGS`, `-include $(wildcard *.d)`, and `*.d` in the `clean` target across **64 makefiles**: the VM (13, including `.mod`/`.obd` variants), the VM's archive sub-makefiles (13), compiler (11), shared/debugger/REPL/module (4 each), and launcher/updater (10). Every arch and msys2 variant, so no platform keeps the old behaviour. `*.d` added to `.gitignore`.

`$(wildcard *.d)` rather than `$(SRC:.o=.d)` on purpose: three makefiles list cross-directory objects like `../jit_common.o`, and the substitution form would pull in a depfile whose internal target paths are relative to a different directory.

`core/vm/Makefile` and `core/compiler/Makefile` are tracked byte-copies that the deploy scripts regenerate with `cp make/Makefile.amd64 Makefile`; both patched and still byte-identical to their sources.

## Verified on Linux (WSL2, g++ 13.3.0)

- Clean build succeeds; 10 depfiles generated across the VM tree.
- `touch core/shared/version.h` now recompiles `common.cpp`, `loader.cpp` and `posix_main.cpp` then relinks — **exactly** the three VM translation units that include `version.h`, and not the other three.
- Same test on the compiler: 6 of 11 TUs depend on `version.h` (`emit.cpp` directly, four more transitively via `emit.h`); all 6 rebuilt.
- A no-op `make` is still a no-op — this does not force perpetual rebuilds.
- `make clean` removes the depfiles.
- All 64 parse: `make -n clean` succeeds on every one, including the arm64 and msys2 variants that can't be compiled here.
- Rebuilt `obc` and `obr`, compiled and ran a program: unchanged behaviour.

## Deliberately not changed (18 makefiles)

The orphaned `arch/win32` POSIX variants, `lib/diags`, `lib/odbc` and the autotools artifacts under it, `lib/experimental` (gitignored as deprecated), and the sample modules — none are referenced by any deploy script or workflow, and the `lib` ones are built by scripts that `rm -rf *.o` first, so staleness is impossible there.

## Two related holes found and NOT fixed

Different in kind, and half a fix is worse than none:

1. **Recursive archive targets have no prerequisites** — e.g. `memory.a:` with only a recipe, so once the `.a` exists make never recurses. Editing `memory.cpp`, `jit_common.cpp` or `sys.cpp` is silently ignored from the parent makefile. Reproduced. Needs `.PHONY`.
2. **`ar -cvq` is quick-append, not replace** — so fixing (1) alone would duplicate members and the linker would resolve from the stale first copy. Reproduced: `memory.o` appears twice. Needs `-crv` across ~15 archive makefiles.

Both must land together; filed here rather than half-done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)