### PR TITLE
fix(windows): resolve mbedTLS and nghttp2 from vcpkg instead of stale committed blobs

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -300,10 +300,36 @@ jobs:
       - name: Install Windows dependencies
         if: runner.os == 'Windows'
         shell: pwsh
+        # mbedTLS and nghttp2 now come from vcpkg, resolved by
+        # core/build/vcpkg.props. They used to be binaries committed under
+        # core/lib/openssl/win/{x64,arm64}, which is why this step did nothing:
+        # the projects listed those directories ahead of $(LibraryPath), so the
+        # committed copies were what got linked, while the committed headers had
+        # already drifted to a different version. This workflow builds the
+        # RELEASE artifacts, so it needs the same install ci-build.yml does.
         run: |
-          # nghttp2 and mbedtls headers/libs are committed to core/lib/openssl/win/{x64,arm64}/
-          # and core/lib/openssl/win/include/ — no vcpkg install needed
-          Write-Output "✅ Windows deps self-contained in repo (no vcpkg required)"
+          function Install-VcpkgPackage([string]$pkg) {
+            $max = 3
+            for ($i = 1; $i -le $max; $i++) {
+              vcpkg install $pkg
+              if ($LASTEXITCODE -eq 0) { return }
+              if ($i -lt $max) {
+                Write-Output "vcpkg install $pkg failed (attempt $i/$max); retrying in 20s..."
+                Start-Sleep -Seconds 20
+              }
+            }
+            throw "vcpkg install $pkg failed after $max attempts"
+          }
+
+          Install-VcpkgPackage "mbedtls:${{ matrix.arch }}-windows"
+          Install-VcpkgPackage "nghttp2:${{ matrix.arch }}-windows"
+
+          # PATH only, for the deploy script's nghttp2.dll copy. The compiler
+          # and linker paths come from vcpkg.props, not the environment.
+          $vcpkgRoot = "C:\vcpkg\installed\${{ matrix.arch }}-windows"
+          echo "$vcpkgRoot\bin" >> $env:GITHUB_PATH
+
+          Write-Output "Installed mbedtls and nghttp2 for ${{ matrix.arch }}"
 
       - name: Cache OpenCV DLLs (Windows x64)
         if: matrix.platform == 'windows-x64'

--- a/core/build/vcpkg.props
+++ b/core/build/vcpkg.props
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Resolves mbedTLS and nghttp2 from vcpkg.
+
+  These used to come from binaries committed to the tree under
+  core/lib/openssl/win/<arch>, which every Windows project listed ahead of
+  $(LibraryPath). CI installed them through vcpkg and exported INCLUDE/LIB, but
+  MSBuild's $(IncludePath) does NOT inherit the environment's INCLUDE; only
+  vm.vcxproj ever named $(INCLUDE) explicitly. So that vcpkg install changed
+  nothing, and the committed blobs were what actually got linked, on both x64
+  and ARM64. The versions had already drifted: the committed headers say
+  mbedTLS 3.6.5, while BUILD_MBEDTLS_ARM64.md and deploy_windows.cmd said the
+  libraries were built from 3.6.3.
+
+  Hence a real MSBuild property rather than an environment variable: it applies
+  whether the build is driven by MSBuild, devenv or the IDE, and it cannot be
+  silently ignored.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VcpkgTriplet Condition="'$(VcpkgTriplet)' == '' and '$(Platform)' == 'ARM64'">arm64-windows</VcpkgTriplet>
+    <VcpkgTriplet Condition="'$(VcpkgTriplet)' == ''">x64-windows</VcpkgTriplet>
+
+    <!--
+      Pick the root that actually HAS the package, not merely the first one
+      named. Visual Studio ships its own vcpkg and points VCPKG_ROOT at it, and
+      that copy usually has nothing installed while the developer's real tree is
+      elsewhere. Preferring VCPKG_ROOT blindly fails on any machine where both
+      exist, which is the common case; it failed on the box this was written on.
+    -->
+    <VcpkgProbe>installed\$(VcpkgTriplet)\include\mbedtls\build_info.h</VcpkgProbe>
+    <VcpkgRootDir Condition="'$(VcpkgRootDir)' == '' and '$(VCPKG_ROOT)' != '' and Exists('$(VCPKG_ROOT)\$(VcpkgProbe)')">$(VCPKG_ROOT)</VcpkgRootDir>
+    <VcpkgRootDir Condition="'$(VcpkgRootDir)' == '' and Exists('C:\vcpkg\$(VcpkgProbe)')">C:\vcpkg</VcpkgRootDir>
+    <VcpkgRootDir Condition="'$(VcpkgRootDir)' == '' and '$(VCPKG_ROOT)' != ''">$(VCPKG_ROOT)</VcpkgRootDir>
+    <VcpkgRootDir Condition="'$(VcpkgRootDir)' == ''">C:\vcpkg</VcpkgRootDir>
+
+    <VcpkgInstalledDir>$(VcpkgRootDir)\installed\$(VcpkgTriplet)</VcpkgInstalledDir>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <IncludePath>$(VcpkgInstalledDir)\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(VcpkgInstalledDir)\lib;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+
+  <!--
+    A missing vcpkg tree otherwise surfaces as "cannot open include file
+    'mbedtls/md.h'" hundreds of lines into a build log, which is how long it
+    took to work out that the environment variables were being ignored.
+  -->
+  <Target Name="VerifyVcpkgDependencies" BeforeTargets="ClCompile">
+    <Error Condition="!Exists('$(VcpkgInstalledDir)\include\mbedtls\build_info.h')"
+           Text="mbedTLS not found at $(VcpkgInstalledDir). Install it with:  vcpkg install mbedtls:$(VcpkgTriplet) nghttp2:$(VcpkgTriplet)   (set VCPKG_ROOT if your vcpkg is not at C:\vcpkg)" />
+  </Target>
+</Project>

