### PR TITLE
test: make the regression runners diagnosable and honest about skips

### DIFF
--- a/programs/regression/run_regression.cmd
+++ b/programs/regression/run_regression.cmd
@@ -35,11 +35,18 @@ set OBJECK_LIB_PATH=%CD%
 popd
 set NATIVE_LIB_DIR=%DEPLOY_DIR%\lib\native
 if exist "%NATIVE_LIB_DIR%" set PATH=%NATIVE_LIB_DIR%;%PATH%
+REM The SDL2 runtime DLLs live in lib\sdl, not lib\native (see
+REM deploy_windows.cmd), and libobjk_sdl.dll imports them. Without this, any
+REM test that touches SDL fails with a misleading
+REM "Runtime error loading shared library: ..\lib\native\libobjk_sdl.dll".
+set SDL_LIB_DIR=%DEPLOY_DIR%\lib\sdl
+if exist "%SDL_LIB_DIR%" set PATH=%SDL_LIB_DIR%;%PATH%
 
 if not exist "%RESULTS_DIR%" mkdir "%RESULTS_DIR%"
 
 set PASS_COUNT=0
 set FAIL_COUNT=0
+set SKIP_COUNT=0
 
 REM Accumulate failed test names+reasons in a file (robust string handling in
 REM batch); consumed for the end-of-run failed list and the CI step summary.
@@ -128,10 +135,25 @@ for %%f in (*.obs) do (
                 if !RUN_RESULT! neq 0 (
                     echo   FAIL ^(runtime error^)
                     >>"%FAILED_FILE%" echo %%~nf - runtime error ^(exit !RUN_RESULT!^)
+                    REM Show what the test actually said. Without this a CI
+                    REM failure gives only a test name, and the captured output
+                    REM sits unread in results\ on a runner that is then thrown
+                    REM away -- so diagnosing needs another full CI round trip.
+                    echo   --- output ---
+                    type "%RESULTS_DIR%\%%~nf_output.txt" 2>nul
+                    echo   --------------
                     set /a FAIL_COUNT+=1
                 ) else (
-                    echo   PASS
-                    set /a PASS_COUNT+=1
+                    REM Exit 0 after printing "SKIP:" means the checks never
+                    REM ran. Counting it as a pass overstates coverage.
+                    findstr /b /c:"SKIP:" "%RESULTS_DIR%\%%~nf_output.txt" >nul 2>&1
+                    if !errorlevel! equ 0 (
+                        echo   SKIP
+                        set /a SKIP_COUNT+=1
+                    ) else (
+                        echo   PASS
+                        set /a PASS_COUNT+=1
+                    )
                 )
             )
         )
