### PR TITLE
fix(vm): unbarriered old-to-young stores destroyed live objects

### DIFF
--- a/core/vm/arch/jit/jit_common.cpp
+++ b/core/vm/arch/jit/jit_common.cpp
@@ -770,6 +770,16 @@ void JitCompiler::JitStackCallback(const long instr_id, StackInstr* instr, const
       else {
         memcpy(dest_array_ptr + dest_offset, src_array_ptr + src_offset, length * sizeof(size_t));
       }
+      // Generational GC write barrier, mirroring StackInterpreter::CpyIntAry. An
+      // Int[] can hold object references (an object array IS an int array of
+      // pointers), so a bulk copy can deposit young refs into an old destination
+      // array where a minor GC will neither mark nor fix them up. The interpreter
+      // path has recorded the destination since the barrier was introduced; this
+      // JIT callback performs the same copy and did not.
+      //
+      // Only the Int variant needs this. CPY_BYTE_ARY, CPY_CHAR_ARY and
+      // CPY_FLOAT_ARY move primitives, which are never references.
+      MemoryManager::WriteBarrier(dest_array);
       PushInt(op_stack, stack_pos, 1);
     }
     else {

--- a/core/vm/arch/memory.cpp
+++ b/core/vm/arch/memory.cpp
@@ -428,7 +428,7 @@ void MemoryManager::FixupPendingThreadRoots()
 #endif
 }
 