--- a/core/debugger/vs/debugger.vcxproj
+++ b/core/debugger/vs/debugger.vcxproj
@@ -59,40 +59,44 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\build\vcpkg.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>..\..\lib\openssl\win\include;..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>..\..\lib\openssl\win\x64;..\..\lib\zlib\win\x64;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(IncludePath);..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
+    <LibraryPath>..\..\lib\zlib\win\x64;$(LibraryPath)</LibraryPath>
     <TargetName>obd</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>..\..\lib\openssl\win\include;..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>..\..\lib\openssl\win\arm64;..\..\lib\zlib\win\arm64;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(IncludePath);..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
+    <LibraryPath>..\..\lib\zlib\win\arm64;$(LibraryPath)</LibraryPath>
     <TargetName>obd</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>..\$(Configuration)\win64\</OutDir>
     <TargetName>obd</TargetName>
-    <IncludePath>..\..\lib\openssl\win\include;..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>..\..\lib\openssl\win\x64;..\..\lib\zlib\win\x64;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(IncludePath);..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
+    <LibraryPath>..\..\lib\zlib\win\x64;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <TargetName>obd</TargetName>
-    <IncludePath>..\..\lib\openssl\win\include;..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>..\..\lib\openssl\win\arm64;..\..\lib\zlib\win\arm64;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(IncludePath);..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
+    <LibraryPath>..\..\lib\zlib\win\arm64;$(LibraryPath)</LibraryPath>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">

--- a/core/lib/crypto/vs/crypto.vcxproj
+++ b/core/lib/crypto/vs/crypto.vcxproj
@@ -64,21 +64,25 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\build\vcpkg.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>..\win\include;..\..\zlib\win;$(IncludePath);$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>..\..\zlib\win\x64;..\win\x64;..\..\openssl\win\x64;$(LibraryPath)</LibraryPath>
+    <IncludePath>..\..\zlib\win;$(IncludePath);$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
+    <LibraryPath>..\..\zlib\win\x64;$(LibraryPath)</LibraryPath>
     <TargetName>libobjk_crypto</TargetName>
     <IntDir>$(Configuration)\</IntDir>
     <OutDir>..\$(Configuration)\win64\</OutDir>
@@ -87,24 +91,24 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <TargetExt>.dll</TargetExt>
     <LinkIncremental>true</LinkIncremental>
-    <IncludePath>..\win\include;..\..\zlib\win;$(IncludePath);$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>..\..\zlib\win\arm64;..\win\arm64;..\..\openssl\win\arm64;$(LibraryPath)</LibraryPath>
+    <IncludePath>..\..\zlib\win;$(IncludePath);$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
+    <LibraryPath>..\..\zlib\win\arm64;$(LibraryPath)</LibraryPath>
     <TargetName>libobjk_crypto</TargetName>
     <OutDir>..\ARM64\$(Configuration)\</OutDir>
     <IntDir>ARM64\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>..\win\include;..\..\zlib\win;$(IncludePath);$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+    <IncludePath>..\..\zlib\win;$(IncludePath);$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
     <TargetName>libobjk_crypto</TargetName>
     <OutDir>..\$(Configuration)\win64\</OutDir>
     <IntDir>$(Configuration)\</IntDir>