@@ -140,7 +162,7 @@ for %%f in (*.obs) do (
 
 echo.
 echo ========================================
-echo   Results: !PASS_COUNT! passed, !FAIL_COUNT! failed
+echo   Results: !PASS_COUNT! passed, !SKIP_COUNT! skipped, !FAIL_COUNT! failed
 echo ========================================
 
 REM List exactly what failed so the reader never has to scroll the full log.

--- a/programs/regression/run_regression.sh
+++ b/programs/regression/run_regression.sh
@@ -23,7 +23,9 @@ mkdir -p "$RESULTS_DIR"
 
 PASS_COUNT=0
 FAIL_COUNT=0
+SKIP_COUNT=0
 FAILED_TESTS=()
+SKIPPED_TESTS=()
 
 # Record a failure: print it, remember the test name + reason for the final
 # summary, and bump the counter. Keeps the end-of-run report from forcing the
@@ -32,6 +34,14 @@ record_fail() {
     echo "  [FAIL] $1"
     FAILED_TESTS+=("${NAME} — $1")
     ((FAIL_COUNT++))
+    # Show what the test actually said. Without this a CI failure gives only a
+    # test name, and the captured output sits unread in results/ on a runner that
+    # is then discarded -- so diagnosing anything needs another full round trip.
+    if [ -s "${RESULTS_DIR}/${NAME}_output.txt" ]; then
+        echo "  --- output ---"
+        sed 's/^/  /' "${RESULTS_DIR}/${NAME}_output.txt"
+        echo "  --------------"
+    fi
 }
 
 # Per-test wall-clock cap so a hung/infinite-loop test fails fast instead of
@@ -150,11 +160,19 @@ for test in *.obs; do
             record_fail "VM produced no output — possible crash"
         fi
     elif [ $RUN_EXIT -eq 0 ]; then
-        echo "  [PASS] (${ELAPSED}s)"
-        ((PASS_COUNT++))
+        # A test that exits 0 after printing "SKIP:" did not run its checks.
+        # Counting that as a pass overstates coverage -- the failure mode
+        # where a whole platform is silently untested while CI stays green.
+        if grep -q "^SKIP:" "$RESULTS_DIR/${NAME}_output.txt" 2>/dev/null; then
+            echo "  [SKIP] $(grep -m1 "^SKIP:" "$RESULTS_DIR/${NAME}_output.txt")"
+            SKIPPED_TESTS+=("${NAME}")
+            ((SKIP_COUNT++))
+        else
+            echo "  [PASS] (${ELAPSED}s)"
+            ((PASS_COUNT++))
+        fi
     else
         record_fail "runtime error (exit ${RUN_EXIT})"
-        cat "$RESULTS_DIR/${NAME}_output.txt" 2>/dev/null | head -200
     fi
 done
 
@@ -163,10 +181,17 @@ cd "$REGRESSION_DIR"
 
 echo ""
 echo "========================================"
-echo "  Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+echo "  Results: $PASS_COUNT passed, $SKIP_COUNT skipped, $FAIL_COUNT failed"
 echo "========================================"
 
 # List exactly what failed so the reader never has to scroll the full log.
+if [ $SKIP_COUNT -gt 0 ]; then
+    echo "  Skipped (checks did not run):"
+    for t in "${SKIPPED_TESTS[@]}"; do
+        echo "    - $t"
+    done
+fi
+
 if [ $FAIL_COUNT -gt 0 ]; then
     echo ""
     echo "Failed tests:"
@@ -180,7 +205,7 @@ fi
 # page without opening the raw job log.
 if [ -n "$GITHUB_STEP_SUMMARY" ]; then
     {
-        echo "### Regression — ${PLATFORM}: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+        echo "### Regression — ${PLATFORM}: ${PASS_COUNT} passed, ${SKIP_COUNT} skipped, ${FAIL_COUNT} failed"
         if [ $FAIL_COUNT -gt 0 ]; then
             echo ""
             echo "| Result | Test — reason |"


### PR DESCRIPTION
Split out of the SDL/OpenGL branch. Three fixes to the shared runners, all independent of any feature work — they apply to every one of the 191 tests.

## 1. A failure told you nothing

Both runners captured each test's output to `results/<name>_output.txt` and then **never read it**. On a CI runner — discarded when the job ends — that made the actual message unrecoverable, so a failing test looked like this and nothing more:

```
Running: gl_context_test...
  FAIL (runtime error)
  x gl_context_test - runtime error (exit 1)
```

Diagnosing anything therefore cost a full extra CI round trip. I hit this directly. Both runners now print the captured output when a test fails.

## 2. Skips were counted as passes

A test that exits 0 after printing `SKIP:` ran none of its checks, but both runners printed PASS for any zero exit. `api_gemini_test`, `api_ollama_test` and `api_openai_test` all skip when no API key is present, so the suite has been reporting

```
Results: 191 passed, 0 failed
```

when the truth is

```
Results: 188 passed, 3 skipped, 0 failed
```

That's a green number standing in for work that didn't happen, and it hides the case that actually matters: **a whole platform quietly losing coverage while CI stays green.** Both runners now detect a leading `SKIP:`, count it separately, and the POSIX runner names the skipped tests in the summary and the GitHub step summary.

Concretely, on the branch this was split from, the per-platform totals became legible for the first time:

| platform | before | after |
|---|---|---|
| linux-x64 | 191 passed | 188 passed, 3 skipped |
| windows-x64 | 191 passed | 187 passed, **4** skipped |

The one-test difference *is* the coverage report. Both previously read identically.

## 3. Windows never put `lib\sdl` on PATH

`run_regression.cmd` exported only `lib\native`, but `deploy_windows.cmd` installs the SDL2 runtime DLLs to `lib\sdl` and `libobjk_sdl.dll` imports them. So any test touching SDL failed on Windows with

```
Runtime error loading shared library: ..\lib\native\libobjk_sdl.dll
```

naming the wrong DLL entirely. Nothing had hit it because no SDL test existed.

## Verified

Full suite on Windows against this branch alone: **187 passed, 3 skipped, 0 failed** (190 tests — the GL test lives on the other branch), and the three named skips are exactly the `api_*` trio that were previously inflating the pass count. `bash -n` clean on the POSIX runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)