### PR TITLE
fix(jit): a stored float compare clobbered a callee-saved register on AMD64

### DIFF
--- a/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
+++ b/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
@@ -3735,9 +3735,9 @@ void JitAmd64::math_imm_xreg(RegInstr* instr, Register reg, InstructionType type
 #else
     cmp_imm_xreg(instr->GetOperand(), reg);
 #endif
-    if(!cond_jmp(type)) {
-      cmov_reg(reg, type);
-    }
+    // See the note in math_xreg_xreg: cmov_reg must never be handed an XMM
+    // register. The caller materialises the bool into a general-purpose one.
+    cond_jmp(type);
     break;
     
   default:
@@ -3777,9 +3777,27 @@ void JitAmd64::math_xreg_xreg(Register src, Register dest, InstructionType type)
   case NEQL_FLOAT:
   case GTR_EQL_FLOAT:
     cmp_xreg_xreg(src, dest);
-    if(!cond_jmp(type)) {
-      cmov_reg(dest, type);
-    }
+    // NO cmov_reg here. cmov_reg's first act is move_imm_reg(0, reg) -- a
+    // GENERAL-PURPOSE move -- so handing it an XMM register emitted a mov into
+    // whatever general-purpose register that XMM's number encodes to. The float
+    // pool is XMM10..XMM15, which encode to R10..R15, and R12-R15 are
+    // callee-saved: JIT-compiled code was quietly trashing a register the
+    // surrounding C++ VM still relied on, so the fault landed inside the VM
+    // after control returned to it. The bool is materialised by the LES_FLOAT/
+    // GTR_FLOAT/... case in ProcessInstructions, which pops this meaningless xmm
+    // result ("pop invalid xmm register") and calls cmov_reg on a register from
+    // GetRegister(). ARM64 already does the equivalent -- it releases the FP
+    // register and allocates a general-purpose one before cmov_reg.
+    //
+    // Only reachable when the compare is NOT fused with a following conditional
+    // jump, i.e. when its result is stored or otherwise materialised
+    // (`close := a < b;`) rather than branched on (`if(a < b)`), which is why
+    // this survived: `if` is the common shape, and a clobber only faults when
+    // the encoded register happens to be live.
+    //
+    // cmp_* leaves the flags for the caller; nothing between here and its
+    // cmov_reg emits an instruction, so the flags still stand.
+    cond_jmp(type);
     break;
 
   default:

--- a/programs/examples/gl_walkthrough.obs
+++ b/programs/examples/gl_walkthrough.obs
@@ -167,10 +167,12 @@ class Walkthrough {
 		dx := eye->GetX();
 		dz := eye->GetZ() + 7.4;
 		# The square root is bound to a local rather than compared inline. Written
-		# as `close := (dx * dx + dz * dz)->Sqrt() < 4.0;` this SEGFAULTS under the
-		# JIT and runs correctly with OBJECK_JIT_THRESHOLD set high -- a miscompile
-		# of a sqrt feeding straight into a float comparison inside a hot method.
-		# Splitting it costs nothing and reads better anyway.
+		# as `close := (dx * dx + dz * dz)->Sqrt() < 4.0;` this used to SEGFAULT
+		# under the JIT. The sqrt was incidental: a float comparison whose result
+		# was STORED clobbered a callee-saved register, because the AMD64 emitters
+		# passed an XMM register to cmov_reg, which begins with a general-purpose
+		# move. Fixed; guarded by programs/regression/jit_float_compare_store.obs.
+		# Kept split because it costs nothing and reads better anyway.
 		reach := (dx * dx + dz * dz)->Sqrt();
 		if(reach < 4.0) {
 			@door_open := true;

--- a/programs/regression/TESTS.md
+++ b/programs/regression/TESTS.md
@@ -13,7 +13,7 @@ python gen_manifest.py
 ```
 
 
-**Total runtime tests: 197** (plus 14 debugger tests, see below).
+**Total runtime tests: 198** (plus 14 debugger tests, see below).
 
 
 ## Tests by Category
@@ -22,8 +22,8 @@ python gen_manifest.py
 |----------|-------|
 | Core Language | 38 |
 | Other | 23 |
+| AMD64/JIT | 21 |
 | Negative | 21 |
-| AMD64/JIT | 20 |
 | Bug Fix | 13 |
 | System.ML | 13 |
 | Collections | 10 |
@@ -184,73 +184,74 @@ python gen_manifest.py
 | 128 | `jit_concurrent_compile.obs` | AMD64/JIT | Concurrency guard for the JIT code-page allocator (PageManager::GetPage). Several threads JIT-com... | ✅ |
 | 129 | `jit_conditional_native.obs` | AMD64/JIT | jit conditional native | ✅ |
 | 130 | `jit_dispatch_native.obs` | AMD64/JIT | jit dispatch native | ✅ |
-| 131 | `jit_float_equality.obs` | AMD64/JIT | Regression test for float equality compares on array elements (2026-06). The front-end chose EQL_... | ✅ |
-| 132 | `jit_float_intensive.obs` | AMD64/JIT | jit float intensive | ✅ |
-| 133 | `jit_float_mem_ops.obs` | AMD64/JIT | Float arithmetic and comparison against MEMORY operands, under the JIT. IMPORTANT: must run with... | ✅ |
-| 134 | `jit_float_round_trig.obs` | AMD64/JIT | Exercises two JIT float-codegen bugs that only surface once a method using them is auto-JIT'd (de... | ✅ |
-| 135 | `jit_frame_trap_test.obs` | AMD64/JIT | Regression test for the JIT frame-dependent trap crash (2026-06). Traps such as SERL_INT/SERL_FLO... | ✅ |
-| 136 | `jit_func_ref_hot.obs` | AMD64/JIT | jit func ref hot | ✅ |
-| 137 | `jit_gc_stress.obs` | AMD64/JIT | JIT + GC interaction stress (2026-06). One CI run on linux-x64 failed with a JIT-to-JIT runtime e... | ✅ |
-| 138 | `jit_loop_native.obs` | AMD64/JIT | jit loop native | ✅ |
-| 139 | `jit_native_cls_fields.obs` | AMD64/JIT | JIT Native Class Fields Test Tests object reference storage in class instance fields with GC pres... | ✅ |
-| 140 | `jit_native_float_array.obs` | AMD64/JIT | JIT Native Float Array Test Tests native function with float array creation and math operations R... | ✅ |
-| 141 | `jit_native_func_ref.obs` | AMD64/JIT | JIT Native Function Reference Test Tests native functions with function reference storage in clas... | ✅ |
-| 142 | `jit_native_math.obs` | AMD64/JIT | JIT Native Math Builtins Test Tests native math functions: Factorial, Sinh/Cosh/Tanh/Log2/Cbrt, P... | ✅ |
-| 143 | `jit_string_ops.obs` | AMD64/JIT | jit string ops | ✅ |
-| 144 | `jit_tco_bare_local.obs` | AMD64/JIT | Regression for the TCO deferred-local-load miscompile (both arches). A self-recursive tail call t... | ✅ |
-| 145 | `json_build_ops.obs` | JSON | json build ops | ✅ |
-| 146 | `json_parse_ops.obs` | JSON | json parse ops | ✅ |
-| 147 | `lame_encode_test.obs` | Other | Audio.Lame->PcmToMp3 encodes PCM to MP3. EXTRA_LIBS: lame This library had no runtime test at all... | ✅ |
-| 148 | `lsp_features.obs` | LSP | lsp features | ✅ |
-| 149 | `math_float_ops.obs` | Math | math float ops | ✅ |
-| 150 | `math_log_exp.obs` | Math | math log exp | ✅ |
-| 151 | `math_random_ops.obs` | Math | math random ops | ✅ |
-| 152 | `math_rounding.obs` | Math | math rounding | ✅ |
-| 153 | `math_sqrt_ops.obs` | Math | math sqrt ops | ✅ |
-| 154 | `math_trig_funcs.obs` | Math | math trig funcs | ✅ |
-| 155 | `mcp_debug_test.obs` | MCP Server | DEBUG VERSION of mcp_server_test.obs Identical to programs/regression/mcp_server_test.obs except:... | ✅ |
-| 156 | `mcp_server_test.obs` | MCP Server | mcp server test | ✅ |
-| 157 | `minor_gc_stress.obs` | Other | Regression for generational MINOR GC: old objects holding young references. 'keep' is an object a... | ✅ |
-| 158 | `ml_adaboost_test.obs` | System.ML | Regression tests for System.ML AdaBoost (overhaul phase 3): boosting over boolean decision stumps... | ✅ |
-| 159 | `ml_api_test.obs` | System.ML | Regression tests for the System.ML estimator API consistency sweep (item 11): RandomForest Fit (r... | ✅ |
-| 160 | `ml_dbscan_test.obs` | System.ML | Regression tests for System.ML DBSCAN (overhaul phase 3): two dense blobs plus far-away outliers... | ✅ |
-| 161 | `ml_gbt_test.obs` | System.ML | Regression tests for System.ML gradient boosting (overhaul phase 3 leftover): a RegressionTree le... | ✅ |
-| 162 | `ml_gmm_test.obs` | System.ML | Regression tests for System.ML GaussianMixture (overhaul phase 3): EM on two well-separated blobs... | ✅ |
-| 163 | `ml_kdtree_test.obs` | System.ML | Regression tests for System.ML KDTree (overhaul phase 3): for several queries and k values over a... | ✅ |
-| 164 | `ml_library_test.obs` | System.ML | ml library test | ✅ |
-| 165 | `ml_linearclf_test.obs` | System.ML | Regression tests for the System.ML linear classifiers (overhaul phase 2): Perceptron (mistake-dri... | ✅ |
-| 166 | `ml_nn_test.obs` | System.ML | Regression tests for the System.ML NeuralNetwork with hidden/output bias vectors (ML overhaul ite... | ✅ |
-| 167 | `ml_pca_gnb_test.obs` | System.ML | Regression tests for System.ML PCA (power-iteration decomposition: dominant diagonal direction re... | ✅ |
-| 168 | `ml_phase1_test.obs` | System.ML | Regression tests for the System.ML correctness fixes (phase 1): seedable PRNG, DotSigmoid dimensi... | ✅ |
-| 169 | `ml_regularized_test.obs` | System.ML | Regression tests for the System.ML regularized linear models (overhaul phase 2): RidgeRegression... | ✅ |
-| 170 | `ml_trees_test.obs` | System.ML | Regression tests for the System.ML tree models: the real recursive DecisionTree (left/right child... | ✅ |
-| 171 | `native_gc_barrier_test.obs` | Other | A value returned by a native library must survive a collection. A C++ shared library returns a va... | ✅ |
-| 172 | `native_gc_leak_test.obs` | Other | Objects a native library returns must be RECLAIMED, not merely reachable. native_gc_barrier_test.... | ✅ |
-| 173 | `nil_safe_ops.obs` | Core Language | Nil-safe operators: '??' (nil-coalesce) and '?->' (nil-safe call). Both desugar onto existing int... | ✅ |
-| 174 | `oauth_test.obs` | Networking | oauth test | ✅ |
-| 175 | `odbc_sqlite_test.obs` | ODBC | ODBC SQLite Integration Test Tests live database operations against an in-memory SQLite database.... | ✅ |
-| 176 | `onnx_runtime_test.obs` | Other | API.Onnx.OnnxRuntime->GetProviders() reaches the native ONNX Runtime. EXTRA_LIBS: onnx,opencv,cip... | ✅ |
-| 177 | `primitive_receiver_order.obs` | Other | Argument order for instance-style calls on primitives. Writing `v->Pow(10)` on a primitive does n... | ✅ |
-| 178 | `regex_bench.obs` | Regex | regex bench | ✅ |
-| 179 | `regex_dfa_test.obs` | Regex | regex dfa test | ✅ |
-| 180 | `runtime_feature_test.obs` | Other | Regression tests for the "runtime.feature.*" properties, which report which optional protocol eng... | ✅ |
-| 181 | `select_dispatch_test.obs` | Control Flow | Single-case, linear (2-5 cases), jump-table (dense >=6), and binary-tree (sparse) paths | ✅ |
-| 182 | `string_find_ops.obs` | Strings | string find ops | ✅ |
-| 183 | `string_format_ops.obs` | Strings | Verifies String->Format() positional substitution. | ✅ |
-| 184 | `string_number_conv.obs` | Strings | string number conv | ✅ |
-| 185 | `string_replace_ops.obs` | Strings | string replace ops | ✅ |
-| 186 | `string_split_ops.obs` | Strings | string split ops | ✅ |
-| 187 | `task_scope.obs` | Other | Regression for a structured-concurrency nursery (TaskScope) built purely on the existing System.C... | ✅ |
-| 188 | `tco_receiver.obs` | Other | Tail-call optimization must respect the receiver. TCO used to fire on matching class-id and metho... | ✅ |
-| 189 | `trap_array_barrier_test.obs` | Other | A String[] returned by a VM trap must survive a collection. Every trap that returns an array of o... | ✅ |
-| 190 | `trap_array_mt_barrier_test.obs` | Other | A trap-returned array must survive ANOTHER THREAD's allocation. trap_array_barrier_test.obs cover... | ✅ |
-| 191 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
-| 192 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
-| 193 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
-| 194 | `websocket_test.obs` | Networking | websocket test | ✅ |
-| 195 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
-| 196 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
-| 197 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
+| 131 | `jit_float_compare_store.obs` | AMD64/JIT | A float comparison whose result is STORED must not clobber a live register. `cmov_reg`'s first ac... | ✅ |
+| 132 | `jit_float_equality.obs` | AMD64/JIT | Regression test for float equality compares on array elements (2026-06). The front-end chose EQL_... | ✅ |
+| 133 | `jit_float_intensive.obs` | AMD64/JIT | jit float intensive | ✅ |
+| 134 | `jit_float_mem_ops.obs` | AMD64/JIT | Float arithmetic and comparison against MEMORY operands, under the JIT. IMPORTANT: must run with... | ✅ |
+| 135 | `jit_float_round_trig.obs` | AMD64/JIT | Exercises two JIT float-codegen bugs that only surface once a method using them is auto-JIT'd (de... | ✅ |
+| 136 | `jit_frame_trap_test.obs` | AMD64/JIT | Regression test for the JIT frame-dependent trap crash (2026-06). Traps such as SERL_INT/SERL_FLO... | ✅ |
+| 137 | `jit_func_ref_hot.obs` | AMD64/JIT | jit func ref hot | ✅ |
+| 138 | `jit_gc_stress.obs` | AMD64/JIT | JIT + GC interaction stress (2026-06). One CI run on linux-x64 failed with a JIT-to-JIT runtime e... | ✅ |
+| 139 | `jit_loop_native.obs` | AMD64/JIT | jit loop native | ✅ |
+| 140 | `jit_native_cls_fields.obs` | AMD64/JIT | JIT Native Class Fields Test Tests object reference storage in class instance fields with GC pres... | ✅ |
+| 141 | `jit_native_float_array.obs` | AMD64/JIT | JIT Native Float Array Test Tests native function with float array creation and math operations R... | ✅ |
+| 142 | `jit_native_func_ref.obs` | AMD64/JIT | JIT Native Function Reference Test Tests native functions with function reference storage in clas... | ✅ |
+| 143 | `jit_native_math.obs` | AMD64/JIT | JIT Native Math Builtins Test Tests native math functions: Factorial, Sinh/Cosh/Tanh/Log2/Cbrt, P... | ✅ |
+| 144 | `jit_string_ops.obs` | AMD64/JIT | jit string ops | ✅ |
+| 145 | `jit_tco_bare_local.obs` | AMD64/JIT | Regression for the TCO deferred-local-load miscompile (both arches). A self-recursive tail call t... | ✅ |
+| 146 | `json_build_ops.obs` | JSON | json build ops | ✅ |
+| 147 | `json_parse_ops.obs` | JSON | json parse ops | ✅ |
+| 148 | `lame_encode_test.obs` | Other | Audio.Lame->PcmToMp3 encodes PCM to MP3. EXTRA_LIBS: lame This library had no runtime test at all... | ✅ |
+| 149 | `lsp_features.obs` | LSP | lsp features | ✅ |
+| 150 | `math_float_ops.obs` | Math | math float ops | ✅ |
+| 151 | `math_log_exp.obs` | Math | math log exp | ✅ |
+| 152 | `math_random_ops.obs` | Math | math random ops | ✅ |
+| 153 | `math_rounding.obs` | Math | math rounding | ✅ |
+| 154 | `math_sqrt_ops.obs` | Math | math sqrt ops | ✅ |
+| 155 | `math_trig_funcs.obs` | Math | math trig funcs | ✅ |
+| 156 | `mcp_debug_test.obs` | MCP Server | DEBUG VERSION of mcp_server_test.obs Identical to programs/regression/mcp_server_test.obs except:... | ✅ |
+| 157 | `mcp_server_test.obs` | MCP Server | mcp server test | ✅ |
+| 158 | `minor_gc_stress.obs` | Other | Regression for generational MINOR GC: old objects holding young references. 'keep' is an object a... | ✅ |
+| 159 | `ml_adaboost_test.obs` | System.ML | Regression tests for System.ML AdaBoost (overhaul phase 3): boosting over boolean decision stumps... | ✅ |
+| 160 | `ml_api_test.obs` | System.ML | Regression tests for the System.ML estimator API consistency sweep (item 11): RandomForest Fit (r... | ✅ |
+| 161 | `ml_dbscan_test.obs` | System.ML | Regression tests for System.ML DBSCAN (overhaul phase 3): two dense blobs plus far-away outliers... | ✅ |
+| 162 | `ml_gbt_test.obs` | System.ML | Regression tests for System.ML gradient boosting (overhaul phase 3 leftover): a RegressionTree le... | ✅ |
+| 163 | `ml_gmm_test.obs` | System.ML | Regression tests for System.ML GaussianMixture (overhaul phase 3): EM on two well-separated blobs... | ✅ |
+| 164 | `ml_kdtree_test.obs` | System.ML | Regression tests for System.ML KDTree (overhaul phase 3): for several queries and k values over a... | ✅ |
+| 165 | `ml_library_test.obs` | System.ML | ml library test | ✅ |
+| 166 | `ml_linearclf_test.obs` | System.ML | Regression tests for the System.ML linear classifiers (overhaul phase 2): Perceptron (mistake-dri... | ✅ |
+| 167 | `ml_nn_test.obs` | System.ML | Regression tests for the System.ML NeuralNetwork with hidden/output bias vectors (ML overhaul ite... | ✅ |
+| 168 | `ml_pca_gnb_test.obs` | System.ML | Regression tests for System.ML PCA (power-iteration decomposition: dominant diagonal direction re... | ✅ |
+| 169 | `ml_phase1_test.obs` | System.ML | Regression tests for the System.ML correctness fixes (phase 1): seedable PRNG, DotSigmoid dimensi... | ✅ |
+| 170 | `ml_regularized_test.obs` | System.ML | Regression tests for the System.ML regularized linear models (overhaul phase 2): RidgeRegression... | ✅ |
+| 171 | `ml_trees_test.obs` | System.ML | Regression tests for the System.ML tree models: the real recursive DecisionTree (left/right child... | ✅ |
+| 172 | `native_gc_barrier_test.obs` | Other | A value returned by a native library must survive a collection. A C++ shared library returns a va... | ✅ |
+| 173 | `native_gc_leak_test.obs` | Other | Objects a native library returns must be RECLAIMED, not merely reachable. native_gc_barrier_test.... | ✅ |
+| 174 | `nil_safe_ops.obs` | Core Language | Nil-safe operators: '??' (nil-coalesce) and '?->' (nil-safe call). Both desugar onto existing int... | ✅ |
+| 175 | `oauth_test.obs` | Networking | oauth test | ✅ |
+| 176 | `odbc_sqlite_test.obs` | ODBC | ODBC SQLite Integration Test Tests live database operations against an in-memory SQLite database.... | ✅ |
+| 177 | `onnx_runtime_test.obs` | Other | API.Onnx.OnnxRuntime->GetProviders() reaches the native ONNX Runtime. EXTRA_LIBS: onnx,opencv,cip... | ✅ |
+| 178 | `primitive_receiver_order.obs` | Other | Argument order for instance-style calls on primitives. Writing `v->Pow(10)` on a primitive does n... | ✅ |
+| 179 | `regex_bench.obs` | Regex | regex bench | ✅ |
+| 180 | `regex_dfa_test.obs` | Regex | regex dfa test | ✅ |
+| 181 | `runtime_feature_test.obs` | Other | Regression tests for the "runtime.feature.*" properties, which report which optional protocol eng... | ✅ |
+| 182 | `select_dispatch_test.obs` | Control Flow | Single-case, linear (2-5 cases), jump-table (dense >=6), and binary-tree (sparse) paths | ✅ |
+| 183 | `string_find_ops.obs` | Strings | string find ops | ✅ |
+| 184 | `string_format_ops.obs` | Strings | Verifies String->Format() positional substitution. | ✅ |
+| 185 | `string_number_conv.obs` | Strings | string number conv | ✅ |
+| 186 | `string_replace_ops.obs` | Strings | string replace ops | ✅ |
+| 187 | `string_split_ops.obs` | Strings | string split ops | ✅ |
+| 188 | `task_scope.obs` | Other | Regression for a structured-concurrency nursery (TaskScope) built purely on the existing System.C... | ✅ |
+| 189 | `tco_receiver.obs` | Other | Tail-call optimization must respect the receiver. TCO used to fire on matching class-id and metho... | ✅ |
+| 190 | `trap_array_barrier_test.obs` | Other | A String[] returned by a VM trap must survive a collection. Every trap that returns an array of o... | ✅ |
+| 191 | `trap_array_mt_barrier_test.obs` | Other | A trap-returned array must survive ANOTHER THREAD's allocation. trap_array_barrier_test.obs cover... | ✅ |
+| 192 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
+| 193 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
+| 194 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
+| 195 | `websocket_test.obs` | Networking | websocket test | ✅ |
+| 196 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
+| 197 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
+| 198 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
 
 ## Debugger Tests (`run_debugger_tests.sh`)
 

--- a/programs/regression/jit_float_compare_store.obs
+++ b/programs/regression/jit_float_compare_store.obs
@@ -1,0 +1,162 @@
+#~
+# A float comparison whose result is STORED must not clobber a live register.
+#
+# `cmov_reg`'s first act is `move_imm_reg(0, reg)` -- a general-purpose move.
+# The AMD64 float emitters `math_xreg_xreg` and `math_imm_xreg` handed it an
+# XMM register, so it emitted a mov into whatever general-purpose register that
+# XMM's number encodes to: XMM10->R10, XMM11->R11, XMM12->R12, XMM13->R13,
+# XMM14->R14, XMM15->R15. The last four are callee-saved, so JIT-compiled code
+# silently trashed a register the surrounding C++ VM was relying on, and the
+# crash landed inside the VM after control returned to it.
+#
+# Two conditions had to coincide, which is why it survived so long:
+#
+#   1. The compare must NOT be fused with a following conditional jump. Written
+#      `if(a < b)` the JIT emits a branch and never materialises a bool, so the
+#      bad path is skipped. Only a materialised result -- stored to a variable,
+#      returned, or passed as an argument -- reaches it.
+#   2. The clobbered register must be live. The XMM pool hands out XMM10 first,
+#      then XMM11, ... so one or two live floats only ever touch R10/R11, which
+#      are scratch. It takes three or more concurrently live floats to reach
+#      R12+, and only then does anything break.
+#
+# It was originally found as "sqrt feeding a comparison segfaults" in
+# gl_walkthrough.obs. Sqrt was incidental: it just happened to leave its result
+# in a register, which is condition 2. ARM64 was never affected -- its float
+# path already releases the FP register and allocates a general-purpose one
+# before calling cmov_reg.
+#
+# Pinned() below arranges both conditions deterministically, and segfaults on a
+# pre-fix build at the default JIT threshold. Shapes() and Ops() then check that
+# the comparisons still produce the RIGHT answers rather than merely not
+# crashing -- the interpreter agrees with every assertion here.
+~#
+
+class JitFloatCompareStore {
+	@failures : Int;
+	@limit : Float;
+
+	function : Main(args : String[]) ~ Nil {
+		t := JitFloatCompareStore->New();
+		t->Run();
+	}
+
+	New() {
+		@failures := 0;
+		@limit := 4.0;
+	}
+
+	method : Check(what : String, got : Bool, want : Bool) ~ Nil {
+		if(got <> want) {
+			"FAIL: {$what} (got={$got} want={$want})"->PrintLine();
+			@failures += 1;
+		};
+	}
+
+	method : Note(what : String) ~ Nil {
+		"FAIL: {$what}"->PrintLine();
+		@failures += 1;
+	}
+
+	#~
+	The crash shape. Each float local store caches its value in an XMM register,
+	so the five stores pin XMM10..XMM14 and the compare's own operand lands on a
+	high XMM -- i.e. on a callee-saved general-purpose register once encoded.
+	The pinned locals are read afterwards so none of it is dead code.
+	~#
+	method : Pinned(a : Float, b : Float, c : Float, d : Float, e : Float, f : Float) ~ Bool {
+		p := a * 1.5;
+		q := b * 2.5;
+		s := c * 3.5;
+		t := d * 4.5;
+		u := e * 5.5;
+		flag := (f * 6.5) < 100.0;
+		total := p + q + s + t + u;
+		if(total < 0.0) {
+			Note("pinned locals went negative");
+		};
+
+		return flag;
+	}
+
+	#~
+	Every operand shape a float compare can take, with the result stored to a
+	local before it is read.
+	~#
+	method : Shapes(a : Float, b : Float) ~ Nil {
+		r1 : Bool; r2 : Bool; r3 : Bool; r4 : Bool;
+		r5 : Bool; r6 : Bool; r7 : Bool; r8 : Bool;
+
+		r1 := (a * 1.0) < 4.0;         Check("reg<imm", r1, a < 4.0);
+		r2 := 4.0 < (a * 1.0);         Check("imm<reg", r2, 4.0 < a);
+		r3 := (a * 1.0) < b;           Check("reg<mem", r3, a < b);
+		r4 := b < (a * 1.0);           Check("mem<reg", r4, b < a);
+		r5 := a < b;                   Check("mem<mem", r5, a < b);
+		r6 := a < 4.0;                 Check("mem<imm", r6, a < 4.0);
+		r7 := 4.0 < a;                 Check("imm<mem", r7, 4.0 < a);
+		r8 := (a * 1.0) < (b * 1.0);   Check("reg<reg", r8, a < b);
+	}
+
+	#~
+	All six comparison operators, each with a register-resident left operand.
+	~#
+	method : Ops(a : Float, b : Float) ~ Nil {
+		r1 : Bool; r2 : Bool; r3 : Bool;
+		r4 : Bool; r5 : Bool; r6 : Bool;
+
+		r1 := (a * 1.0) <  b;   Check("lt", r1, a <  b);
+		r2 := (a * 1.0) <= b;   Check("le", r2, a <= b);
+		r3 := (a * 1.0) >  b;   Check("gt", r3, a >  b);
+		r4 := (a * 1.0) >= b;   Check("ge", r4, a >= b);
+		r5 := (a * 1.0) =  b;   Check("eq", r5, a =  b);
+		r6 := (a * 1.0) <> b;   Check("ne", r6, a <> b);
+	}
+
+	# The bool crossing a return, which materialises it just as a store does.
+	method : Returned(a : Float) ~ Bool {
+		r := (a * 1.0) < @limit;
+		return r;
+	}
+
+	# The bool as a call argument, the third way to materialise one.
+	method : Sink(flag : Bool, want : Bool) ~ Nil {
+		Check("passed-arg", flag, want);
+	}
+
+	method : Run() ~ Nil {
+		i : Int;
+		a : Float;
+		b : Float;
+		bad : Int;
+
+		bad := 0;
+		# Hot enough that every method above is JIT-compiled at the default
+		# threshold, with inputs that straddle each comparison boundary.
+		for(i := 0; i < 80000; i += 1;) {
+			a := (i % 9)->As(Float);
+			b := ((i + 3) % 7)->As(Float);
+
+			Shapes(a, b);
+			Ops(a, b);
+			Check("returned", Returned(a), a < 4.0);
+			Sink((a * 1.0) < 4.0, a < 4.0);
+
+			got := Pinned(a, a + 1.0, a + 2.0, a + 3.0, a + 4.0, a + 5.0);
+			if(got <> (((a + 5.0) * 6.5) < 100.0)) {
+				bad += 1;
+			};
+		};
+
+		if(bad > 0) {
+			Note("{$bad} wrong results from the register-pinned compare");
+		};
+
+		if(@failures = 0) {
+			"All tests passed"->PrintLine();
+		}
+		else {
+			"{$@failures} test(s) failed"->PrintLine();
+			Runtime->Exit(1);
+		};
+	}
+}


### PR DESCRIPTION
Fixes #655.

## The reported bug was mis-titled

#655 was filed as "`(expr)->Sqrt() < literal` segfaults in a hot method". Sqrt has nothing to do with it. `(dx * dx + dz * dz) < 4.0`, with no sqrt anywhere, segfaults identically. Sqrt merely leaves its result in a register, which is one of the two conditions below.

The real defect is much broader: **on AMD64, any float comparison whose result is materialised could clobber a callee-saved general-purpose register.**

## Root cause

`cmov_reg`'s first instruction is `move_imm_reg(0, reg)` — a **general-purpose** move. `math_xreg_xreg` and `math_imm_xreg` handed it an **XMM** register:

```cpp
cmp_xreg_xreg(src, dest);
if(!cond_jmp(type)) {
  cmov_reg(dest, type);      // dest is an XMM register
}
```

So it emitted a `mov` into whatever general-purpose register that XMM's number encodes to. The float pool is `XMM10..XMM15`, which encode to `R10..R15` (`RegisterEncode3` groups `XMM13` with `R13`, `XMM15` with `R15`, and so on), and **R12–R15 are callee-saved**. JIT-compiled code was quietly trashing a register the surrounding C++ VM still relied on, so the fault landed *inside the VM* once control returned to it. gdb confirms: faulting on `mov %rcx,0x0(%r13)`, in VM code, called from a JIT page.

## Why it survived this long

Two conditions had to coincide:

1. **The compare must not be fused with a following conditional jump.** Written `if(a < b)`, the JIT emits a branch and never materialises a bool, so the bad path is skipped entirely. Only a materialised result — stored to a variable, returned, or passed as an argument — reaches it. `if` is overwhelmingly the common shape.
2. **The clobbered register must be live.** The pool hands out `XMM10` first, then `XMM11`, … so one or two live floats only ever touch `R10`/`R11`, which are scratch. It takes three or more concurrently live floats to reach `R12+`.

Condition 2 is also why `>` survived while `<` crashed on the very same expression, and why the bug looked like it needed "a hot method": it is purely which XMM the allocator happened to hand out.

## The fix

Remove the inner call. The `LES_FLOAT`/`GTR_FLOAT`/… case in `ProcessInstructions` already materialises the bool correctly — it pops the xmm result (its own comment calls it *"pop invalid xmm register"*), allocates a general-purpose register via `GetRegister()`, and calls `cmov_reg` on that. The inner call was a second, bogus materialisation.

`cond_jmp(type)` still runs, so jump fusion is unchanged. `cmp_*` leaves the flags for the caller, and nothing between there and the caller's `cmov_reg` emits an instruction, so the flags still stand.

**ARM64 was never affected.** Its float path already does the right thing:

```cpp
cmp_freg_freg(src, dest->GetRegister());
if(!cond_jmp(type)) {
  ReleaseFpRegister(dest);
  dest = GetRegister();          // a GENERAL-PURPOSE register
  cmov_reg(dest->GetRegister(), type);
}
```

AMD64 simply never got that. No ARM64 change is needed, which is worth stating explicitly because #655 asked for both backends to be checked.

## Verification

| | pre-fix | post-fix |
|---|---|---|
| `gl_walkthrough.obs`, folded form (the original report) | segfault | runs |
| 4 of 7 expression variants (`<` imm / `<` var / swapped / **no sqrt**) | segfault | run |
| `jit_float_compare_store.obs`, **default** JIT threshold | **segfault** | passes |
| `jit_float_compare_store.obs`, JIT disabled | passes | passes |
| 6 operators × 8 operand shapes, JIT vs interpreter | — | agree |
| Full local regression suite | — | 195 passed, 3 skipped, **0 failed** |

I built a pre-fix VM specifically to confirm the new test fails on it. That mattered: **my first draft of the test passed on the buggy build**, because it never had more than two live floats, so it would have guarded nothing. The committed version pins `XMM10..XMM14` through the float local cache, so the compare's operand deterministically lands on a callee-saved register, and it crashes at the default threshold without needing any env var.

The test also asserts *values*, not just survival — six operators against eight operand shapes, cross-checked against the interpreter — so a future change cannot trade the crash for wrong answers.

## Also in this PR

- **Audited the other 16 calls** of a general-purpose emitter from inside a float emitter (`move_imm_reg` in `move_imm_xreg`, `add_imm_xreg`, `cmp_imm_xreg`, `cvt_imm_xreg`, …). Every one already passes a real `GetRegister()` holder. These two `cmov_reg` calls were the only defects of this kind.
- **Corrected the comment in `gl_walkthrough.obs`**, which asserted a live JIT miscompile. The code stays split — it reads better, as the original comment said — but the explanation now names the real defect and points at the regression test instead of claiming a bug that no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