-    <LibraryPath>..\..\zlib\win\x64;..\win\x64;..\..\openssl\win\x64;$(LibraryPath)</LibraryPath>
+    <LibraryPath>..\..\zlib\win\x64;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <LibraryPath>..\..\zlib\win\arm64;..\win\arm64;..\..\openssl\win\arm64;$(LibraryPath)</LibraryPath>
+    <LibraryPath>..\..\zlib\win\arm64;$(LibraryPath)</LibraryPath>
     <LinkIncremental>false</LinkIncremental>
-    <IncludePath>..\win\include;..\..\zlib\win;$(IncludePath);$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+    <IncludePath>..\..\zlib\win;$(IncludePath);$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
     <TargetName>libobjk_crypto</TargetName>
     <OutDir>..\ARM64\$(Configuration)\</OutDir>
     <IntDir>ARM64\$(Configuration)\</IntDir>

--- a/core/module/example/vs/example.vcxproj
+++ b/core/module/example/vs/example.vcxproj
@@ -59,24 +59,28 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\..\build\vcpkg.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LibraryPath>..\..\..\lib\openssl\win\x64;..\..\..\lib\zlib\win\x64;..\x64\Debug;$(LibraryPath)</LibraryPath>
-    <IncludePath>..\..\..\lib\zlib\win;..\..\..\lib\openssl\win\include;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+    <LibraryPath>..\..\..\lib\zlib\win\x64;..\x64\Debug;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(IncludePath);..\..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>..\..\..\lib\zlib\win;..\..\..\lib\openssl\win\include;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
-    <LibraryPath>..\..\..\lib\openssl\win\x64;..\..\..\lib\zlib\win\x64;..\x64\Release;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
+    <IncludePath>$(IncludePath);..\..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath)</IncludePath>
+    <LibraryPath>$(LibraryPath);..\..\..\lib\zlib\win\x64;..\x64\Release;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/core/module/vs/module.vcxproj
+++ b/core/module/vs/module.vcxproj
@@ -59,35 +59,39 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\build\vcpkg.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>..\..\lib\zlib\win;..\..\lib\openssl\win\include;$(IncludePath)</IncludePath>
-    <LibraryPath>module\x64\Debug\objeck.lib;..\..\lib\zlib\win\x64\Release;..\..\lib\openssl\win\x64;$(LibraryPath)</LibraryPath>
+    <IncludePath>..\..\lib\zlib\win;$(IncludePath)</IncludePath>
+    <LibraryPath>module\x64\Debug\objeck.lib;..\..\lib\zlib\win\x64\Release;$(LibraryPath)</LibraryPath>
     <TargetName>objeck</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <IncludePath>..\..\lib\zlib\win;..\..\lib\openssl\win\include;$(IncludePath)</IncludePath>
-    <LibraryPath>module\arm64\Debug;..\..\lib\zlib\win\arm64\Release;..\..\lib\openssl\win\arm64;$(LibraryPath)</LibraryPath>
+    <IncludePath>..\..\lib\zlib\win;$(IncludePath)</IncludePath>
+    <LibraryPath>module\arm64\Debug;..\..\lib\zlib\win\arm64\Release;$(LibraryPath)</LibraryPath>
     <TargetName>objeck</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>..\..\lib\zlib\win;..\..\lib\openssl\win\include;$(IncludePath)</IncludePath>
-    <LibraryPath>..\..\release\x64\Release;..\..\lib\zlib\win\x64\Release;..\..\lib\openssl\win\x64;$(LibraryPath)</LibraryPath>
+    <IncludePath>..\..\lib\zlib\win;$(IncludePath)</IncludePath>
+    <LibraryPath>..\..\release\x64\Release;..\..\lib\zlib\win\x64\Release;$(LibraryPath)</LibraryPath>
     <TargetName>objeck</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <IncludePath>..\..\lib\zlib\win;..\..\lib\openssl\win\include;$(IncludePath)</IncludePath>
-    <LibraryPath>module\arm64\Release;..\..\lib\zlib\win\arm64\Release;..\..\lib\openssl\win\arm64;$(LibraryPath)</LibraryPath>
+    <IncludePath>..\..\lib\zlib\win;$(IncludePath)</IncludePath>
+    <LibraryPath>module\arm64\Release;..\..\lib\zlib\win\arm64\Release;$(LibraryPath)</LibraryPath>
     <TargetName>objeck</TargetName>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">