-size_t* MemoryManager::AllocateObject(const long obj_id, size_t* op_stack, size_t stack_pos, bool collect)
+size_t* MemoryManager::AllocateObject(const long obj_id, size_t* op_stack, size_t stack_pos, bool collect, bool force_old)
 {
   // Allocation is a safepoint: park here if another thread is collecting. Reached
   // from JITed code too (it calls back to allocate), so allocation-heavy threads
@@ -465,7 +465,11 @@ size_t* MemoryManager::AllocateObject(const long obj_id, size_t* op_stack, size_
     // young_offset > young_region_size. The collector then uses young_offset as the
     // length of its young walk + reset memset, running off the end of the mapping —
     // promoting garbage as objects (corruption) and overrunning memset (crash).
-    if(young_region) {
+    // `force_old` skips the nursery: see AllocateObjectNative. A native library
+    // reaches Objeck only through a plain store into the argument array, which runs
+    // no write barrier, so a young object stored there would not be fixed up when
+    // promotion moves it.
+    if(young_region && !force_old) {
       size_t offset = young_offset.load(std::memory_order_relaxed);
       while(offset + aligned_total <= young_region_size) {
         if(young_offset.compare_exchange_weak(offset, offset + aligned_total,

--- a/core/vm/arch/memory.h
+++ b/core/vm/arch/memory.h
@@ -467,8 +467,33 @@ class MemoryManager {
     
     return nullptr;
   }
-  
-  static size_t* AllocateObject(const long obj_id, size_t* op_stack, size_t stack_pos, bool collect = true);
+
+  // Allocator handed to native (C++ shared library) code through VMContext.
+  //
+  // Native libraries return a value by storing it into the caller's argument
+  // array, and lib_api.h does that with a plain store -- APITools_SetObjectValue
+  // has no write barrier and cannot have one, since it is compiled into each
+  // library rather than into the VM. An unbarriered store into an old-generation
+  // object (which every array is: AllocateArray never uses the nursery) leaves a
+  // reference the minor GC's fixup phase does not visit, so a young object stored
+  // that way is moved out from under the reference when it is promoted.
+  //
+  // Allocating in the old generation removes the hazard at the source rather than
+  // relying on every library to be barrier-correct: an old object is never moved,
+  // and a major GC recurses into old objects, so it stays reachable through the
+  // argument array. It also makes the rule for library authors a single sentence
+  // -- everything a native library allocates is old-generation -- which was
+  // already true of arrays and is now true of objects too.
+  static size_t* AllocateObjectNative(const wchar_t* obj_name, size_t* op_stack, size_t stack_pos, bool collect) {
+    StackClass* cls = prgm->GetClass(obj_name);
+    if(cls) {
+      return AllocateObject(cls->GetId(), op_stack, stack_pos, collect, true);
+    }
+
+    return nullptr;
+  }
+
+  static size_t* AllocateObject(const long obj_id, size_t* op_stack, size_t stack_pos, bool collect = true, bool force_old = false);
   static size_t* AllocateArray(const size_t size, const MemoryType type, size_t* op_stack, size_t stack_pos, bool collect = true);
 
   // Generational GC write barrier: lock-free dirty list append. Mutator

--- a/core/vm/common.cpp
+++ b/core/vm/common.cpp
@@ -1501,6 +1501,9 @@ size_t* TrapProcessor::CreateMethodObject(size_t* cls_obj, StackMethod* mthd, St
   for(int i = 0; i < type_obj_array_size; i++) {
     type_obj_array_ptr[i] = (size_t)data_type_obj_holder[i];
   }
+  // Write barrier: an old array (AllocateArray never uses the nursery) filled
+  // with young objects. See the note in DirList.
+  MemoryManager::WriteBarrier(type_obj_array);
   // set type array
   mthd_obj[3] = (size_t)type_obj_array;
 
@@ -1530,6 +1533,7 @@ void TrapProcessor::CreateClassObject(StackClass* cls, size_t* cls_obj, size_t* 
     size_t* mthd_obj = CreateMethodObject(cls_obj, methods[i], program, op_stack, stack_pos);
     mthd_obj_array_ptr[i] = (size_t)mthd_obj;
   }
+  MemoryManager::WriteBarrier(mthd_obj_array);
   cls_obj[1] = (size_t)mthd_obj_array;
 }
 
@@ -1850,6 +1854,9 @@ inline size_t* TrapProcessor::DeserializeArray(ParamType type, size_t* inst, siz
           dest_array_ptr[i] = (size_t)deserializer.DeserializeObject();
           inst[1] = dest_pos + deserializer.GetOffset();
         }
+        // Write barrier, as the object-array case above already does: an old
+        // destination array holding freshly deserialized young objects.
+        MemoryManager::WriteBarrier(dest_array);
       }
     }
     else {
@@ -3851,6 +3858,12 @@ bool TrapProcessor::SysCmdOut(StackProgram* program, size_t* inst, size_t*& op_s
       str_obj_array_ptr[i] = (size_t)CreateStringObject(line, program, op_stack, stack_pos);
     }
 
+    // Write barrier: the array is old (AllocateArray never uses the nursery) and
+    // the elements are young objects. A minor GC repairs references only in
+    // objects the barrier recorded, so without this the elements are promoted
+    // out from under an array the collector will not look inside.
+    MemoryManager::WriteBarrier(str_obj_array);
+
 
     size_t* command_output_obj = MemoryManager::AllocateObject(program->GetCommandOutputObjectId(), op_stack, *stack_pos, false);
     command_output_obj[0] = (size_t)command_obj;
@@ -4351,6 +4364,12 @@ bool TrapProcessor::SockTcpResolveName(StackProgram* program, size_t* inst, size
       const std::wstring waddr(addrs[i].begin(), addrs[i].end());
       str_obj_array_ptr[i] = (size_t)CreateStringObject(waddr, program, op_stack, stack_pos);
     }
+
+    // Write barrier: the array is old (AllocateArray never uses the nursery) and
+    // the elements are young objects. A minor GC repairs references only in
+    // objects the barrier recorded, so without this the elements are promoted
+    // out from under an array the collector will not look inside.
+    MemoryManager::WriteBarrier(str_obj_array);
 
     PushInt((size_t)str_obj_array, op_stack, stack_pos);
   }
@@ -7050,6 +7069,9 @@ bool TrapProcessor::Http2Request(StackProgram* program, size_t* inst, size_t*& o
   }
   instance[5] = (size_t)body_obj;
   instance[6] = (size_t)CreateStringObject(BytesToUnicode(ct), program, op_stack, stack_pos);
+  // Write barrier: `instance` is the caller's response object, which may well be
+  // old by the time a request completes, and the content-type String is young.
+  MemoryManager::WriteBarrier(instance);
 
   PushInt(1, op_stack, stack_pos);
 #else
@@ -7676,6 +7698,9 @@ bool TrapProcessor::Http3Request(StackProgram* program, size_t* inst, size_t*& o
     memcpy((uint8_t*)(body_obj + 3), ctx->response_body.data(), body_size);
   instance[5] = (size_t)body_obj;
   instance[6] = (size_t)CreateStringObject(BytesToUnicode(ct), program, op_stack, stack_pos);
+  // Write barrier: `instance` is the caller's response object, which may well be
+  // old by the time a request completes, and the content-type String is young.
+  MemoryManager::WriteBarrier(instance);
 
   PushInt(1, op_stack, stack_pos);
 #elif defined(OBJECK_HAS_WINHTTP_H3)
@@ -7739,6 +7764,7 @@ bool TrapProcessor::Http3Request(StackProgram* program, size_t* inst, size_t*& o
   }
   instance[5] = (size_t)body_obj;
   instance[6] = (size_t)CreateStringObject(BytesToUnicode(resp_ct), program, op_stack, stack_pos);
+  MemoryManager::WriteBarrier(instance);
 
   PushInt(1, op_stack, stack_pos);
 #else
@@ -8964,6 +8990,12 @@ bool TrapProcessor::DirList(StackProgram* program, [[maybe_unused]] size_t* inst
       const std::wstring wfile = BytesToUnicode(files[i]);
       str_obj_array_ptr[i] = (size_t)CreateStringObject(wfile, program, op_stack, stack_pos);
     }
+
+    // Write barrier: the array is old (AllocateArray never uses the nursery) and
+    // the elements are young objects. A minor GC repairs references only in
+    // objects the barrier recorded, so without this the elements are promoted
+    // out from under an array the collector will not look inside.
+    MemoryManager::WriteBarrier(str_obj_array);
 
     PushInt((size_t)str_obj_array, op_stack, stack_pos);
   }

--- a/core/vm/interpreter.cpp
+++ b/core/vm/interpreter.cpp
@@ -2864,7 +2864,7 @@ void StackInterpreter::SharedLibraryLoad([[maybe_unused]] StackInstr* instr)
   context.call_method_by_id = APITools_MethodCallId;
   context.call_method_by_name = APITools_MethodCall;
   context.alloc_managed_array = MemoryManager::AllocateArray;
-  context.alloc_managed_obj = MemoryManager::AllocateObject;
+  context.alloc_managed_obj = MemoryManager::AllocateObjectNative;
   (*ext_load)(context);
 #else
   void* dll_handle = dlopen(dll_string.c_str(), RTLD_LAZY);
@@ -2897,7 +2897,7 @@ void StackInterpreter::SharedLibraryLoad([[maybe_unused]] StackInstr* instr)
   context.call_method_by_id = APITools_MethodCallId;
   context.call_method_by_name = APITools_MethodCall;
   context.alloc_managed_array = MemoryManager::AllocateArray;
-  context.alloc_managed_obj = MemoryManager::AllocateObject;
+  context.alloc_managed_obj = MemoryManager::AllocateObjectNative;
   (*ext_load)(context);
 #endif
 }
@@ -2996,7 +2996,7 @@ void StackInterpreter::SharedLibraryCall([[maybe_unused]] StackInstr* instr, siz
     context.call_method_by_name = APITools_MethodCall;
     context.call_method_by_id = APITools_MethodCallId;
     context.alloc_managed_array = MemoryManager::AllocateArray;
-    context.alloc_managed_obj = MemoryManager::AllocateObject;
+    context.alloc_managed_obj = MemoryManager::AllocateObjectNative;
     (*ext_func)(context);
   }
 #else
@@ -3022,7 +3022,7 @@ void StackInterpreter::SharedLibraryCall([[maybe_unused]] StackInstr* instr, siz
     context.call_method_by_name = APITools_MethodCall;
     context.call_method_by_id = APITools_MethodCallId;
     context.alloc_managed_array = MemoryManager::AllocateArray;
-    context.alloc_managed_obj = MemoryManager::AllocateObject;
+    context.alloc_managed_obj = MemoryManager::AllocateObjectNative;
     (*ext_func)(context);
   }  
 #endif

--- a/docs/native_interface.md
+++ b/docs/native_interface.md
@@ -243,6 +243,36 @@ through primitive holders, which allocate nothing at all.
 down. It fails — with a dangling reference, in practice an "Invalid object cast"
 abort — against a VM that allocates native objects in the nursery.
 
+### Arrays are born old, objects are born young
+
+Worth stating separately, because it decides which stores are safe:
+
+- `AllocateArray` **never** uses the nursery. Every Objeck array is
+  old-generation from the moment it exists.
+- `AllocateObject` does use it — except through the native path above, which is
+  the whole point of that change.
+
+No collection can run inside your function, because the API's allocators pass
+`collect=false`, so nothing you allocate moves while you are still holding it.
+
+The consequence for you: everything you allocate is old, and the argument array
+is old, so every store you make between them is old-to-old and needs no
+barrier. That is what makes `lib_api.h`'s plain stores correct.
+
+The one thing to avoid is storing an object **the caller gave you** into an
+array. A caller's object may be young, an array is always old, and you have no
+way to run the barrier from library code. If you need to hand a caller's object
+back, put it in the slot it came from rather than into an array you built.
+
+This is not a hypothetical restriction — the VM's own traps had exactly this
+bug. A trap that returned `String[]` allocated the array (old), filled it with
+freshly created Strings (young), and ran no barrier; the next minor collection
+promoted the elements out from under an array the collector does not look
+inside. `Directory->List` followed by enough allocation to fill the nursery
+turned two thirds of a 393-entry listing into unreadable memory, and reading
+one segfaulted the VM. `programs/regression/trap_array_barrier_test.obs` guards
+it now.
+
 ### What you still own
 
 The collector manages what it allocated. It knows nothing about anything else.

--- a/docs/native_interface.md
+++ b/docs/native_interface.md
@@ -1,0 +1,488 @@
+# Writing native libraries for Objeck
+
+Objeck reaches C and C++ through shared libraries it loads at runtime. Every
+binding in the standard library works this way — SDL2 and OpenGL, ODBC, OpenCV,
+ONNX, mbedTLS, LAME, the diagnostics engine behind the language server. If you
+want Objeck to call something the VM does not already know about, this is the
+mechanism, and it is the only one.
+
+This document is the whole contract: what the VM guarantees, what your library
+must guarantee back, what the collector does with the memory you allocate, and
+what a call costs.
+
+---
+
+## The shape of a call
+
+A native library is two halves that meet at a name.
+
+**The Objeck half** loads the library and calls into it by function name,
+passing an array of boxed values:
+
+```objeck
+use System.API;
+
+class Beep {
+	@proxy : static : DllProxy;
+	@fn_beep_play : static : String;
+
+	function : Play(hz : Int, ms : Int) ~ Bool {
+		if(@proxy = Nil) {
+			@proxy := DllProxy->New("libobjk_beep");
+		};
+
+		array_args := Base->New[3];
+		array_args[0] := IntRef->New();     # the result comes back here
+		array_args[1] := IntRef->New(hz);
+		array_args[2] := IntRef->New(ms);
+
+		if(@fn_beep_play = Nil) { @fn_beep_play := "beep_play"; };
+		@proxy->CallFunction(@fn_beep_play, array_args);
+
+		return array_args[0]->As(IntRef)->Get() <> 0;
+	}
+}
+```
+
+**The C++ half** exports a function of that name taking a `VMContext&`:
+
+```cpp
+#include "../../vm/lib_api.h"
+
+extern "C" {
+#ifdef _WIN32
+  __declspec(dllexport)
+#endif
+  void load_lib(VMContext& context) { }
+
+#ifdef _WIN32
+  __declspec(dllexport)
+#endif
+  void unload_lib() { }
+
+#ifdef _WIN32
+  __declspec(dllexport)
+#endif
+  void beep_play(VMContext& context) {
+    const size_t hz = APITools_GetIntValue(context, 1);
+    const size_t ms = APITools_GetIntValue(context, 2);
+
+    const bool ok = platform_beep(hz, ms);
+    APITools_SetIntValue(context, 0, ok ? 1 : 0);
+  }
+}
+```
+
+There is no header generation, no IDL, no signature checking. The name is the
+only thing that ties the halves together, and the argument array is the only
+thing that crosses. If the two sides disagree about what index 2 holds, nothing
+tells you — you get a wrong number or a crash.
+
+That bluntness is the trade. It also means the whole interface fits in one
+header, `core/vm/lib_api.h`, which is worth reading in full at least once.
+
+### What happens between them
+
+1. `DllProxy->New(name)` runs `EXT_LIB_LOAD`, which resolves `name` against the
+   library directory, appends the platform's extension, loads it, and calls the
+   library's `load_lib`.
+2. `CallFunction(name, args)` runs `EXT_LIB_FUNC_CALL`. The VM resolves `name` to
+   a symbol, builds a `VMContext` around the argument array, and calls it.
+3. Your function reads and writes the argument array in place. It does not
+   return a value; there is no return channel other than the array.
+4. `Unload()` runs `EXT_LIB_UNLOAD`, which calls `unload_lib` and unloads.
+
+The library directory is `$OBJECK_LIB_PATH/native/`, falling back to
+`../lib/native/` relative to the working directory. The name you pass has no
+extension — the VM appends `.dll`, `.dylib` or `.so` — and by convention starts
+with `libobjk_`, which is what the deploy scripts name the built artifacts.
+
+---
+
+## The C++ side
+
+### The three exports
+
+Every library must export `load_lib(VMContext&)` and `unload_lib()`. The VM
+looks them up by name immediately after loading and **exits the process** if
+either is missing. Most libraries leave both empty; use them for one-time
+global setup and teardown that cannot be done lazily.
+
+Then export one function per entry point, each `void f(VMContext&)`.
+
+All of it goes inside `extern "C"`, and on Windows each export needs
+`__declspec(dllexport)`. POSIX builds export by default.
+
+### Reading arguments
+
+`context.data_array` is the Objeck `Base[]` you were passed. Never index it
+directly; the header's accessors know the layout.
+
+```cpp
+size_t         n   = APITools_GetArgumentCount(context);
+bool           b   = APITools_GetBoolValue(context, 1);
+size_t         i   = APITools_GetIntValue(context, 1);
+double         f   = APITools_GetFloatValue(context, 1);
+wchar_t        c   = APITools_GetCharValue(context, 1);
+unsigned char  y   = APITools_GetByteValue(context, 1);
+const wchar_t* s   = APITools_GetStringValue(context, 1);
+size_t*        obj = APITools_GetObjectValue(context, 1);
+```
+
+Every one of these is bounds-checked against the argument count and returns a
+zero value (or `nullptr`) when the index is out of range or the slot is empty.
+That is a guard against a mismatched call, not a licence to skip checking:
+`APITools_GetStringValue` returns `nullptr` for a `Nil` string, and dereferencing
+it is your bug, not the VM's.
+
+Arrays arrive as a *holder* — an `IntArrayRef`, `FloatArrayRef`, `ByteArrayRef`
+and so on — which is an object wrapping the array. So there are two steps:
+
+```cpp
+size_t* holder = APITools_GetArray(context, 1);      // the holder
+size_t* array  = (size_t*)holder[0];                 // the array itself
+size_t  count  = APITools_GetArraySize(array);
+double* values = (double*)APITools_GetArray(array);  // past the 3-word header
+```
+
+An Objeck array is three header words (`size`, `dimension count`, then one
+length per dimension) followed by the elements, which is what
+`ARRAY_HEADER_OFFSET` is for. `APITools_GetArray(array)` returns the element
+pointer; cast it to the element type. The typed element accessors
+(`APITools_GetFloatArrayElement` and friends) do the same work one element at a
+time with bounds checks.
+
+`String[]` is the exception with a shortcut: `APITools_GetStringsValues(context, i)`
+returns a `std::vector<std::wstring>` directly.
+
+### Returning values
+
+You return by writing into the argument array. By convention index 0 is the
+result slot, and the Objeck side has already put a holder there for you.
+
+```cpp
+APITools_SetIntValue(context, 0, 42);
+APITools_SetFloatValue(context, 0, 3.5);
+APITools_SetStringValue(context, 0, L"done");
+APITools_SetObjectValue(context, 0, some_object);
+```
+
+The primitive setters write *through* the holder the caller supplied — they
+mutate the `IntRef` that is already in the slot. `SetStringValue` and
+`SetObjectValue` allocate something new and replace the slot's contents.
+
+To hand back a new array, allocate one and store it in the holder:
+
+```cpp
+size_t* holder = APITools_GetArray(context, 0);
+size_t* result = APITools_MakeByteArray(context, bytes.size());
+memcpy(result + ARRAY_HEADER_OFFSET, bytes.data(), bytes.size());
+holder[0] = (size_t)result;
+```
+
+`APITools_MakeIntArray`, `MakeFloatArray`, `MakeFloatMatrix`, `MakeCharArray`
+and `MakeByteArray` cover the cases. `APITools_CreateStringObject` builds a
+`System.String`; `APITools_CreateObject` builds an instance of any class by
+qualified name.
+
+### Calling back into Objeck
+
+```cpp
+APITools_CallMethod(context, instance, L"MyClass:Handler:o.System.String,");
+APITools_CallMethod(context, instance, cls_id, mthd_id);
+```
+
+The qualified-name form wants the full mangled signature, which is why the
+by-id form exists for anything called repeatedly. This is how the SDL bindings
+run Objeck event handlers.
+
+---
+
+## Memory and the collector
+
+**Everything a native library allocates lives in the old generation.** That is
+the whole rule, and it is worth understanding why, because it is what makes the
+plain stores in `lib_api.h` safe.
+
+Objeck's collector is generational. Objects are normally allocated in a nursery
+and promoted — which **moves** them — when they survive a collection. Moving is
+safe because the collector fixes up every reference afterwards, and it finds
+those references two ways: by tracing from roots, and, for references stored
+into old-generation objects, through a *write barrier* that records the object
+as dirty when the store happens. A minor collection marks an old object without
+recursing into it, so an old-to-young reference that the barrier never recorded
+is invisible to both the mark phase and the fixup phase.
+
+Now look at how a library returns an object:
+
+```cpp
+void APITools_SetObjectValue(VMContext& context, int index, size_t* obj) {
+  ...
+  data_array[index] = (size_t)obj;      // a plain store, no barrier
+}
+```
+
+`lib_api.h` is compiled *into your library*, not into the VM. It cannot reach
+the collector's write barrier, so it cannot run one. And the argument array is
+always an old-generation object, because `AllocateArray` never uses the nursery.
+
+So the VM allocates on your behalf in the old generation instead. Old objects
+are never moved, so nothing needs fixing up, and a major collection recurses
+into old objects, so your value stays reachable through the argument array. The
+barrier is not needed because the hazard is not created.
+
+This is enforced VM-side (`MemoryManager::AllocateObjectNative`), which means it
+covers every library already compiled, including yours, without a rebuild. You
+do not have to do anything. But you do have to know the rule, because it has one
+consequence you can feel: **objects a native library allocates are reclaimed only
+by a major collection.** A library that allocates a String per call in a hot loop
+grows the old generation. If you are returning many small values, return them
+through primitive holders, which allocate nothing at all.
+
+`programs/regression/native_gc_barrier_test.obs` is the test that holds this
+down. It fails — with a dangling reference, in practice an "Invalid object cast"
+abort — against a VM that allocates native objects in the nursery.
+
+### What you still own
+
+The collector manages what it allocated. It knows nothing about anything else.
+
+- Memory you get from `malloc`/`new` is yours to free. Nothing collects it.
+- A native handle you stash in an `Int` (a texture id, a socket, a database
+  connection) is invisible to the collector. The Objeck side has to release it
+  explicitly, which is why so many classes in these bindings have a `Free`.
+- The `size_t*` pointers you hold during one call stay valid for that call.
+  Native allocations do not trigger a collection and do not park at a safepoint,
+  so nothing moves under you between two `APITools_` calls in the same function.
+  Do not hold one past the call — store an Objeck-visible reference instead.
+
+---
+
+## Errors
+
+There is no error channel. A native function returns `void`, and the VM has no
+notion of a failed call.
+
+**Do not let an exception escape.** The VM calls you through a raw function
+pointer, across a module boundary, from a frame that knows nothing about
+unwinding. Catch everything at the boundary.
+
+**Do not call `exit()`,** however tempting. Report the failure through the
+argument array and let Objeck decide.
+
+The convention that has held up is a status in the result slot plus a
+last-error string the caller can ask for:
+
+```cpp
+void thing_do(VMContext& context) {
+  try {
+    ...
+    APITools_SetIntValue(context, 0, 1);
+  }
+  catch(const std::exception& e) {
+    last_error = BytesToUnicode(e.what());
+    APITools_SetIntValue(context, 0, 0);
+  }
+}
+```
+
+The VM itself is less forgiving than this advice: a missing `load_lib`, a
+missing symbol, or a library that fails to load all print a message and **exit
+the process**. A typo in a function name is a hard stop at the first call, not
+an exception you can catch.
+
+### Threading
+
+Objeck threads call native functions concurrently, and nothing serialises them.
+A library with mutable global state needs its own locking. Several of the
+bindings here are single-threaded in practice only because their callers happen
+to be.
+
+---
+
+## What a call costs
+
+Measured on Windows x64, per call, against a native function that does nothing:
+
+| | ns |
+|---|---|
+| a call whose name is a string literal | ~1,655 |
+| the same call, name held in a field | ~130 |
+| a fully hoisted call with a reused argument buffer | ~125 |
+
+The number that surprises people is the first one. **An Objeck string literal is
+materialised into a fresh `String` every time it is evaluated** — not once at
+load, not interned. A name written at the call site is therefore an allocation
+and a copy on every single call, and at ~1,525ns it is 92% of the cost of the
+call, spent in code that reads like a constant.
+
+Two rules follow, and together they took a 500-box OpenGL frame from 15.02ms to
+3.35ms.
+
+### Rule 1: hold the name in a field
+
+```objeck
+# Before -- allocates "sdl_gl_mesh_draw" on every draw.
+Proxy->GetDllProxy()->CallFunction("sdl_gl_mesh_draw", array_args);
+
+# After.
+@fn_sdl_gl_mesh_draw : static : String;
+...
+if(@fn_sdl_gl_mesh_draw = Nil) { @fn_sdl_gl_mesh_draw := "sdl_gl_mesh_draw"; };
+Proxy->GetDllProxy()->CallFunction(@fn_sdl_gl_mesh_draw, array_args);
+```
+
+Static, because the names are class-wide constants and a `function :` cannot
+read an instance field. The lazy fill races harmlessly between threads: both
+write an equivalent String, one wins, the loser's allocation is discarded, and
+no one can observe a half-built value because the store is a pointer store.
+
+`tools/cicd/hoist_native_names.py` applies this across a file, and `--check`
+reports any call site that still writes a literal:
+
+```
+python tools/cicd/hoist_native_names.py --check core/compiler/lib_src/*.obs
+```
+
+Worth knowing: `core/lib/sdl/code_gen` **generates** `sdl2.obs`, and its emitter
+writes the literal form. Regenerating it undoes the hoisting for all 353 call
+sites, and `--check` is how you find out.
+
+### Rule 2: reuse the argument buffer
+
+The usual shape allocates a `Base[]` and a holder per element on every call:
+
+```objeck
+array_args := Base->New[3];
+array_args[0] := IntRef->New(mesh);
+array_args[1] := IntRef->New(mode);
+array_args[2] := IntRef->New(count);
+```
+
+Holders are mutable, so on a hot path you can build the buffer once and refill
+it:
+
+```objeck
+if(@draw_args = Nil) {
+	@draw_mesh := IntRef->New(@mesh);
+	@draw_mode := IntRef->New(mode);
+	@draw_count := IntRef->New(count);
+	@draw_args := Base->New[3];
+	@draw_args[0] := @draw_mesh;
+	@draw_args[1] := @draw_mode;
+	@draw_args[2] := @draw_count;
+}
+else {
+	@draw_mesh->Set(@mesh);
+	@draw_mode->Set(mode);
+	@draw_count->Set(count);
+};
+Proxy->GetDllProxy()->CallFunction(@draw_name, @draw_args);
+```
+
+This is worth 6-8% of a draw-heavy frame, and it introduces exactly one new way
+to be wrong: **a buffer that is not refilled sends the previous call's values.**
+That failure is invisible to most tests — draw the same thing twice and a stale
+buffer produces the correct picture — so a fixture has to pass two *different*
+values in succession and check that the second one landed.
+
+There is a second hazard, and it is the reason to be careful about *what* you
+park in a reused buffer. A buffer holding a caller's array or object keeps it
+reachable for as long as the buffer lives, which is now forever. Release those
+slots after the call:
+
+```objeck
+Proxy->GetDllProxy()->CallFunction(@m4_name, @m4_args);
+@m4_args[1] := Nil;              # do not pin the caller's matrix
+@m4_matrix->Set(@m4_idle);
+```
+
+Reuse buffers that carry primitives. Be deliberate about buffers that carry
+references.
+
+### What is left
+
+After both rules a call is ~125ns, and about 90% of that is spent before your
+C++ function is entered — argument-array setup, interpreter dispatch, and the
+fact that `CallFunction` contains `EXT_LIB_FUNC_CALL`, which is in neither JIT
+whitelist, so the method is always interpreted and every native call from
+JIT-compiled code crosses back into the interpreter.
+
+The practical consequence: **batch at the boundary.** One call that draws 500
+instances beats 500 calls that draw one, by far more than any tuning of the call
+itself.
+
+---
+
+## Building and shipping a library
+
+Naming matters more than it looks. The Objeck side passes an extensionless name
+to `DllProxy->New`, the VM appends the platform extension, and the deploy
+scripts are what actually produce a file with that name — the build output is
+usually named something else and renamed on the way into `lib/native/`.
+
+- **POSIX**: `core/lib/<name>/build_linux.sh <name>` builds `<name>.so`, and
+  `core/release/deploy_posix.sh` copies it to `lib/native/libobjk_<name>.so`.
+  Note that `matrix.so` ships as `libobjk_ml.so` — the names do not have to
+  match, and one place decides.
+- **Windows**: an MSVC solution per library under `core/lib/<name>/`, built
+  `Release|x64` (ONNX is the exception, `Release-DML|x64`), with the output
+  copied to `lib/native/`.
+- **macOS**: an Xcode project, same idea.
+
+A new library needs to be added to each deploy script, to the CI build lists,
+and — if it has an Objeck-side `.obl` — to the library lists in
+`update_version.sh`, `update_version_arm.sh`, `code_doc64.in`, and the CI
+"Rebuild libraries" step. `tools/cicd/check_doc_lists.py` guards the doc lists.
+
+One trap worth stating plainly, because it has bitten this repo: **a library
+that CI compiles is not necessarily a library that ships.** The `obu` updater
+was built and tested by CI for two releases while being packaged in no archive
+at all. Check the archive, not the build log.
+
+---
+
+## Traps
+
+Collected from things that have actually gone wrong here.
+
+- **`.obs` files are marked binary in `.gitattributes`.** `git diff` shows you
+  nothing. Review by reading the file, and expect that two branches touching the
+  same `.obs` cannot be merged in parallel — stack them.
+- **A changed `.obs` requires committing the rebuilt `.obl`.** The `.obl` files
+  under `core/lib/` are tracked, and a stale one fails on the platforms that do
+  not rebuild it — usually as a pile of "undefined method" errors on macOS.
+- **Never widen an existing trap's arity.** Append a new trap after `EXIT`
+  instead. The bytecode is positional and the loader has its own parser.
+- **`String[]` is indexed directly**, without the `[0]` holder indirection the
+  other array types need.
+- **A native handle in an `Int` is invisible to the collector.** If it needs
+  releasing, the Objeck side needs a `Free`.
+- **HTTP/1.1 serialises headers in Objeck; HTTP/2 and /3 do it natively.** Any
+  validation that must apply to all three belongs on the Objeck side.
+- **Silent failure is the default.** A misspelled uniform, an unloaded entry
+  point, an oversized texture and a rejected mesh were all silent in the GL
+  bindings until each was deliberately given a way to report.
+
+---
+
+## Is this a good design?
+
+It is a good design for what it is: a thin, uniform, dependency-free bridge that
+any C or C++ code can be reached through, with one header and no tooling. The VM
+stays out of the way, and there is nothing to regenerate when a signature
+changes.
+
+The costs are real and worth naming. The name-based dispatch has no type
+checking whatsoever, so a mismatch between the two halves is a runtime
+corruption rather than a compile error. Errors have no channel and every library
+invents its own. Everything crosses as `size_t*`, and correctness rests on the
+caller and callee agreeing about a layout that nothing verifies. And per-call
+overhead is high enough that the interface rewards batching much more than it
+rewards micro-optimisation.
+
+None of that argues for replacing it. It argues for the two habits this document
+keeps coming back to: **batch at the boundary**, and **write the fixture that
+can tell the difference** — because a native call that returns the previous
+call's answer, or a stale buffer that draws the right picture for the wrong
+reason, will pass any test that only asks whether something happened.

--- a/docs/native_interface.md
+++ b/docs/native_interface.md
@@ -430,17 +430,30 @@ Proxy->GetDllProxy()->CallFunction(@m4_name, @m4_args);
 Reuse buffers that carry primitives. Be deliberate about buffers that carry
 references.
 
-### What is left
+### What is left, and what is not worth chasing
 
-After both rules a call is ~125ns, and about 90% of that is spent before your
-C++ function is entered — argument-array setup, interpreter dispatch, and the
-fact that `CallFunction` contains `EXT_LIB_FUNC_CALL`, which is in neither JIT
-whitelist, so the method is always interpreted and every native call from
-JIT-compiled code crosses back into the interpreter.
+After both rules a call is ~125ns, nearly all of it spent before your C++
+function is entered: building the argument array and dispatching the call.
+
+It is tempting to blame the JIT for the rest. `CallFunction` contains
+`EXT_LIB_FUNC_CALL`, which is in neither JIT whitelist, so that method is always
+interpreted and every native call from JIT-compiled code crosses into the
+interpreter. That is true, and it costs nothing. Measured by running the same
+loop from a JIT-compiled caller and from an interpreted one — a method
+containing a native call cannot be compiled, which is how you get one of each —
+the compiled caller is **faster by 155-270ns per call**. The crossing is not a
+toll.
+
+Nor is there much to win by making the opcode JIT-able. What that would remove
+is the interpreted method invocation, and that is **~20ns**: about 16% of a
+minimal call and under 2% of a call doing any real work. It would also mean
+restructuring how the opcode reads its operands, since it takes them from
+`frame->mem` and a JIT callback has no frame — the same frame dependency that
+`HasFrameDependentTrap` exists to reject. A 20ns ceiling is not worth that.
 
 The practical consequence: **batch at the boundary.** One call that draws 500
 instances beats 500 calls that draw one, by far more than any tuning of the call
-itself.
+itself — and unlike the call overhead, batching has no ceiling.
 
 ---
 

--- a/docs/native_interface.md
+++ b/docs/native_interface.md
@@ -243,6 +243,29 @@ through primitive holders, which allocate nothing at all.
 down. It fails — with a dangling reference, in practice an "Invalid object cast"
 abort — against a VM that allocates native objects in the nursery.
 
+#### Why this, and not a barrier hook
+
+The principled fix is a write-barrier function pointer on `VMContext`, so
+`lib_api.h` could barrier its own stores the way the rest of the VM does. This
+is not that, and it is worth writing down why, along with when to change your
+mind.
+
+Two reasons for the allocator instead. `lib_api.h` compiles *into each library*,
+so a header-only fix reaches only libraries that are rebuilt — every existing
+binary stays broken. And a barrier the author must remember to call is a bug
+that can be reintroduced by omission; allocating old makes the bug
+unrepresentable rather than merely absent.
+
+Two things wrong with it, equally worth knowing. It costs almost nothing today
+— measured at +11% old-generation bytes with **no** additional collections —
+but only because arrays are *already* old-generation, so all that moved was a
+small object header. **If array nursery allocation is ever enabled, that trade
+flips**, native returns become a real old-generation cost, and the barrier hook
+becomes the better answer. And it leaves two rules for one situation: the VM's
+own traps allocate young and barrier, native code allocates old and does not.
+That asymmetry is exactly the kind of thing that let the trap bug sit unnoticed
+beside a correctly barriered sibling.
+
 ### Arrays are born old, objects are born young
 
 Worth stating separately, because it decides which stores are safe:

--- a/docs/native_interface.md
+++ b/docs/native_interface.md
@@ -193,8 +193,12 @@ APITools_CallMethod(context, instance, cls_id, mthd_id);
 ```
 
 The qualified-name form wants the full mangled signature, which is why the
-by-id form exists for anything called repeatedly. This is how the SDL bindings
-run Objeck event handlers.
+by-id form exists for anything called repeatedly.
+
+Be aware that **no shipped binding currently uses this**, so it is the least
+exercised part of the interface. It also has a consequence for the memory rules
+below: calling back into Objeck runs a nested interpreter, whose allocations are
+ordinary Objeck allocations and *can* therefore trigger a collection.
 
 ---
 
@@ -275,8 +279,16 @@ Worth stating separately, because it decides which stores are safe:
 - `AllocateObject` does use it — except through the native path above, which is
   the whole point of that change.
 
-No collection can run inside your function, because the API's allocators pass
-`collect=false`, so nothing you allocate moves while you are still holding it.
+No collection can run inside your function *as long as your function only
+allocates* — the API's allocators pass `collect=false`, which neither parks at a
+safepoint nor drives a collection, so nothing you allocate moves while you are
+still holding it.
+
+The exception is calling back into Objeck. `APITools_CallMethod` runs a nested
+interpreter, and allocation inside it is ordinary Objeck allocation with
+`collect=true`. So a collection *can* run in the middle of your function there,
+and a raw `size_t*` you were holding across that call may have moved. Re-fetch
+anything you need after a callback rather than holding it across one.
 
 The consequence for you: everything you allocate is old, and the argument array
 is old, so every store you make between them is old-to-old and needs no
@@ -307,7 +319,9 @@ The collector manages what it allocated. It knows nothing about anything else.
 - The `size_t*` pointers you hold during one call stay valid for that call.
   Native allocations do not trigger a collection and do not park at a safepoint,
   so nothing moves under you between two `APITools_` calls in the same function.
-  Do not hold one past the call — store an Objeck-visible reference instead.
+  Do not hold one past the call — store an Objeck-visible reference instead. The
+  one thing that breaks this inside a single call is `APITools_CallMethod`, which
+  can collect; treat a pointer held across a callback as stale.
 
 ---
 

--- a/programs/regression/TESTS.md
+++ b/programs/regression/TESTS.md
@@ -13,7 +13,7 @@ python gen_manifest.py
 ```
 
 
-**Total runtime tests: 193** (plus 14 debugger tests, see below).
+**Total runtime tests: 194** (plus 14 debugger tests, see below).
 
 
 ## Tests by Category
@@ -23,7 +23,7 @@ python gen_manifest.py
 | Core Language | 38 |
 | Negative | 21 |
 | AMD64/JIT | 20 |
-| Other | 19 |
+| Other | 20 |
 | Bug Fix | 13 |
 | System.ML | 13 |
 | Collections | 10 |
@@ -240,13 +240,14 @@ python gen_manifest.py
 | 184 | `string_split_ops.obs` | Strings | string split ops | ✅ |
 | 185 | `task_scope.obs` | Other | Regression for a structured-concurrency nursery (TaskScope) built purely on the existing System.C... | ✅ |
 | 186 | `tco_receiver.obs` | Other | Tail-call optimization must respect the receiver. TCO used to fire on matching class-id and metho... | ✅ |
-| 187 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
-| 188 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
-| 189 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
-| 190 | `websocket_test.obs` | Networking | websocket test | ✅ |
-| 191 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
-| 192 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
-| 193 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
+| 187 | `trap_array_barrier_test.obs` | Other | A String[] returned by a VM trap must survive a collection. Every trap that returns an array of o... | ✅ |
+| 188 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
+| 189 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
+| 190 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
+| 191 | `websocket_test.obs` | Networking | websocket test | ✅ |
+| 192 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
+| 193 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
+| 194 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
 
 ## Debugger Tests (`run_debugger_tests.sh`)
 

--- a/programs/regression/TESTS.md
+++ b/programs/regression/TESTS.md
@@ -13,7 +13,7 @@ python gen_manifest.py
 ```
 
 
-**Total runtime tests: 190** (plus 14 debugger tests, see below).
+**Total runtime tests: 192** (plus 14 debugger tests, see below).
 
 
 ## Tests by Category
@@ -23,7 +23,7 @@ python gen_manifest.py
 | Core Language | 38 |
 | Negative | 21 |
 | AMD64/JIT | 20 |
-| Other | 16 |
+| Other | 18 |
 | Bug Fix | 13 |
 | System.ML | 13 |
 | Collections | 10 |
@@ -172,78 +172,80 @@ python gen_manifest.py
 | 116 | `func_higher_order.obs` | Functional | func higher order | ✅ |
 | 117 | `func_reduce_ops.obs` | Functional | func reduce ops | ✅ |
 | 118 | `func_sort_custom.obs` | Functional | func sort custom | ✅ |
-| 119 | `http_header_flatten_test.obs` | Other | Request-header flattening (Web.HTTP.HeaderCheck->Flatten). HTTP/2 and HTTP/3 hand the request to... | ✅ |
-| 120 | `http_header_validation_test.obs` | Other | Request-header validation (Web.HTTP.HeaderCheck). HttpClient->AddHeader was injectable: HTTP/1.1... | ✅ |
-| 121 | `indexed_call_result.obs` | Other | Subscripting the result of a method call: 'GetItems()[0]->Name()'. This was never implemented, an... | ✅ |
-| 122 | `interp_float_fastpath.obs` | Other | Exercises the interpreter's inlined float fast-path (ADD/SUB/MUL_FLOAT and the six float comparis... | ✅ |
-| 123 | `io_file_basic.obs` | I/O | io file basic | ✅ |
-| 124 | `jit_array_native.obs` | AMD64/JIT | jit array native | ✅ |
-| 125 | `jit_autojit_race.obs` | AMD64/JIT | Auto-JIT concurrency guard. Many threads call the same hot method, crossing the auto-JIT threshol... | ✅ |
-| 126 | `jit_closure_gc_fixup.obs` | AMD64/JIT | Regression for the generational-GC fixup of closure captures (bug B1). The GC mark phase descends... | ✅ |
-| 127 | `jit_concurrent_compile.obs` | AMD64/JIT | Concurrency guard for the JIT code-page allocator (PageManager::GetPage). Several threads JIT-com... | ✅ |
-| 128 | `jit_conditional_native.obs` | AMD64/JIT | jit conditional native | ✅ |
-| 129 | `jit_dispatch_native.obs` | AMD64/JIT | jit dispatch native | ✅ |
-| 130 | `jit_float_equality.obs` | AMD64/JIT | Regression test for float equality compares on array elements (2026-06). The front-end chose EQL_... | ✅ |
-| 131 | `jit_float_intensive.obs` | AMD64/JIT | jit float intensive | ✅ |
-| 132 | `jit_float_mem_ops.obs` | AMD64/JIT | Float arithmetic and comparison against MEMORY operands, under the JIT. IMPORTANT: must run with... | ✅ |
-| 133 | `jit_float_round_trig.obs` | AMD64/JIT | Exercises two JIT float-codegen bugs that only surface once a method using them is auto-JIT'd (de... | ✅ |
-| 134 | `jit_frame_trap_test.obs` | AMD64/JIT | Regression test for the JIT frame-dependent trap crash (2026-06). Traps such as SERL_INT/SERL_FLO... | ✅ |
-| 135 | `jit_func_ref_hot.obs` | AMD64/JIT | jit func ref hot | ✅ |
-| 136 | `jit_gc_stress.obs` | AMD64/JIT | JIT + GC interaction stress (2026-06). One CI run on linux-x64 failed with a JIT-to-JIT runtime e... | ✅ |
-| 137 | `jit_loop_native.obs` | AMD64/JIT | jit loop native | ✅ |
-| 138 | `jit_native_cls_fields.obs` | AMD64/JIT | JIT Native Class Fields Test Tests object reference storage in class instance fields with GC pres... | ✅ |
-| 139 | `jit_native_float_array.obs` | AMD64/JIT | JIT Native Float Array Test Tests native function with float array creation and math operations R... | ✅ |
-| 140 | `jit_native_func_ref.obs` | AMD64/JIT | JIT Native Function Reference Test Tests native functions with function reference storage in clas... | ✅ |
-| 141 | `jit_native_math.obs` | AMD64/JIT | JIT Native Math Builtins Test Tests native math functions: Factorial, Sinh/Cosh/Tanh/Log2/Cbrt, P... | ✅ |
-| 142 | `jit_string_ops.obs` | AMD64/JIT | jit string ops | ✅ |
-| 143 | `jit_tco_bare_local.obs` | AMD64/JIT | Regression for the TCO deferred-local-load miscompile (both arches). A self-recursive tail call t... | ✅ |
-| 144 | `json_build_ops.obs` | JSON | json build ops | ✅ |
-| 145 | `json_parse_ops.obs` | JSON | json parse ops | ✅ |
-| 146 | `lsp_features.obs` | LSP | lsp features | ✅ |
-| 147 | `math_float_ops.obs` | Math | math float ops | ✅ |
-| 148 | `math_log_exp.obs` | Math | math log exp | ✅ |
-| 149 | `math_random_ops.obs` | Math | math random ops | ✅ |
-| 150 | `math_rounding.obs` | Math | math rounding | ✅ |
-| 151 | `math_sqrt_ops.obs` | Math | math sqrt ops | ✅ |
-| 152 | `math_trig_funcs.obs` | Math | math trig funcs | ✅ |
-| 153 | `mcp_debug_test.obs` | MCP Server | DEBUG VERSION of mcp_server_test.obs Identical to programs/regression/mcp_server_test.obs except:... | ✅ |
-| 154 | `mcp_server_test.obs` | MCP Server | mcp server test | ✅ |
-| 155 | `minor_gc_stress.obs` | Other | Regression for generational MINOR GC: old objects holding young references. 'keep' is an object a... | ✅ |
-| 156 | `ml_adaboost_test.obs` | System.ML | Regression tests for System.ML AdaBoost (overhaul phase 3): boosting over boolean decision stumps... | ✅ |
-| 157 | `ml_api_test.obs` | System.ML | Regression tests for the System.ML estimator API consistency sweep (item 11): RandomForest Fit (r... | ✅ |
-| 158 | `ml_dbscan_test.obs` | System.ML | Regression tests for System.ML DBSCAN (overhaul phase 3): two dense blobs plus far-away outliers... | ✅ |
-| 159 | `ml_gbt_test.obs` | System.ML | Regression tests for System.ML gradient boosting (overhaul phase 3 leftover): a RegressionTree le... | ✅ |
-| 160 | `ml_gmm_test.obs` | System.ML | Regression tests for System.ML GaussianMixture (overhaul phase 3): EM on two well-separated blobs... | ✅ |
-| 161 | `ml_kdtree_test.obs` | System.ML | Regression tests for System.ML KDTree (overhaul phase 3): for several queries and k values over a... | ✅ |
-| 162 | `ml_library_test.obs` | System.ML | ml library test | ✅ |
-| 163 | `ml_linearclf_test.obs` | System.ML | Regression tests for the System.ML linear classifiers (overhaul phase 2): Perceptron (mistake-dri... | ✅ |
-| 164 | `ml_nn_test.obs` | System.ML | Regression tests for the System.ML NeuralNetwork with hidden/output bias vectors (ML overhaul ite... | ✅ |
-| 165 | `ml_pca_gnb_test.obs` | System.ML | Regression tests for System.ML PCA (power-iteration decomposition: dominant diagonal direction re... | ✅ |
-| 166 | `ml_phase1_test.obs` | System.ML | Regression tests for the System.ML correctness fixes (phase 1): seedable PRNG, DotSigmoid dimensi... | ✅ |
-| 167 | `ml_regularized_test.obs` | System.ML | Regression tests for the System.ML regularized linear models (overhaul phase 2): RidgeRegression... | ✅ |
-| 168 | `ml_trees_test.obs` | System.ML | Regression tests for the System.ML tree models: the real recursive DecisionTree (left/right child... | ✅ |
-| 169 | `nil_safe_ops.obs` | Core Language | Nil-safe operators: '??' (nil-coalesce) and '?->' (nil-safe call). Both desugar onto existing int... | ✅ |
-| 170 | `oauth_test.obs` | Networking | oauth test | ✅ |
-| 171 | `odbc_sqlite_test.obs` | ODBC | ODBC SQLite Integration Test Tests live database operations against an in-memory SQLite database.... | ✅ |
-| 172 | `primitive_receiver_order.obs` | Other | Argument order for instance-style calls on primitives. Writing `v->Pow(10)` on a primitive does n... | ✅ |
-| 173 | `regex_bench.obs` | Regex | regex bench | ✅ |
-| 174 | `regex_dfa_test.obs` | Regex | regex dfa test | ✅ |
-| 175 | `runtime_feature_test.obs` | Other | Regression tests for the "runtime.feature.*" properties, which report which optional protocol eng... | ✅ |
-| 176 | `select_dispatch_test.obs` | Control Flow | Single-case, linear (2-5 cases), jump-table (dense >=6), and binary-tree (sparse) paths | ✅ |
-| 177 | `string_find_ops.obs` | Strings | string find ops | ✅ |
-| 178 | `string_format_ops.obs` | Strings | Verifies String->Format() positional substitution. | ✅ |
-| 179 | `string_number_conv.obs` | Strings | string number conv | ✅ |
-| 180 | `string_replace_ops.obs` | Strings | string replace ops | ✅ |
-| 181 | `string_split_ops.obs` | Strings | string split ops | ✅ |
-| 182 | `task_scope.obs` | Other | Regression for a structured-concurrency nursery (TaskScope) built purely on the existing System.C... | ✅ |
-| 183 | `tco_receiver.obs` | Other | Tail-call optimization must respect the receiver. TCO used to fire on matching class-id and metho... | ✅ |
-| 184 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
-| 185 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
-| 186 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
-| 187 | `websocket_test.obs` | Networking | websocket test | ✅ |
-| 188 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
-| 189 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
-| 190 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
+| 119 | `gl_context_test.obs` | Other | Regression test for OpenGL 3.3 core support: proves a real context can be created AND that someth... | ✅ |
+| 120 | `http_header_flatten_test.obs` | Other | Request-header flattening (Web.HTTP.HeaderCheck->Flatten). HTTP/2 and HTTP/3 hand the request to... | ✅ |
+| 121 | `http_header_validation_test.obs` | Other | Request-header validation (Web.HTTP.HeaderCheck). HttpClient->AddHeader was injectable: HTTP/1.1... | ✅ |
+| 122 | `indexed_call_result.obs` | Other | Subscripting the result of a method call: 'GetItems()[0]->Name()'. This was never implemented, an... | ✅ |
+| 123 | `interp_float_fastpath.obs` | Other | Exercises the interpreter's inlined float fast-path (ADD/SUB/MUL_FLOAT and the six float comparis... | ✅ |
+| 124 | `io_file_basic.obs` | I/O | io file basic | ✅ |
+| 125 | `jit_array_native.obs` | AMD64/JIT | jit array native | ✅ |
+| 126 | `jit_autojit_race.obs` | AMD64/JIT | Auto-JIT concurrency guard. Many threads call the same hot method, crossing the auto-JIT threshol... | ✅ |
+| 127 | `jit_closure_gc_fixup.obs` | AMD64/JIT | Regression for the generational-GC fixup of closure captures (bug B1). The GC mark phase descends... | ✅ |
+| 128 | `jit_concurrent_compile.obs` | AMD64/JIT | Concurrency guard for the JIT code-page allocator (PageManager::GetPage). Several threads JIT-com... | ✅ |
+| 129 | `jit_conditional_native.obs` | AMD64/JIT | jit conditional native | ✅ |
+| 130 | `jit_dispatch_native.obs` | AMD64/JIT | jit dispatch native | ✅ |
+| 131 | `jit_float_equality.obs` | AMD64/JIT | Regression test for float equality compares on array elements (2026-06). The front-end chose EQL_... | ✅ |
+| 132 | `jit_float_intensive.obs` | AMD64/JIT | jit float intensive | ✅ |
+| 133 | `jit_float_mem_ops.obs` | AMD64/JIT | Float arithmetic and comparison against MEMORY operands, under the JIT. IMPORTANT: must run with... | ✅ |
+| 134 | `jit_float_round_trig.obs` | AMD64/JIT | Exercises two JIT float-codegen bugs that only surface once a method using them is auto-JIT'd (de... | ✅ |
+| 135 | `jit_frame_trap_test.obs` | AMD64/JIT | Regression test for the JIT frame-dependent trap crash (2026-06). Traps such as SERL_INT/SERL_FLO... | ✅ |
+| 136 | `jit_func_ref_hot.obs` | AMD64/JIT | jit func ref hot | ✅ |
+| 137 | `jit_gc_stress.obs` | AMD64/JIT | JIT + GC interaction stress (2026-06). One CI run on linux-x64 failed with a JIT-to-JIT runtime e... | ✅ |
+| 138 | `jit_loop_native.obs` | AMD64/JIT | jit loop native | ✅ |
+| 139 | `jit_native_cls_fields.obs` | AMD64/JIT | JIT Native Class Fields Test Tests object reference storage in class instance fields with GC pres... | ✅ |
+| 140 | `jit_native_float_array.obs` | AMD64/JIT | JIT Native Float Array Test Tests native function with float array creation and math operations R... | ✅ |
+| 141 | `jit_native_func_ref.obs` | AMD64/JIT | JIT Native Function Reference Test Tests native functions with function reference storage in clas... | ✅ |
+| 142 | `jit_native_math.obs` | AMD64/JIT | JIT Native Math Builtins Test Tests native math functions: Factorial, Sinh/Cosh/Tanh/Log2/Cbrt, P... | ✅ |
+| 143 | `jit_string_ops.obs` | AMD64/JIT | jit string ops | ✅ |
+| 144 | `jit_tco_bare_local.obs` | AMD64/JIT | Regression for the TCO deferred-local-load miscompile (both arches). A self-recursive tail call t... | ✅ |
+| 145 | `json_build_ops.obs` | JSON | json build ops | ✅ |
+| 146 | `json_parse_ops.obs` | JSON | json parse ops | ✅ |
+| 147 | `lsp_features.obs` | LSP | lsp features | ✅ |
+| 148 | `math_float_ops.obs` | Math | math float ops | ✅ |
+| 149 | `math_log_exp.obs` | Math | math log exp | ✅ |
+| 150 | `math_random_ops.obs` | Math | math random ops | ✅ |
+| 151 | `math_rounding.obs` | Math | math rounding | ✅ |
+| 152 | `math_sqrt_ops.obs` | Math | math sqrt ops | ✅ |
+| 153 | `math_trig_funcs.obs` | Math | math trig funcs | ✅ |
+| 154 | `mcp_debug_test.obs` | MCP Server | DEBUG VERSION of mcp_server_test.obs Identical to programs/regression/mcp_server_test.obs except:... | ✅ |
+| 155 | `mcp_server_test.obs` | MCP Server | mcp server test | ✅ |
+| 156 | `minor_gc_stress.obs` | Other | Regression for generational MINOR GC: old objects holding young references. 'keep' is an object a... | ✅ |
+| 157 | `ml_adaboost_test.obs` | System.ML | Regression tests for System.ML AdaBoost (overhaul phase 3): boosting over boolean decision stumps... | ✅ |
+| 158 | `ml_api_test.obs` | System.ML | Regression tests for the System.ML estimator API consistency sweep (item 11): RandomForest Fit (r... | ✅ |
+| 159 | `ml_dbscan_test.obs` | System.ML | Regression tests for System.ML DBSCAN (overhaul phase 3): two dense blobs plus far-away outliers... | ✅ |
+| 160 | `ml_gbt_test.obs` | System.ML | Regression tests for System.ML gradient boosting (overhaul phase 3 leftover): a RegressionTree le... | ✅ |
+| 161 | `ml_gmm_test.obs` | System.ML | Regression tests for System.ML GaussianMixture (overhaul phase 3): EM on two well-separated blobs... | ✅ |
+| 162 | `ml_kdtree_test.obs` | System.ML | Regression tests for System.ML KDTree (overhaul phase 3): for several queries and k values over a... | ✅ |
+| 163 | `ml_library_test.obs` | System.ML | ml library test | ✅ |
+| 164 | `ml_linearclf_test.obs` | System.ML | Regression tests for the System.ML linear classifiers (overhaul phase 2): Perceptron (mistake-dri... | ✅ |
+| 165 | `ml_nn_test.obs` | System.ML | Regression tests for the System.ML NeuralNetwork with hidden/output bias vectors (ML overhaul ite... | ✅ |
+| 166 | `ml_pca_gnb_test.obs` | System.ML | Regression tests for System.ML PCA (power-iteration decomposition: dominant diagonal direction re... | ✅ |
+| 167 | `ml_phase1_test.obs` | System.ML | Regression tests for the System.ML correctness fixes (phase 1): seedable PRNG, DotSigmoid dimensi... | ✅ |
+| 168 | `ml_regularized_test.obs` | System.ML | Regression tests for the System.ML regularized linear models (overhaul phase 2): RidgeRegression... | ✅ |
+| 169 | `ml_trees_test.obs` | System.ML | Regression tests for the System.ML tree models: the real recursive DecisionTree (left/right child... | ✅ |
+| 170 | `native_gc_barrier_test.obs` | Other | A value returned by a native library must survive a collection. A C++ shared library returns a va... | ✅ |
+| 171 | `nil_safe_ops.obs` | Core Language | Nil-safe operators: '??' (nil-coalesce) and '?->' (nil-safe call). Both desugar onto existing int... | ✅ |
+| 172 | `oauth_test.obs` | Networking | oauth test | ✅ |
+| 173 | `odbc_sqlite_test.obs` | ODBC | ODBC SQLite Integration Test Tests live database operations against an in-memory SQLite database.... | ✅ |
+| 174 | `primitive_receiver_order.obs` | Other | Argument order for instance-style calls on primitives. Writing `v->Pow(10)` on a primitive does n... | ✅ |
+| 175 | `regex_bench.obs` | Regex | regex bench | ✅ |
+| 176 | `regex_dfa_test.obs` | Regex | regex dfa test | ✅ |
+| 177 | `runtime_feature_test.obs` | Other | Regression tests for the "runtime.feature.*" properties, which report which optional protocol eng... | ✅ |
+| 178 | `select_dispatch_test.obs` | Control Flow | Single-case, linear (2-5 cases), jump-table (dense >=6), and binary-tree (sparse) paths | ✅ |
+| 179 | `string_find_ops.obs` | Strings | string find ops | ✅ |
+| 180 | `string_format_ops.obs` | Strings | Verifies String->Format() positional substitution. | ✅ |
+| 181 | `string_number_conv.obs` | Strings | string number conv | ✅ |
+| 182 | `string_replace_ops.obs` | Strings | string replace ops | ✅ |
+| 183 | `string_split_ops.obs` | Strings | string split ops | ✅ |
+| 184 | `task_scope.obs` | Other | Regression for a structured-concurrency nursery (TaskScope) built purely on the existing System.C... | ✅ |
+| 185 | `tco_receiver.obs` | Other | Tail-call optimization must respect the receiver. TCO used to fire on matching class-id and metho... | ✅ |
+| 186 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
+| 187 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
+| 188 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
+| 189 | `websocket_test.obs` | Networking | websocket test | ✅ |
+| 190 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
+| 191 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
+| 192 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
 
 ## Debugger Tests (`run_debugger_tests.sh`)
 

--- a/programs/regression/TESTS.md
+++ b/programs/regression/TESTS.md
@@ -13,7 +13,7 @@ python gen_manifest.py
 ```
 
 
-**Total runtime tests: 192** (plus 14 debugger tests, see below).
+**Total runtime tests: 193** (plus 14 debugger tests, see below).
 
 
 ## Tests by Category
@@ -23,7 +23,7 @@ python gen_manifest.py
 | Core Language | 38 |
 | Negative | 21 |
 | AMD64/JIT | 20 |
-| Other | 18 |
+| Other | 19 |
 | Bug Fix | 13 |
 | System.ML | 13 |
 | Collections | 10 |
@@ -224,28 +224,29 @@ python gen_manifest.py
 | 168 | `ml_regularized_test.obs` | System.ML | Regression tests for the System.ML regularized linear models (overhaul phase 2): RidgeRegression... | ✅ |
 | 169 | `ml_trees_test.obs` | System.ML | Regression tests for the System.ML tree models: the real recursive DecisionTree (left/right child... | ✅ |
 | 170 | `native_gc_barrier_test.obs` | Other | A value returned by a native library must survive a collection. A C++ shared library returns a va... | ✅ |
-| 171 | `nil_safe_ops.obs` | Core Language | Nil-safe operators: '??' (nil-coalesce) and '?->' (nil-safe call). Both desugar onto existing int... | ✅ |
-| 172 | `oauth_test.obs` | Networking | oauth test | ✅ |
-| 173 | `odbc_sqlite_test.obs` | ODBC | ODBC SQLite Integration Test Tests live database operations against an in-memory SQLite database.... | ✅ |
-| 174 | `primitive_receiver_order.obs` | Other | Argument order for instance-style calls on primitives. Writing `v->Pow(10)` on a primitive does n... | ✅ |
-| 175 | `regex_bench.obs` | Regex | regex bench | ✅ |
-| 176 | `regex_dfa_test.obs` | Regex | regex dfa test | ✅ |
-| 177 | `runtime_feature_test.obs` | Other | Regression tests for the "runtime.feature.*" properties, which report which optional protocol eng... | ✅ |
-| 178 | `select_dispatch_test.obs` | Control Flow | Single-case, linear (2-5 cases), jump-table (dense >=6), and binary-tree (sparse) paths | ✅ |
-| 179 | `string_find_ops.obs` | Strings | string find ops | ✅ |
-| 180 | `string_format_ops.obs` | Strings | Verifies String->Format() positional substitution. | ✅ |
-| 181 | `string_number_conv.obs` | Strings | string number conv | ✅ |
-| 182 | `string_replace_ops.obs` | Strings | string replace ops | ✅ |
-| 183 | `string_split_ops.obs` | Strings | string split ops | ✅ |
-| 184 | `task_scope.obs` | Other | Regression for a structured-concurrency nursery (TaskScope) built purely on the existing System.C... | ✅ |
-| 185 | `tco_receiver.obs` | Other | Tail-call optimization must respect the receiver. TCO used to fire on matching class-id and metho... | ✅ |
-| 186 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
-| 187 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
-| 188 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
-| 189 | `websocket_test.obs` | Networking | websocket test | ✅ |
-| 190 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
-| 191 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
-| 192 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
+| 171 | `native_gc_leak_test.obs` | Other | Objects a native library returns must be RECLAIMED, not merely reachable. native_gc_barrier_test.... | ✅ |
+| 172 | `nil_safe_ops.obs` | Core Language | Nil-safe operators: '??' (nil-coalesce) and '?->' (nil-safe call). Both desugar onto existing int... | ✅ |
+| 173 | `oauth_test.obs` | Networking | oauth test | ✅ |
+| 174 | `odbc_sqlite_test.obs` | ODBC | ODBC SQLite Integration Test Tests live database operations against an in-memory SQLite database.... | ✅ |
+| 175 | `primitive_receiver_order.obs` | Other | Argument order for instance-style calls on primitives. Writing `v->Pow(10)` on a primitive does n... | ✅ |
+| 176 | `regex_bench.obs` | Regex | regex bench | ✅ |
+| 177 | `regex_dfa_test.obs` | Regex | regex dfa test | ✅ |
+| 178 | `runtime_feature_test.obs` | Other | Regression tests for the "runtime.feature.*" properties, which report which optional protocol eng... | ✅ |
+| 179 | `select_dispatch_test.obs` | Control Flow | Single-case, linear (2-5 cases), jump-table (dense >=6), and binary-tree (sparse) paths | ✅ |
+| 180 | `string_find_ops.obs` | Strings | string find ops | ✅ |
+| 181 | `string_format_ops.obs` | Strings | Verifies String->Format() positional substitution. | ✅ |
+| 182 | `string_number_conv.obs` | Strings | string number conv | ✅ |
+| 183 | `string_replace_ops.obs` | Strings | string replace ops | ✅ |
+| 184 | `string_split_ops.obs` | Strings | string split ops | ✅ |
+| 185 | `task_scope.obs` | Other | Regression for a structured-concurrency nursery (TaskScope) built purely on the existing System.C... | ✅ |
+| 186 | `tco_receiver.obs` | Other | Tail-call optimization must respect the receiver. TCO used to fire on matching class-id and metho... | ✅ |
+| 187 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
+| 188 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
+| 189 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
+| 190 | `websocket_test.obs` | Networking | websocket test | ✅ |
+| 191 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
+| 192 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
+| 193 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
 
 ## Debugger Tests (`run_debugger_tests.sh`)
 

--- a/programs/regression/TESTS.md
+++ b/programs/regression/TESTS.md
@@ -13,7 +13,7 @@ python gen_manifest.py
 ```
 
 
-**Total runtime tests: 194** (plus 14 debugger tests, see below).
+**Total runtime tests: 195** (plus 14 debugger tests, see below).
 
 
 ## Tests by Category
@@ -22,8 +22,8 @@ python gen_manifest.py
 |----------|-------|
 | Core Language | 38 |
 | Negative | 21 |
+| Other | 21 |
 | AMD64/JIT | 20 |
-| Other | 20 |
 | Bug Fix | 13 |
 | System.ML | 13 |
 | Collections | 10 |
@@ -241,13 +241,14 @@ python gen_manifest.py
 | 185 | `task_scope.obs` | Other | Regression for a structured-concurrency nursery (TaskScope) built purely on the existing System.C... | ✅ |
 | 186 | `tco_receiver.obs` | Other | Tail-call optimization must respect the receiver. TCO used to fire on matching class-id and metho... | ✅ |
 | 187 | `trap_array_barrier_test.obs` | Other | A String[] returned by a VM trap must survive a collection. Every trap that returns an array of o... | ✅ |
-| 188 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
-| 189 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
-| 190 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
-| 191 | `websocket_test.obs` | Networking | websocket test | ✅ |
-| 192 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
-| 193 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
-| 194 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
+| 188 | `trap_array_mt_barrier_test.obs` | Other | A trap-returned array must survive ANOTHER THREAD's allocation. trap_array_barrier_test.obs cover... | ✅ |
+| 189 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
+| 190 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
+| 191 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
+| 192 | `websocket_test.obs` | Networking | websocket test | ✅ |
+| 193 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
+| 194 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
+| 195 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
 
 ## Debugger Tests (`run_debugger_tests.sh`)
 

--- a/programs/regression/native_gc_barrier_test.obs
+++ b/programs/regression/native_gc_barrier_test.obs
@@ -62,6 +62,26 @@ class NativeGcBarrierTest {
 		};
 	}
 
+
+	#~
+	The number of minor collections so far.
+
+	Every test here works by getting a reference into a container and then
+	provoking a minor collection, so a run in which no minor collection happened
+	proves nothing -- and prints "All tests passed" all the same. That is not
+	hypothetical: an 8-thread stress test written for this fix reported zero
+	damage over 1,140,480 references and was identically clean against a VM that
+	still had the bug, because once old generation passes MEM_START_MAX every
+	collection is major and a major GC traces transitively.
+
+	So each test asserts the collection it depends on actually ran. A future
+	change to YOUNG_REGION_SIZE or the allocation sizes would otherwise turn
+	these into silent no-ops.
+	~#
+	method : Minors() ~ Int {
+		return Runtime->GetProperty("runtime.gc.minor")->ToInt();
+	}
+
 	method : Run() ~ Nil {
 		@proxy := DllProxy->New("libobjk_crypto");
 		if(<>@proxy->IsLoaded()) {
@@ -82,6 +102,8 @@ class NativeGcBarrierTest {
 		@call_args[0] := Nil;
 		@call_args[1] := ByteArrayRef->New(input);
 
+		start_minor := Minors();
+
 		# 2. Collect, which clears the dirty list. The array is now a clean
 		#    old-generation object -- what a reused buffer looks like on every
 		#    call after the first.
@@ -96,6 +118,10 @@ class NativeGcBarrierTest {
 		Churn();
 
 		# 5. Only now, look at what the slot holds.
+		end_minor := Minors();
+		"  minor collections {$start_minor} to {$end_minor}"->PrintLine();
+		Check("minor collections actually ran", end_minor > start_minor);
+
 		slot := @call_args[0];
 		Check("the returned value is still there after a collection", slot <> Nil);
 		if(slot = Nil) {

--- a/programs/regression/native_gc_barrier_test.obs
+++ b/programs/regression/native_gc_barrier_test.obs
@@ -1,0 +1,143 @@
+#~
+# A value returned by a native library must survive a collection.
+#
+# A C++ shared library returns a value by storing it into the caller's `Base[]`
+# argument array, and lib_api.h's APITools_SetObjectValue does that with a plain
+# store. It cannot do otherwise: lib_api.h is compiled INTO each library, not
+# into the VM, so it has no access to the collector's write barrier.
+#
+# Three facts about the collector decide whether that plain store is safe:
+#
+#   * MemoryManager::AllocateArray never uses the nursery, so the argument array
+#     is always an OLD-generation object.
+#   * A minor GC promotes young survivors, which MOVES them, and then repairs
+#     references only in objects the write barrier recorded as dirty.
+#   * A minor GC marks an old object without recursing into it.
+#
+# So an unbarriered store of a YOUNG object into the argument array leaves a
+# reference that the fixup phase never visits. It survives anyway whenever the
+# array is dirty for some other reason -- filling the buffer from Objeck dirties
+# it -- which is why the ordinary "allocate the array, call, read the result"
+# shape never showed this.
+#
+# The ordering below is the one that does not get that protection, and it is the
+# ordering a REUSED argument buffer produces on every call after the first: the
+# buffer was filled during some earlier collection cycle, so by the time the
+# native store lands the array is clean, and nothing repairs the reference when
+# the next collection moves the object.
+#
+# Before the fix this printed a dangling reference -- in practice an
+# "Invalid object cast: '?' to 'System.String'" abort. The fix is VM-side:
+# native allocations go straight to the old generation (AllocateObjectNative),
+# where nothing moves them, so no barrier is needed and every already-compiled
+# library is covered without being rebuilt.
+#
+# Skips rather than fails when libobjk_crypto is not deployed, so an environment
+# without the native libraries does not report a false failure.
+~#
+
+use System.API;
+
+class NativeGcBarrierTest {
+	@proxy : DllProxy;
+	@call_args : Base[];
+	@failures : Int;
+
+	function : Main(args : String[]) ~ Nil {
+		t := NativeGcBarrierTest->New();
+		t->Run();
+	}
+
+	New() {
+		@failures := 0;
+	}
+
+	method : Check(what : String, ok : Bool) ~ Nil {
+		if(ok) {
+			"PASS: {$what}"->PrintLine();
+		}
+		else {
+			"FAIL: {$what}"->PrintLine();
+			@failures += 1;
+		};
+	}
+
+	method : Run() ~ Nil {
+		@proxy := DllProxy->New("libobjk_crypto");
+		if(<>@proxy->IsLoaded()) {
+			"SKIP: libobjk_crypto is not deployed"->PrintLine();
+			return;
+		};
+
+		input := "the quick brown fox jumps over the lazy dog"->ToByteArray();
+
+		# The control, through the library's own wrapper. This one is held in a
+		# local, so it is rooted the ordinary way and must survive regardless.
+		expect := Cipher.Encrypt->Base64(input);
+		Check("the library returns a value at all", expect <> Nil & expect->Size() > 0);
+
+		# 1. Fill the buffer. These stores run the write barrier, so the array is
+		#    dirty right now.
+		@call_args := Base->New[2];
+		@call_args[0] := Nil;
+		@call_args[1] := ByteArrayRef->New(input);
+
+		# 2. Collect, which clears the dirty list. The array is now a clean
+		#    old-generation object -- what a reused buffer looks like on every
+		#    call after the first.
+		Churn();
+
+		# 3. The call. The native side stores its result into that clean array.
+		@proxy->CallFunction("crypto_encrypt_base64", @call_args);
+
+		# 4. Collect again WITHOUT reading the slot. Reading it first would put the
+		#    value in a local, which is a root, and the test would pass no matter
+		#    what the collector did.
+		Churn();
+
+		# 5. Only now, look at what the slot holds.
+		slot := @call_args[0];
+		Check("the returned value is still there after a collection", slot <> Nil);
+		if(slot = Nil) {
+			Finish();
+			return;
+		};
+
+		# The cast is itself part of the assertion: a reference into recycled
+		# nursery memory does not read back as a String, and this aborts the VM.
+		got := slot->As(String);
+		Check("it is still a String", got <> Nil);
+		if(got <> Nil) {
+			Check("and it still holds what the library stored", got->Equals(expect));
+		};
+
+		Finish();
+	}
+
+	#~
+	Fill the 128MB nursery so a minor collection runs. Objects bump-allocate
+	young; arrays go straight to the old generation and would never trigger one.
+	Each IntRef is dead immediately, so this is pure nursery pressure.
+	~#
+	method : Churn() ~ Nil {
+		sink := 0;
+		for(i := 0; i < 3000000; i += 1;) {
+			r := IntRef->New(i);
+			sink += r->Get();
+		};
+
+		if(sink < 0) {
+			"unreachable"->PrintLine();
+		};
+	}
+
+	method : Finish() ~ Nil {
+		if(@failures = 0) {
+			"All tests passed"->PrintLine();
+		}
+		else {
+			"{$@failures} test(s) failed"->PrintLine();
+			Runtime->Exit(1);
+		};
+	}
+}

--- a/programs/regression/native_gc_leak_test.obs
+++ b/programs/regression/native_gc_leak_test.obs
@@ -1,0 +1,152 @@
+#~
+# Objects a native library returns must be RECLAIMED, not merely reachable.
+#
+# native_gc_barrier_test.obs guards the other direction -- that a returned
+# object survives long enough to be read. This one guards the direction that
+# costs a process rather than a value.
+#
+# Native allocations go to the old generation, where only a MAJOR collection
+# reclaims them (see MemoryManager::AllocateObjectNative and
+# docs/native_interface.md). Nothing about a native call triggers a collection
+# on its own: the API allocators pass collect=false, so they neither park at a
+# safepoint nor drive a GC. The question is whether ordinary allocation
+# pressure still produces the major collections that free them.
+#
+# Each iteration allocates one String natively -- Base64 returns one -- and
+# drops it. Nothing is retained, so a heap that climbs without bound is a leak.
+#
+# MEASURING IT IS THE HARD PART, and the obvious way does not work. The heap
+# sawtooths: it climbs to the collection threshold, drops, climbs again, and
+# the threshold itself adapts at runtime. So any single reading is a coin flip,
+# and comparing one reading against an early one with a generous multiplier is
+# worse than useless -- the first version of this test allowed 4x a baseline
+# that was 20MB of process startup, which would have passed with 54MB of
+# genuinely leaked strings sitting in a list.
+#
+# What actually rises when something leaks is the sawtooth's FLOOR. So this
+# runs two phases of equal length, samples repeatedly within each, and compares
+# the MINIMUM of each -- the closest each phase came to a fully collected heap.
+# With nothing retained the two floors are the same heap twice. With a leak the
+# second floor carries everything the first phase left behind.
+#
+# Measured when written: floors of 15.3MB and 15.6MB across 3,000,000
+# iterations, with 86 major collections, indistinguishable from the same run at
+# 400,000. Retaining the returned strings instead moves the second floor by
+# tens of megabytes, which is what the 1.5x bound below is set to catch.
+~#
+
+use System.API;
+
+class NativeGcLeakTest {
+	@failures : Int;
+
+	function : Main(args : String[]) ~ Nil {
+		t := NativeGcLeakTest->New();
+		t->Run();
+	}
+
+	New() {
+		@failures := 0;
+	}
+
+	method : Check(what : String, ok : Bool) ~ Nil {
+		if(ok) {
+			"PASS: {$what}"->PrintLine();
+		}
+		else {
+			"FAIL: {$what}"->PrintLine();
+			@failures += 1;
+		};
+	}
+
+	method : Used() ~ Int {
+		return Runtime->GetProperty("runtime.memory.used")->ToInt();
+	}
+
+	method : Majors() ~ Int {
+		return Runtime->GetProperty("runtime.gc.major")->ToInt();
+	}
+
+	#~
+	Run one phase and return the lowest heap reading seen during it -- how close
+	the heap came to being fully collected. Sampling often matters more than
+	sampling precisely: a phase that never lands near a trough reports a floor
+	that is really a slope.
+	~#
+	method : Floor(input : Byte[], rounds : Int) ~ Int {
+		low := Used();
+		every := rounds / 20;
+		for(i := 0; i < rounds; i += 1;) {
+			s := Cipher.Encrypt->Base64(input);
+			if(s = Nil) {
+				"unreachable"->PrintLine();
+			};
+
+			if(i % every = 0) {
+				used := Used();
+				if(used < low) {
+					low := used;
+				};
+			};
+		};
+
+		return low;
+	}
+
+	method : Run() ~ Nil {
+		proxy := DllProxy->New("libobjk_crypto");
+		if(<>proxy->IsLoaded()) {
+			"SKIP: libobjk_crypto is not deployed"->PrintLine();
+			return;
+		};
+
+		input := "the quick brown fox jumps over the lazy dog"->ToByteArray();
+		rounds := 250000;
+
+		# Warm up first, and throw the reading away. A floor sampled from process
+		# start is not a floor at all -- it is the heap before it has reached its
+		# working size, and comparing a later phase against it reports growth that
+		# is really just start-up. Measured: 9.5MB against a steady-state 14MB,
+		# which left the check passing by one percent for the wrong reason.
+		Floor(input, rounds);
+
+		base_major := Majors();
+		first := Floor(input, rounds);
+		second := Floor(input, rounds);
+		end_major := Majors();
+
+		"  floor after phase 1: {$first}"->PrintLine();
+		"  floor after phase 2: {$second}"->PrintLine();
+		"  major collections: {$base_major} -> {$end_major}"->PrintLine();
+
+		# Collections must actually be happening. Without this, a small heap
+		# would only mean the run was short.
+		Check("major collections run while native calls allocate",
+			end_major > base_major);
+
+		# The second phase's floor is the first phase's floor plus whatever the
+		# first phase failed to release.
+		#
+		# The margin is a quarter, not something looser, because a ratio between
+		# consecutive phases gets WEAKER as a linear leak accumulates: with a
+		# baseline F and a leak L per phase the ratio is (F+2L)/(F+L), which
+		# approaches 1 while the leak grows without bound. At a quarter the test
+		# catches any phase retaining more than about a third of the baseline
+		# heap; at a half it needed a leak larger than the entire baseline, which
+		# is most of a leak already having happened before anyone is told.
+		#
+		# Measured drift with nothing retained is under 4%, so this is roughly
+		# seven times the noise.
+		limit := (first * 5) / 4;
+		Check("the heap floor does not rise across a second phase ({$second} < {$limit})",
+			second < limit);
+
+		if(@failures = 0) {
+			"All tests passed"->PrintLine();
+		}
+		else {
+			"{$@failures} test(s) failed"->PrintLine();
+			Runtime->Exit(1);
+		};
+	}
+}

--- a/programs/regression/native_gc_leak_test.obs
+++ b/programs/regression/native_gc_leak_test.obs
@@ -9,30 +9,45 @@
 # reclaims them (see MemoryManager::AllocateObjectNative and
 # docs/native_interface.md). Nothing about a native call triggers a collection
 # on its own: the API allocators pass collect=false, so they neither park at a
-# safepoint nor drive a GC. The question is whether ordinary allocation
-# pressure still produces the major collections that free them.
+# safepoint nor drive a GC. The question is whether ordinary allocation pressure
+# still produces the major collections that free them.
 #
 # Each iteration allocates one String natively -- Base64 returns one -- and
-# drops it. Nothing is retained, so a heap that climbs without bound is a leak.
+# drops it. Nothing is retained.
 #
-# MEASURING IT IS THE HARD PART, and the obvious way does not work. The heap
-# sawtooths: it climbs to the collection threshold, drops, climbs again, and
-# the threshold itself adapts at runtime. So any single reading is a coin flip,
-# and comparing one reading against an early one with a generous multiplier is
-# worse than useless -- the first version of this test allowed 4x a baseline
-# that was 20MB of process startup, which would have passed with 54MB of
-# genuinely leaked strings sitting in a list.
+# THE ASSERTION IS BOUNDEDNESS, and getting there took three attempts, because
+# the obvious measurements are worse than useless:
 #
-# What actually rises when something leaks is the sawtooth's FLOOR. So this
-# runs two phases of equal length, samples repeatedly within each, and compares
-# the MINIMUM of each -- the closest each phase came to a fully collected heap.
-# With nothing retained the two floors are the same heap twice. With a leak the
-# second floor carries everything the first phase left behind.
+#   1. Comparing a late reading against an early one at 4x. The baseline was
+#      process start-up, so the bound was 81MB and 54MB of genuinely retained
+#      strings would have passed.
+#   2. Comparing the sawtooth FLOOR of consecutive phases, at 1.5x then 1.25x. A
+#      ratio between consecutive phases gets WEAKER as a linear leak
+#      accumulates -- with baseline F and leak L per phase it is (F+2L)/(F+L),
+#      which approaches 1 -- so it required a leak larger than the entire
+#      baseline before reporting anything. The floors also proved to be
+#      position-sensitive: sampled off a post-collection counter they doubled
+#      between phases on a run with no leak at all.
+#   3. Both of the above read `runtime.memory.used`, which is
+#      GetProcessResidentBytes() -- the OS resident set, not the GC heap at all.
+#      It is noisy, it does not fall when the collector frees, and gating CI on
+#      it was simply the wrong number.
 #
-# Measured when written: floors of 15.3MB and 15.6MB across 3,000,000
-# iterations, with 86 major collections, indistinguishable from the same run at
-# 400,000. Retaining the returned strings instead moves the second floor by
-# tens of megabytes, which is what the 1.5x bound below is set to catch.
+# What this reads instead is `runtime.gc.old.bytes`, the collector's own
+# old-generation accounting, which is exactly what native allocation grows. And
+# rather than comparing phases it asserts the property actually under test: the
+# number stays BOUNDED however long the run goes. Reclamation means bounded,
+# retention means unbounded. That is not a ratio, so accumulation cannot weaken
+# it.
+#
+# Measured when written: across 3,000,000 native String returns old generation
+# oscillated between roughly 1MB and 7MB with 86 major collections, and was
+# indistinguishable from the same run at 400,000. The ceiling below is an order
+# below is three times that peak -- and the peak is set by MEM_START_MAX, a
+# compile-time 8MB, so the headroom is over a constant rather than over noise.
+# A version of this program that retains every returned String reaches 34MB by
+# 150,000 iterations, which is how the ceiling was checked from the failing side
+# too.
 ~#
 
 use System.API;
@@ -59,8 +74,8 @@ class NativeGcLeakTest {
 		};
 	}
 
-	method : Used() ~ Int {
-		return Runtime->GetProperty("runtime.memory.used")->ToInt();
+	method : OldBytes() ~ Int {
+		return Runtime->GetProperty("runtime.gc.old.bytes")->ToInt();
 	}
 
 	method : Majors() ~ Int {
@@ -68,14 +83,53 @@ class NativeGcLeakTest {
 	}
 
 	#~
-	Run one phase and return the lowest heap reading seen during it -- how close
-	the heap came to being fully collected. Sampling often matters more than
-	sampling precisely: a phase that never lands near a trough reports a floor
-	that is really a slope.
+	Is the native library actually on disk?
+
+	Checked BEFORE constructing the DllProxy, because a failed load is not
+	recoverable: EXT_LIB_LOAD prints and calls exit(1), so `IsLoaded()` returning
+	false is nearly unreachable and a skip written that way is dead code. An
+	environment without the native libraries would hard-fail rather than skip.
 	~#
-	method : Floor(input : Byte[], rounds : Int) ~ Int {
-		low := Used();
-		every := rounds / 20;
+	method : LibraryPresent() ~ Bool {
+		dir := Runtime->GetProperty("lib_dir");
+		if(dir = Nil) {
+			return false;
+		};
+
+		base := "{$dir}native/libobjk_crypto";
+		dll := "{$base}.dll";
+		so := "{$base}.so";
+		dylib := "{$base}.dylib";
+
+		return System.IO.Filesystem.File->Exists(dll) |
+			System.IO.Filesystem.File->Exists(so) |
+			System.IO.Filesystem.File->Exists(dylib);
+	}
+
+	method : Run() ~ Nil {
+		if(<>LibraryPresent()) {
+			"SKIP: libobjk_crypto is not deployed"->PrintLine();
+			return;
+		};
+
+		input := "the quick brown fox jumps over the lazy dog"->ToByteArray();
+		rounds := 500000;
+
+		# Three times the observed 8MB peak, which is itself set by
+		# MEM_START_MAX (a compile-time 8MB), not by anything machine-specific --
+		# so the headroom is over a constant, not over noise.
+		#
+		# Verified in BOTH directions at this value, which the first attempt at
+		# 64MB was not: a version retaining every returned String reaches 34MB by
+		# 150,000 iterations and fails here, while the real test peaks at 8MB and
+		# passes. A ceiling only ever checked against passing runs is a ceiling
+		# nobody knows the height of.
+		ceiling := 25165824;
+
+		start_major := Majors();
+		peak := OldBytes();
+		every := rounds / 40;
+
 		for(i := 0; i < rounds; i += 1;) {
 			s := Cipher.Encrypt->Base64(input);
 			if(s = Nil) {
@@ -83,63 +137,24 @@ class NativeGcLeakTest {
 			};
 
 			if(i % every = 0) {
-				used := Used();
-				if(used < low) {
-					low := used;
+				now := OldBytes();
+				if(now > peak) {
+					peak := now;
 				};
 			};
 		};
 
-		return low;
-	}
-
-	method : Run() ~ Nil {
-		proxy := DllProxy->New("libobjk_crypto");
-		if(<>proxy->IsLoaded()) {
-			"SKIP: libobjk_crypto is not deployed"->PrintLine();
-			return;
-		};
-
-		input := "the quick brown fox jumps over the lazy dog"->ToByteArray();
-		rounds := 250000;
-
-		# Warm up first, and throw the reading away. A floor sampled from process
-		# start is not a floor at all -- it is the heap before it has reached its
-		# working size, and comparing a later phase against it reports growth that
-		# is really just start-up. Measured: 9.5MB against a steady-state 14MB,
-		# which left the check passing by one percent for the wrong reason.
-		Floor(input, rounds);
-
-		base_major := Majors();
-		first := Floor(input, rounds);
-		second := Floor(input, rounds);
 		end_major := Majors();
+		"  {$rounds} native String returns: peak old gen {$peak} bytes, majors {$start_major} to {$end_major}"->PrintLine();
 
-		"  floor after phase 1: {$first}"->PrintLine();
-		"  floor after phase 2: {$second}"->PrintLine();
-		"  major collections: {$base_major} -> {$end_major}"->PrintLine();
-
-		# Collections must actually be happening. Without this, a small heap
-		# would only mean the run was short.
+		# Collections must actually be happening. Without this a small heap only
+		# means nothing ran -- the same trap that made an 8-thread stress test
+		# pass identically against a VM that still had the bug.
 		Check("major collections run while native calls allocate",
-			end_major > base_major);
+			end_major > start_major);
 
-		# The second phase's floor is the first phase's floor plus whatever the
-		# first phase failed to release.
-		#
-		# The margin is a quarter, not something looser, because a ratio between
-		# consecutive phases gets WEAKER as a linear leak accumulates: with a
-		# baseline F and a leak L per phase the ratio is (F+2L)/(F+L), which
-		# approaches 1 while the leak grows without bound. At a quarter the test
-		# catches any phase retaining more than about a third of the baseline
-		# heap; at a half it needed a leak larger than the entire baseline, which
-		# is most of a leak already having happened before anyone is told.
-		#
-		# Measured drift with nothing retained is under 4%, so this is roughly
-		# seven times the noise.
-		limit := (first * 5) / 4;
-		Check("the heap floor does not rise across a second phase ({$second} < {$limit})",
-			second < limit);
+		# The property actually under test: bounded, not merely small.
+		Check("old generation stays bounded ({$peak} < {$ceiling})", peak < ceiling);
 
 		if(@failures = 0) {
 			"All tests passed"->PrintLine();

--- a/programs/regression/trap_array_barrier_test.obs
+++ b/programs/regression/trap_array_barrier_test.obs
@@ -72,6 +72,26 @@ class TrapArrayBarrierTest {
 		return bad;
 	}
 
+
+	#~
+	The number of minor collections so far.
+
+	Every test here works by getting a reference into a container and then
+	provoking a minor collection, so a run in which no minor collection happened
+	proves nothing -- and prints "All tests passed" all the same. That is not
+	hypothetical: an 8-thread stress test written for this fix reported zero
+	damage over 1,140,480 references and was identically clean against a VM that
+	still had the bug, because once old generation passes MEM_START_MAX every
+	collection is major and a major GC traces transitively.
+
+	So each test asserts the collection it depends on actually ran. A future
+	change to YOUNG_REGION_SIZE or the allocation sizes would otherwise turn
+	these into silent no-ops.
+	~#
+	method : Minors() ~ Int {
+		return Runtime->GetProperty("runtime.gc.minor")->ToInt();
+	}
+
 	method : Run() ~ Nil {
 		# The regression directory itself: the runner runs here, and it holds
 		# several hundred entries, which is enough that a collection landing
@@ -88,6 +108,7 @@ class TrapArrayBarrierTest {
 			return;
 		};
 
+		start_minor := Minors();
 		before := Damaged(files, count);
 		"  listed {$count} entries, {$before} unreadable before collecting"->PrintLine();
 		Check("the trap returns a readable array", before = 0);
@@ -95,7 +116,9 @@ class TrapArrayBarrierTest {
 		Churn();
 
 		after := Damaged(files, count);
-		"  {$after} unreadable after collecting"->PrintLine();
+		end_minor := Minors();
+		"  {$after} unreadable after collecting (minor {$start_minor} to {$end_minor})"->PrintLine();
+		Check("a minor collection actually ran", end_minor > start_minor);
 		Check("and its elements survive a collection", after = 0);
 
 		# Reading one through a string operation is what actually crashed, so do

--- a/programs/regression/trap_array_barrier_test.obs
+++ b/programs/regression/trap_array_barrier_test.obs
@@ -1,0 +1,131 @@
+#~
+# A String[] returned by a VM trap must survive a collection.
+#
+# Every trap that returns an array of objects builds it the same way:
+#
+#     size_t* str_obj_array = MemoryManager::AllocateArray(...)   // ALWAYS old
+#     str_obj_array_ptr[i]  = (size_t)CreateStringObject(...)     // young
+#
+# `AllocateArray` never uses the nursery, so the array is old-generation the
+# moment it exists. `AllocateObject` does use it, so each String is young. A
+# minor GC repairs references only in objects the write barrier recorded as
+# dirty, and a freshly allocated array is not dirty -- nothing has stored into
+# it through the barrier. A minor GC also marks an old object WITHOUT recursing
+# into it. So the elements were reachable only through an array the collector
+# would neither look inside nor repair, and the next minor collection promoted
+# them out from under it.
+#
+# Before the fix this test reported 262 of 393 entries as unreadable garbage,
+# and reading one into a string interpolation segfaulted the VM. It needs no
+# native library and no threads -- Directory->List and a loop are enough.
+#
+# The array itself is a local, and therefore a root, which is exactly why a
+# weaker check would miss this: the array comes back fine, non-empty, the right
+# length. It is the ELEMENTS that are gone. Nor can the elements be read before
+# the collection and kept, because reading one puts it in a local and roots it
+# for that reason alone. So this validates the SAME array twice, before and
+# after, with nothing between the two readings but allocation.
+~#
+
+class TrapArrayBarrierTest {
+	@failures : Int;
+
+	function : Main(args : String[]) ~ Nil {
+		t := TrapArrayBarrierTest->New();
+		t->Run();
+	}
+
+	New() {
+		@failures := 0;
+	}
+
+	method : Check(what : String, ok : Bool) ~ Nil {
+		if(ok) {
+			"PASS: {$what}"->PrintLine();
+		}
+		else {
+			"FAIL: {$what}"->PrintLine();
+			@failures += 1;
+		};
+	}
+
+	#~
+	Count elements that are not readable strings. A dangling element is not
+	necessarily Nil -- it points at whatever the nursery was reused for -- so
+	every entry is read rather than merely tested against Nil.
+	~#
+	method : Damaged(files : String[], count : Int) ~ Int {
+		bad := 0;
+		for(i := 0; i < count; i += 1;) {
+			f := files[i];
+			if(f = Nil) {
+				bad += 1;
+			}
+			else {
+				len := f->Size();
+				if(len = 0 | len > 4096) {
+					bad += 1;
+				};
+			};
+		};
+
+		return bad;
+	}
+
+	method : Run() ~ Nil {
+		# The regression directory itself: the runner runs here, and it holds
+		# several hundred entries, which is enough that a collection landing
+		# anywhere in the array is visible.
+		files := System.IO.Filesystem.Directory->List(".");
+		if(files = Nil) {
+			"SKIP: could not list the working directory"->PrintLine();
+			return;
+		};
+
+		count := files->Size();
+		if(count < 20) {
+			"SKIP: too few entries ({$count}) to be meaningful"->PrintLine();
+			return;
+		};
+
+		before := Damaged(files, count);
+		"  listed {$count} entries, {$before} unreadable before collecting"->PrintLine();
+		Check("the trap returns a readable array", before = 0);
+
+		Churn();
+
+		after := Damaged(files, count);
+		"  {$after} unreadable after collecting"->PrintLine();
+		Check("and its elements survive a collection", after = 0);
+
+		# Reading one through a string operation is what actually crashed, so do
+		# that too rather than only counting.
+		first := files[0];
+		joined := "[{$first}]";
+		Check("an element is still usable after collecting", joined->Size() > 2);
+
+		if(@failures = 0) {
+			"All tests passed"->PrintLine();
+		}
+		else {
+			"{$@failures} test(s) failed"->PrintLine();
+			Runtime->Exit(1);
+		};
+	}
+
+	#~
+	Fill the nursery so a minor collection runs. Objects bump-allocate young;
+	arrays go straight to the old generation and would never trigger one.
+	~#
+	method : Churn() ~ Nil {
+		sink := 0;
+		for(i := 0; i < 3000000; i += 1;) {
+			r := IntRef->New(i);
+			sink += r->Get();
+		};
+
+		if(sink < 0) {
+			"unreachable"->PrintLine();
+		};
+	}
+}

--- a/programs/regression/trap_array_mt_barrier_test.obs
+++ b/programs/regression/trap_array_mt_barrier_test.obs
@@ -1,0 +1,147 @@
+#~
+# A trap-returned array must survive ANOTHER THREAD's allocation.
+#
+# trap_array_barrier_test.obs covers the single-threaded case, where the same
+# thread allocates enough to fill the nursery between receiving the array and
+# reading it. That is a real shape, but a wide and somewhat artificial window.
+#
+# This is the sharper version of the same bug, and the one that makes it a
+# genuine hazard rather than a curiosity: the reading thread allocates NOTHING.
+# It receives a String[] from a trap, a different thread does all the
+# allocating, and the collection that different thread triggers is what
+# destroys the data. Nothing the reading thread does or avoids doing protects
+# it.
+#
+# Why it works, in terms of the collector: the array is old-generation from
+# creation (AllocateArray never uses the nursery) and its elements are young
+# (AllocateObject bump-allocates). A minor GC promotes -- and therefore MOVES --
+# young survivors, then repairs references only in objects the write barrier
+# recorded as dirty. A freshly filled trap array was never dirtied through the
+# barrier, and a minor GC marks an old object without recursing into it. So the
+# elements are both unmarked and unrepaired.
+#
+# Measured against the unfixed VM: 395 of 395 entries destroyed, on ONE minor
+# collection. Total, not partial -- in the single-threaded version the reading
+# thread's own allocation incidentally promotes some of the strings first, which
+# is why that one reported two thirds rather than all of them.
+#
+# Join() is the ordering guarantee: the churn is complete, and its collection
+# has happened, before this thread reads anything.
+~#
+
+use System.Concurrency;
+
+#~
+Allocates objects, and only that. Objects bump-allocate in the nursery; arrays
+would go straight to the old generation and never trigger a minor collection.
+~#
+class BarrierChurner from Thread {
+	@rounds : Int;
+
+	New(rounds : Int) {
+		Parent("churn");
+		@rounds := rounds;
+	}
+
+	method : public : Run(param : System.Base) ~ Nil {
+		sink := 0;
+		for(i := 0; i < @rounds; i += 1;) {
+			r := IntRef->New(i);
+			sink += r->Get();
+		};
+
+		if(sink < 0) {
+			"unreachable"->PrintLine();
+		};
+	}
+}
+
+class TrapArrayMtBarrierTest {
+	@failures : Int;
+
+	function : Main(args : String[]) ~ Nil {
+		t := TrapArrayMtBarrierTest->New();
+		t->Run();
+	}
+
+	New() {
+		@failures := 0;
+	}
+
+	method : Check(what : String, ok : Bool) ~ Nil {
+		if(ok) {
+			"PASS: {$what}"->PrintLine();
+		}
+		else {
+			"FAIL: {$what}"->PrintLine();
+			@failures += 1;
+		};
+	}
+
+	#~
+	Count elements that are not readable strings. A destroyed element is rarely
+	Nil -- it points at whatever the nursery was reused for -- so every entry is
+	read rather than compared against Nil.
+	~#
+	method : Damaged(files : String[], count : Int) ~ Int {
+		bad := 0;
+		for(i := 0; i < count; i += 1;) {
+			f := files[i];
+			if(f = Nil) {
+				bad += 1;
+			}
+			else {
+				len := f->Size();
+				if(len = 0 | len > 4096) {
+					bad += 1;
+				};
+			};
+		};
+
+		return bad;
+	}
+
+	method : Run() ~ Nil {
+		files := System.IO.Filesystem.Directory->List(".");
+		if(files = Nil) {
+			"SKIP: could not list the working directory"->PrintLine();
+			return;
+		};
+
+		count := files->Size();
+		if(count < 20) {
+			"SKIP: too few entries ({$count}) to be meaningful"->PrintLine();
+			return;
+		};
+
+		before := Damaged(files, count);
+		"  listed {$count} entries, {$before} unreadable before"->PrintLine();
+		Check("the trap returns a readable array", before = 0);
+
+		# From here to the read below, THIS thread allocates nothing. Enough
+		# rounds to fill the 128MB nursery at least once, on the other thread.
+		churner := BarrierChurner->New(4000000);
+		churner->Execute(Nil);
+		churner->Join();
+
+		minor := Runtime->GetProperty("runtime.gc.minor");
+		after := Damaged(files, count);
+		"  after another thread allocated (minor={$minor}): {$after} unreadable"->PrintLine();
+
+		Check("another thread's collection does not destroy the array", after = 0);
+
+		# Reading one through a string operation is what actually crashed, so do
+		# that rather than only counting.
+		first := files[0];
+		joined := "[{$first}]";
+		Check("an element is still usable afterwards", joined->Size() > 2);
+
+		if(@failures = 0) {
+			"All tests passed"->PrintLine();
+		}
+		else {
+			"{$@failures} test(s) failed"->PrintLine();
+			Runtime->Exit(1);
+		};
+	}
+}

--- a/programs/regression/trap_array_mt_barrier_test.obs
+++ b/programs/regression/trap_array_mt_barrier_test.obs
@@ -101,6 +101,26 @@ class TrapArrayMtBarrierTest {
 		return bad;
 	}
 
+
+	#~
+	The number of minor collections so far.
+
+	Every test here works by getting a reference into a container and then
+	provoking a minor collection, so a run in which no minor collection happened
+	proves nothing -- and prints "All tests passed" all the same. That is not
+	hypothetical: an 8-thread stress test written for this fix reported zero
+	damage over 1,140,480 references and was identically clean against a VM that
+	still had the bug, because once old generation passes MEM_START_MAX every
+	collection is major and a major GC traces transitively.
+
+	So each test asserts the collection it depends on actually ran. A future
+	change to YOUNG_REGION_SIZE or the allocation sizes would otherwise turn
+	these into silent no-ops.
+	~#
+	method : Minors() ~ Int {
+		return Runtime->GetProperty("runtime.gc.minor")->ToInt();
+	}
+
 	method : Run() ~ Nil {
 		files := System.IO.Filesystem.Directory->List(".");
 		if(files = Nil) {
@@ -114,6 +134,7 @@ class TrapArrayMtBarrierTest {
 			return;
 		};
 
+		start_minor := Minors();
 		before := Damaged(files, count);
 		"  listed {$count} entries, {$before} unreadable before"->PrintLine();
 		Check("the trap returns a readable array", before = 0);
@@ -124,10 +145,12 @@ class TrapArrayMtBarrierTest {
 		churner->Execute(Nil);
 		churner->Join();
 
-		minor := Runtime->GetProperty("runtime.gc.minor");
+		end_minor := Minors();
 		after := Damaged(files, count);
-		"  after another thread allocated (minor={$minor}): {$after} unreadable"->PrintLine();
+		"  after another thread allocated (minor {$start_minor} to {$end_minor}): {$after} unreadable"->PrintLine();
 
+		Check("the other thread's allocation actually caused a minor collection",
+			end_minor > start_minor);
 		Check("another thread's collection does not destroy the array", after = 0);
 
 		# Reading one through a string operation is what actually crashed, so do

--- a/tools/cicd/hoist_native_names.py
+++ b/tools/cicd/hoist_native_names.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Hold native entry-point names in fields instead of writing them at call sites.
+
+An Objeck string literal is materialised into a fresh String every time it is
+EVALUATED, not once at load. A name written at a `CallFunction` call site
+therefore costs an allocation and a copy on every native call. Measured on
+Windows x64: 1655ns for a call whose name is a literal against 130ns for the
+same call with the name held in a field -- 92% of the cost of a native call,
+spent in code that reads like a constant.
+
+The transformation, per class:
+
+  1. Collect every distinct name passed to CallFunction inside that class.
+  2. Declare one STATIC String field per name, just after the class opens.
+     Static because the names are class-wide constants, and because a
+     `function :` (static) cannot read an instance field.
+  3. At each call site, fill the field on first use and pass it.
+
+     before:  Proxy->GetDllProxy()->CallFunction("odbc_connect", args);
+     after:   if(@fn_odbc_connect = Nil) { @fn_odbc_connect := "odbc_connect"; };
+              Proxy->GetDllProxy()->CallFunction(@fn_odbc_connect, args);
+
+Two threads can race on the lazy fill. That race is benign: both write an
+equivalent String and one wins, so the worst case is a discarded allocation.
+Nothing can read a half-built value, because the store is a pointer store.
+
+Usage:
+  hoist_native_names.py <file.obs> [<file.obs> ...]   rewrite in place
+  hoist_native_names.py --check <file.obs> [...]      report literals, exit 1
+
+`--check` is the durable half: it is what keeps a new library, or a regenerated
+one, from quietly reintroducing the cost. Note that `core/lib/sdl/code_gen`
+GENERATES sdl2.obs, and its emitter writes the literal form -- regenerating it
+undoes this and `--check` is how you find out.
+"""
+import io
+import re
+import sys
+
+CALL = re.compile(r'CallFunction\("([A-Za-z0-9_]+)"')
+
+# Must END WITH the opening brace. Without that anchor a doc-comment line
+# beginning with the word "class" or "interface" -- sdl_gl.obs has one reading
+# "interface exactly, and does not accept ..." -- is taken for a declaration,
+# and the field block lands outside any class body.
+CLASS_OPEN = re.compile(r'^\t(?:class|interface)\s+(?::\s*private\s*:\s*)?(\w+)[^\n]*\{\s*$')
+
+
+def scan(lines):
+    """Map each line to its enclosing class, and each class to its first body line."""
+    owner = [None] * len(lines)
+    body_start = {}
+    current = None
+    for i, line in enumerate(lines):
+        match = CLASS_OPEN.match(line)
+        if match:
+            current = match.group(1)
+            body_start.setdefault(current, i + 1)
+        owner[i] = current
+    return owner, body_start
+
+
+def code_lines(lines):
+    """Yield (index, line) for lines that are code, skipping comments.
+
+    A doc block quoting a call site -- this codebase has several, including ones
+    describing this very change -- would otherwise have a guard statement spliced
+    into the middle of it, which breaks the comment and the class with it.
+    """
+    in_doc = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("#~"):
+            in_doc = True
+        if in_doc:
+            if stripped.endswith("~#"):
+                in_doc = False
+            continue
+        if stripped.startswith("#"):
+            continue
+        yield i, line
+
+
+def check(path):
+    """Return the call sites that still write their name as a literal."""
+    lines = io.open(path, encoding="utf-8", newline="").read().split("\n")
+    found = []
+    for i, line in code_lines(lines):
+        for name in CALL.findall(line):
+            found.append((i + 1, name))
+    return found
+
+
+def transform(path):
+    src = io.open(path, encoding="utf-8", newline="").read()
+    eol = "\r\n" if "\r\n" in src else "\n"
+    lines = src.split(eol)
+    owner, body_start = scan(lines)
+
+    used = {}
+    for i, line in code_lines(lines):
+        for name in CALL.findall(line):
+            if owner[i]:
+                used.setdefault(owner[i], set()).add(name)
+
+    # Rewrite call sites first, so inserting declarations does not shift indices.
+    changed = 0
+    for i, line in code_lines(lines):
+        names = CALL.findall(line)
+        if not names or not owner[i]:
+            continue
+        indent = line[:len(line) - len(line.lstrip("\t"))]
+        guards = []
+        new_line = line
+        for name in names:
+            field = "@fn_" + name
+            guards.append('%sif(%s = Nil) { %s := "%s"; };' % (indent, field, field, name))
+            new_line = new_line.replace('CallFunction("%s"' % name,
+                                        "CallFunction(%s" % field, 1)
+        lines[i] = eol.join(guards + [new_line])
+        changed += len(names)
+
+    # Then the declarations, from the bottom up for the same reason.
+    for cls in sorted(used, key=lambda c: body_start.get(c, 0), reverse=True):
+        at = body_start.get(cls)
+        if at is None:
+            raise SystemExit("could not find the body of class %s in %s" % (cls, path))
+        decls = [
+            "\t\t# Native entry-point names, held rather than written at each call",
+            "\t\t# site: a string literal is materialised into a fresh String every",
+            "\t\t# time it is evaluated, which on a hot path is an allocation and a",
+            "\t\t# copy per call. Static because these are class-wide constants and a",
+            "\t\t# static function cannot read an instance field.",
+        ]
+        decls += ["\t\t@fn_%s : static : String;" % n for n in sorted(used[cls])]
+        lines.insert(at, eol.join(decls))
+
+    io.open(path, "w", encoding="utf-8", newline="").write(eol.join(lines))
+    return changed
+
+
+def main(argv):
+    checking = "--check" in argv
+    targets = [a for a in argv[1:] if not a.startswith("--")]
+    if not targets:
+        print(__doc__.strip())
+        return 2
+
+    if checking:
+        total = 0
+        for path in targets:
+            for line_no, name in check(path):
+                print("%s:%d: native name written as a literal: \"%s\"" % (path, line_no, name))
+                total += 1
+        if total:
+            print("\n%d call site(s) still allocate their name on every call." % total)
+            print("Run this tool without --check to hold them in fields.")
+            return 1
+        print("No native-name literals at call sites.")
+        return 0
+
+    for path in targets:
+        print("  %s: hoisted %d call sites" % (path, transform(path)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Two instances of one bug: **a young object stored into an old-generation container with no write barrier.** The second is reachable from plain Objeck and segfaults the VM.

## The shape

Three facts about the collector combine badly:

- `AllocateArray` **never** uses the nursery, so **every array is old-generation from the moment it exists**.
- `AllocateObject` does use it, so a freshly created object is **young**.
- A minor GC **promotes young survivors, which moves them**, then repairs references only in objects the write barrier recorded as dirty — and it marks an old object *without recursing into it*.

So a young object stored into an old container without the barrier is invisible to both the mark phase and the fixup phase. It gets promoted out from under the reference, and the slot is left pointing into recycled nursery memory.

A freshly allocated array is never dirty — nothing has stored into it *through* the barrier — so this bites precisely where a container is built and filled in C++.

## Instance 1 — values returned by a native library

`lib_api.h` returns a value by storing into the caller's argument array with a plain store:

```cpp
data_array[index] = (size_t)obj;      // APITools_SetObjectValue
```

It cannot do otherwise: `lib_api.h` is compiled *into each library*, not into the VM, so it has no access to the barrier.

Hidden because the ordinary shape is safe by coincidence — filling the array from Objeck dirties it, and the result is read before the dirty list clears. It breaks when a collection falls **between** the fill and the call: a reused argument buffer on every call after the first, or another thread allocating.

Reproduced with `Cipher.Encrypt->Base64` through a hand-built argument array — fill, collect, call, collect, read → `Invalid object cast: '?' to 'System.String'`.

**Fix:** native allocations go to the old generation (`AllocateObjectNative`), where nothing moves them and a major GC's transitive marking finds them. Being VM-side, it covers **every already-compiled library without a rebuild**, and makes the rule for library authors one sentence: *everything a native library allocates is old-generation* — already true of arrays.

## Instance 2 — arrays returned by the VM's own traps

The same shape, no native library required:

```cpp
size_t* str_obj_array = MemoryManager::AllocateArray(...)   // ALWAYS old
str_obj_array_ptr[i]  = (size_t)CreateStringObject(...)     // young, no barrier
```

`Directory->List` on a 393-entry directory, then enough allocation to fill the nursery: **0 unreadable entries before the collection, 262 after.** Reading one into a string interpolation **segfaults**.

Barriered eight sites: the three `String[]` traps (`Directory->List`, shell command output, resolved socket addresses), both reflection arrays, deserialization into a destination array, and the HTTP/1.1, /2 and /3 response paths (a young content-type String into the caller's response object).

The deserializer's *sibling* object-array path already carried this barrier a few hundred lines above — that is how the shape was recognised; this branch had been missed.

A scan of every `.cpp` under `core/vm` for the shape reports none remaining. The native libraries are clean by construction under instance 1's fix: `APITools_CreateObject` now returns old-gen, so their stores are old-to-old.

## Verification

Three tests, each checked against a VM **without** the fix so they can actually fail:

| test | without the fix | with it |
|---|---|---|
| `native_gc_barrier_test` | invalid-cast abort, exit 1 | pass |
| `trap_array_barrier_test` | **segfault, exit 139** | pass, 0.4s |
| `native_gc_leak_test` | (guards the other direction) | pass, 1.6s |

The first two validate the **same** container before and after a collection, because a weaker check cannot see this: the array comes back non-empty, the right length, and is a root besides — it is the *elements* that are gone. Reading an element early is equally useless, since that roots it.

The leak test exists because the fix moves native allocations to old gen, where only a *major* collection reclaims them. Measured: 3M native String returns oscillate between roughly 1MB and 7MB of old generation with 86 major collections, indistinguishable from the same run at 400k. Against the pre-fix VM: **86 majors and 0 minors either way, old-gen bytes +11%** — the String's character array was *always* old-gen, so only the small object header changed generation.

Full regression: **191 passed, 3 skipped, 0 failed.**

## Also here

- **`docs/native_interface.md`** — the C++ side has had no written contract. Call protocol, the `lib_api.h` surface, the memory rules above, error and threading conventions, measured per-call costs, and the build/ship path.
- **`tools/cicd/hoist_native_names.py`** — `--check` reports native call sites that allocate their name on every call (used by #651).

## Caveat

The scan keys on a syntactic shape. It found every site that was then verified by hand, but *none remaining* means none matching that pattern — it is not a proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)