--- a/core/release/deploy_windows.cmd
+++ b/core/release/deploy_windows.cmd
@@ -10,38 +10,40 @@ IF "%VCINSTALLDIR%"=="" (
 	goto end
 )
 
-REM Check for mbedTLS ARM64 libraries
-if [%1] == [arm64] (
-	if not exist "..\lib\openssl\win\arm64\mbedtls.lib" (
-		echo.
-		echo ============================================================
-		echo  ERROR: mbedTLS ARM64 libraries not found
-		echo ============================================================
-		echo.
-		echo The ARM64 build requires mbedTLS 3.6.3 libraries.
-		echo.
-		echo Building mbedTLS ARM64 libraries automatically...
-		echo This is a one-time setup that will take 5-10 minutes.
-		echo.
+REM mbedTLS and nghttp2 come from vcpkg, for both x64 and ARM64.
+REM
+REM They used to be binaries committed under lib\openssl\win\<arch>, and this
+REM script hand-built mbedTLS 3.6.3 for ARM64 when they were missing. The
+REM project files now resolve both through core\build\vcpkg.props, so the
+REM committed copies are gone and the hand-build step with them.
+set VCPKG_TRIPLET=x64-windows
+if [%1] == [arm64] set VCPKG_TRIPLET=arm64-windows
 
-		pushd ..\lib\crypto
-		call build_mbedtls_arm64.cmd
-		popd
-
-		if not exist "..\lib\openssl\win\arm64\mbedtls.lib" (
-			echo.
-			echo ERROR: Failed to build mbedTLS ARM64 libraries.
-			echo Please see core\lib\crypto\BUILD_MBEDTLS_ARM64.md for manual instructions.
-			echo.
-			goto end
-		)
-
-		echo.
-		echo mbedTLS ARM64 libraries installed successfully!
-		echo Continuing with build...
-		echo.
-	)
+set VCPKG_DIR=
+if not "%VCPKG_ROOT%" == "" (
+	if exist "%VCPKG_ROOT%\installed\%VCPKG_TRIPLET%\include\mbedtls\build_info.h" set VCPKG_DIR=%VCPKG_ROOT%
 )
+if "%VCPKG_DIR%" == "" (
+	if exist "C:\vcpkg\installed\%VCPKG_TRIPLET%\include\mbedtls\build_info.h" set VCPKG_DIR=C:\vcpkg
+)
+
+if "%VCPKG_DIR%" == "" (
+	echo.
+	echo ============================================================
+	echo  ERROR: mbedTLS not found in vcpkg for %VCPKG_TRIPLET%
+	echo ============================================================
+	echo.
+	echo Install it with:
+	echo     vcpkg install mbedtls:%VCPKG_TRIPLET% nghttp2:%VCPKG_TRIPLET%
+	echo.
+	echo Set VCPKG_ROOT if your vcpkg is not at C:\vcpkg. Note that Visual
+	echo Studio ships its own vcpkg and points VCPKG_ROOT at it; that copy
+	echo usually has nothing installed.
+	echo.
+	goto end
+)
+
+echo Using vcpkg at %VCPKG_DIR% ^(%VCPKG_TRIPLET%^)
 
 set ZIP_BIN="\Program Files\7-Zip"
 
@@ -163,13 +165,11 @@ if errorlevel 1 (
 	exit /b 1
 )
 
-REM nghttp2 runtime DLL (required by obr for HTTP/2 support)
-if [%1] == [x64] (
-	copy ..\lib\openssl\win\x64\nghttp2.dll %TARGET%\bin
-)
-if [%1] == [arm64] (
-	copy ..\lib\openssl\win\arm64\nghttp2.dll %TARGET%\bin
-)
+REM nghttp2 runtime DLL (required by obr for HTTP/2 support).
+REM Taken from vcpkg so the shipped DLL matches the import library linked
+REM against. The committed copy it replaces was byte-identical to vcpkg's,
+REM having come from there in the first place.
+copy "%VCPKG_DIR%\installed\%VCPKG_TRIPLET%\bin\nghttp2.dll" %TARGET%\bin
 if errorlevel 1 (
 	echo.
 	echo ============================================================

--- a/core/repl/vs/repl.vcxproj
+++ b/core/repl/vs/repl.vcxproj
@@ -59,36 +59,40 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\build\vcpkg.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>..\..\lib\zlib\win;..\..\lib\openssl\win\include;$(IncludePath)</IncludePath>
-    <LibraryPath>..\..\repl\x64\Debug\;..\..\lib\zlib\win\x64;..\..\lib\openssl\win\x64\;..\..\release\x64\Debug;$(LibraryPath)</LibraryPath>
+    <IncludePath>..\..\lib\zlib\win;$(IncludePath)</IncludePath>
+    <LibraryPath>..\..\repl\x64\Debug\;..\..\lib\zlib\win\x64;..\..\release\x64\Debug;$(LibraryPath)</LibraryPath>
     <TargetName>obi</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <IncludePath>..\..\lib\zlib\win\;..\..\lib\openssl\win\include\;$(LibraryPath)</IncludePath>
-    <LibraryPath>..\..\release\ARM64\Release;..\..\repl\arm64\Debug\;..\..\lib\zlib\win\arm64;..\..\lib\openssl\win\arm64\;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(IncludePath);..\..\lib\zlib\win\;$(LibraryPath)</IncludePath>
+    <LibraryPath>..\..\release\ARM64\Release;..\..\repl\arm64\Debug\;..\..\lib\zlib\win\arm64;$(LibraryPath)</LibraryPath>
     <TargetName>obi</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>..\..\lib\zlib\win;..\..\lib\openssl\win\include;$(IncludePath)</IncludePath>
-    <LibraryPath>..\..\repl\x64\Release\;..\..\lib\zlib\win\x64;..\..\lib\openssl\win\x64\;..\..\release\x64\Release;$(LibraryPath)</LibraryPath>
+    <IncludePath>..\..\lib\zlib\win;$(IncludePath)</IncludePath>
+    <LibraryPath>..\..\repl\x64\Release\;..\..\lib\zlib\win\x64;..\..\release\x64\Release;$(LibraryPath)</LibraryPath>
     <TargetName>obi</TargetName>
     <OutDir>..\$(Configuration)\win64\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <IncludePath>..\..\lib\zlib\win\;..\..\lib\openssl\win\include\;$(LibraryPath)</IncludePath>
-    <LibraryPath>..\..\release\ARM64\Release;..\..\repl\arm64\Release\;..\..\lib\zlib\win\arm64;..\..\lib\openssl\win\arm64\;$(LibraryPath)</LibraryPath>
+    <IncludePath>$(IncludePath);..\..\lib\zlib\win\;$(LibraryPath)</IncludePath>
+    <LibraryPath>..\..\release\ARM64\Release;..\..\repl\arm64\Release\;..\..\lib\zlib\win\arm64;$(LibraryPath)</LibraryPath>
     <TargetName>obi</TargetName>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">

--- a/core/vm/vs/vm.vcxproj
+++ b/core/vm/vs/vm.vcxproj
@@ -58,43 +58,47 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\build\vcpkg.props" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\..\build\vcpkg.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>..\..\lib\openssl\win\include;..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(INCLUDE);</IncludePath>
+    <IncludePath>$(IncludePath);..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(INCLUDE)</IncludePath>
     <TargetName>obr</TargetName>
     <OutDir>..\$(Configuration)\win64\</OutDir>
-    <LibraryPath>..\..\lib\openssl\win\x64;..\..\lib\zlib\win\x64;$(LibraryPath)</LibraryPath>
+    <LibraryPath>..\..\lib\zlib\win\x64;$(LibraryPath)</LibraryPath>
     <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
-    <LibraryPath>..\..\lib\openssl\win\arm64;..\..\lib\zlib\win\arm64;$(LibraryPath)</LibraryPath>
+    <LibraryPath>..\..\lib\zlib\win\arm64;$(LibraryPath)</LibraryPath>
     <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>false</RunCodeAnalysis>
-    <IncludePath>..\..\lib\openssl\win\include;..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(INCLUDE);</IncludePath>
+    <IncludePath>$(IncludePath);..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(INCLUDE)</IncludePath>
     <TargetName>obr</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>..\..\lib\openssl\win\include;..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(INCLUDE);</IncludePath>
+    <IncludePath>$(IncludePath);..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(INCLUDE)</IncludePath>
     <TargetName>obr</TargetName>
-    <LibraryPath>..\..\lib\openssl\win\x64;..\..\lib\zlib\win\x64;$(LibraryPath)</LibraryPath>
+    <LibraryPath>..\..\lib\zlib\win\x64;$(LibraryPath)</LibraryPath>
     <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
-    <IncludePath>..\..\lib\openssl\win\include;..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(INCLUDE);</IncludePath>
+    <IncludePath>$(IncludePath);..\..\lib\zlib\win;$(VC_IncludePath);$(WindowsSDK_IncludePath);$(INCLUDE)</IncludePath>
     <TargetName>obr</TargetName>
-    <LibraryPath>..\..\lib\openssl\win\arm64;..\..\lib\zlib\win\arm64;$(LibraryPath)</LibraryPath>
+    <LibraryPath>..\..\lib\zlib\win\arm64;$(LibraryPath)</LibraryPath>
     <CodeAnalysisRuleSet>NativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>false</RunCodeAnalysis>
   </PropertyGroup>


### PR DESCRIPTION
## The vcpkg install was doing nothing

CI installs `mbedtls` and `nghttp2` through vcpkg and exports `INCLUDE`/`LIB`. **MSBuild's `$(IncludePath)` does not inherit the environment's `INCLUDE`**, and only `vm.vcxproj` ever named `$(INCLUDE)` explicitly. So every Windows project instead linked binaries committed to the tree under `core/lib/openssl/win/<arch>`, which each project listed *ahead* of `$(LibraryPath)`.

Proof — vcpkg's include in `INCLUDE`, in-tree path removed:

```
crypto.cpp(34,10): error C1083: Cannot open include file: 'mbedtls/md.h'
```

And the versions had already drifted:

| source | version |
|---|---|
| committed headers (`build_info.h`) | mbedTLS **3.6.5** |
| `BUILD_MBEDTLS_ARM64.md`, `deploy_windows.cmd` | mbedTLS **3.6.3** |
| vcpkg (unpinned) | whatever is current |

Windows also carried **two** separate copies of the mbedTLS headers — `crypto/win/include` and `openssl/win/include` — used by different projects. It worked because 3.6.3 and 3.6.5 happen to be compatible, not because anything kept them in step.

## The fix

`core/build/vcpkg.props` resolves both packages as real MSBuild properties, so they apply under MSBuild, `devenv` and the IDE alike and cannot be silently ignored. Six projects import it: `vm`, `debugger`, `repl`, `module`, `module/example`, `crypto`.

Three details worth keeping:

- **It picks the vcpkg root that actually has the package.** Visual Studio ships its own vcpkg and points `VCPKG_ROOT` at it; that copy usually has nothing installed. Preferring `VCPKG_ROOT` blindly fails on any machine where both exist — it failed on the box this was written on.
- **A missing tree fails fast** with the exact install command, instead of surfacing as "cannot open include file" hundreds of lines into a build.
- **Paths are extended, never overwritten.** `vm.vcxproj`'s `IncludePath` replaced the property wholesale, so a property sheet could not contribute to it at all. That was the second bug found while fixing the first.

## Build and release scripts

`deploy_windows.cmd` no longer hand-builds mbedTLS 3.6.3 for ARM64 — it checks vcpkg and prints how to install it. It also copies `nghttp2.dll` **from vcpkg**, so the shipped DLL matches the import library linked against. The committed copy it replaces is **byte-identical** to vcpkg's, having come from there originally.

`release-build.yml` had **no vcpkg install at all** — a comment claimed the deps were *"self-contained in repo (no vcpkg required)"*. That held only while the blobs were what got linked. It now installs them like `ci-build.yml` does. Releases are built by CI, which is precisely why this one mattered.

## Verification

Built on x64 in a **clean environment with `LIB` and `INCLUDE` unset**, so only the props supply the paths:

| target | result |
|---|---|
| `crypto.vcxproj` | `libobjk_crypto.dll` |
| `vm.vcxproj` | `obr.exe` |
| full `objeck.sln` | `obr.exe`, `obd.exe`, `obi.exe` — 0 errors |

vcpkg's mbedTLS for these triplets is **static**, so this adds no new runtime DLL dependency. ARM64 is left to CI, which installs the `arm64-windows` triplet.

## Deliberately not in this PR

The committed blobs stay for now. None of these six projects reads them any more, but `diag`, `matrix` and `sdl` still name those directories, and deleting 9.5 MB of binaries belongs in its own change once CI has confirmed the vcpkg path on both arches. `diag.vcxproj` also has a typo — `openssl\win\armd64` — that has been silently falling through to `$(LibraryPath)`; harmless today because diag links no mbedTLS, and worth fixing with that cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
