### PR TITLE
fix(jit): ARM64 truncated every 64-bit immediate to 32 bits on Windows

### DIFF
--- a/core/vm/arch/jit/arm64/jit_arm_a64.cpp
+++ b/core/vm/arch/jit/arm64/jit_arm_a64.cpp
@@ -2665,7 +2665,7 @@ void JitArm64::add_reg_reg(Register src, Register dest) {
   AddMachineCode(op_code);
 }
 
-void JitArm64::add_imm_reg(long imm, Register reg) {
+void JitArm64::add_imm_reg(int64_t imm, Register reg) {
   if(imm < 0) {
     sub_imm_reg(abs(imm), reg);
   }
@@ -2707,7 +2707,7 @@ void JitArm64::inc_mem(long offset, Register dest) {
   add_imm_mem(1, offset, dest);
 }
 
-void JitArm64::add_imm_mem(long imm, long offset, Register dest) {
+void JitArm64::add_imm_mem(int64_t imm, long offset, Register dest) {
   RegisterHolder* mem_holder = GetRegister();
   move_mem_reg(offset, dest, mem_holder->GetRegister());
   add_imm_reg(imm, mem_holder->GetRegister());
@@ -2741,7 +2741,7 @@ void JitArm64::sub_mem_reg(long offset, Register src, Register dest) {
   ReleaseRegister(mem_holder);
 }
 
-void JitArm64::sub_imm_reg(long imm, Register reg) {
+void JitArm64::sub_imm_reg(int64_t imm, Register reg) {
   if(imm < 0) {
     add_imm_reg(abs(imm), reg);
   }
@@ -2771,7 +2771,7 @@ void JitArm64::sub_imm_reg(long imm, Register reg) {
   }
 }
 
-void JitArm64::sub_imm_mem(long imm, long offset, Register dest) {
+void JitArm64::sub_imm_mem(int64_t imm, long offset, Register dest) {
   RegisterHolder* mem_holder = GetRegister();
   move_mem_reg(offset, dest, mem_holder->GetRegister());
   sub_imm_reg(imm, mem_holder->GetRegister());
@@ -2787,7 +2787,7 @@ void JitArm64::dec_reg(Register dest) {
   sub_imm_reg(1, dest);
 }
 
-void JitArm64::mul_imm_reg(long imm, Register reg) {
+void JitArm64::mul_imm_reg(int64_t imm, Register reg) {
   // Optimization: Replace multiply by power-of-2 with left shift
   // Example: x * 8 becomes x << 3 (faster, no register allocation needed)
   if(imm > 0 && (imm & (imm - 1)) == 0) {
@@ -2945,7 +2945,7 @@ void JitArm64::mul_reg_reg(Register src, Register dest) {
   AddMachineCode(op_code);
 }
 
-void JitArm64::div_imm_reg(long imm, Register reg, bool is_mod) {
+void JitArm64::div_imm_reg(int64_t imm, Register reg, bool is_mod) {
   RegisterHolder* src_holder = GetRegister();
   move_imm_reg(imm, src_holder->GetRegister());
   div_reg_reg(src_holder->GetRegister(), reg, is_mod);
@@ -2993,7 +2993,7 @@ void JitArm64::div_reg_reg(Register src, Register dest, bool is_mod) {
   }
 }
 
-void JitArm64::shl_imm_reg(long value, Register dest) {
+void JitArm64::shl_imm_reg(int64_t value, Register dest) {
 #ifdef _DEBUG_JIT_JIT
   std::wcout << L"  " << (++instr_count) << L": [lsl " << GetRegisterName(dest) << L", " << GetRegisterName(dest) << L", #" << value << L"]" << std::endl;
 #endif
@@ -3050,7 +3050,7 @@ void JitArm64::shl_reg_reg(Register src, Register dest)
   AddMachineCode(op_code);
 }
 
-void JitArm64::shr_imm_reg(long value, Register dest) {
+void JitArm64::shr_imm_reg(int64_t value, Register dest) {
 #ifdef _DEBUG_JIT_JIT
   std::wcout << L"  " << (++instr_count) << L": [asr $" << value << L", %" << GetRegisterName(dest) << L"]" << std::endl;
 #endif
@@ -3132,7 +3132,7 @@ void JitArm64::and_reg_reg(Register src, Register dest) {
   AddMachineCode(op_code);
 }
 
-void JitArm64::and_imm_reg(long imm, Register reg) {
+void JitArm64::and_imm_reg(int64_t imm, Register reg) {
   RegisterHolder* src_holder = GetRegister();
   move_imm_reg(imm, src_holder->GetRegister());
   and_reg_reg(src_holder->GetRegister(), reg);
@@ -3187,7 +3187,7 @@ void JitArm64::or_reg_reg(Register src, Register dest) {
   AddMachineCode(op_code);
 }
 
-void JitArm64::or_imm_reg(long imm, Register reg) {
+void JitArm64::or_imm_reg(int64_t imm, Register reg) {
   RegisterHolder* src_holder = GetRegister();
   move_imm_reg(imm, src_holder->GetRegister());
   or_reg_reg(src_holder->GetRegister(), reg);
@@ -3221,7 +3221,7 @@ void JitArm64::xor_reg_reg(Register src, Register dest) {
   AddMachineCode(op_code);
 }
 
-void JitArm64::xor_imm_reg(long imm, Register reg) {
+void JitArm64::xor_imm_reg(int64_t imm, Register reg) {
   RegisterHolder* src_holder = GetRegister();
   move_imm_reg(imm, src_holder->GetRegister());
   xor_reg_reg(src_holder->GetRegister(), reg);
@@ -3235,7 +3235,7 @@ void JitArm64::xor_mem_reg(long offset, Register src, Register dest) {
   ReleaseRegister(src_holder);
 }
 
-void JitArm64::cmp_imm_reg(long imm, Register reg) {
+void JitArm64::cmp_imm_reg(int64_t imm, Register reg) {
   // Track if this is a zero comparison for CBZ/CBNZ optimization
   last_cmp_was_zero = (imm == 0);
   last_cmp_reg = reg;
@@ -3572,7 +3572,7 @@ void JitArm64::move_imm_mem8(int8_t imm, long offset, Register dest) {
   ReleaseRegister(imm_holder);
 }
 
-void JitArm64::move_imm_mem(long imm, long offset, Register dest) {
+void JitArm64::move_imm_mem(int64_t imm, long offset, Register dest) {
   RegisterHolder* imm_holder = GetRegister();
   move_imm_reg(imm, imm_holder->GetRegister());
   move_reg_mem(imm_holder->GetRegister(), offset, dest);
@@ -3668,7 +3668,7 @@ void JitArm64::cmp_imm_freg(size_t addr, Register reg) {
   ReleaseRegister(imm_holder);
 }
 
-void JitArm64::math_imm_reg(long imm, Register reg, InstructionType type) {
+void JitArm64::math_imm_reg(int64_t imm, Register reg, InstructionType type) {
   switch(type) {
   case AND_INT:
     and_imm_reg(imm, reg);

--- a/core/vm/arch/jit/arm64/jit_arm_a64.h
+++ b/core/vm/arch/jit/arm64/jit_arm_a64.h
@@ -690,7 +690,7 @@ namespace Runtime {
     // represent. Centralizes the sign handling that the old per-encoder abs() broke.
     void emit_ldst_imm(uint32_t scaled_op, long scale, long offset, Register base, Register data);
     void move_imm_memf(RegInstr* instr, long offset, Register dest);
-    void move_imm_mem(long imm, long offset, Register dest);
+    void move_imm_mem(int64_t imm, long offset, Register dest);
 #ifdef _WIN64
     void move_imm_reg(int64_t imm, Register reg);
 #else
@@ -703,47 +703,47 @@ namespace Runtime {
     void move_freg_freg(Register src, Register dest);
 
     // math instructions
-    void math_imm_reg(long imm, Register reg, InstructionType type);
+    void math_imm_reg(int64_t imm, Register reg, InstructionType type);
     void math_reg_reg(Register src, Register dest, InstructionType type);
     void math_mem_reg(long offset, Register reg, InstructionType type);
     void math_mem_freg(long offset, RegisterHolder *&reg, InstructionType type);
     void math_freg_freg(Register src, RegisterHolder *&dest, InstructionType type);
     
     // logical
-    void and_imm_reg(long imm, Register reg);
+    void and_imm_reg(int64_t imm, Register reg);
     void and_reg_reg(Register src, Register dest);
     void and_mem_reg(long offset, Register src, Register dest);
-    void or_imm_reg(long imm, Register reg);
+    void or_imm_reg(int64_t imm, Register reg);
     void or_reg_reg(Register src, Register dest);
     void or_mem_reg(long offset, Register src, Register dest);
-    void xor_imm_reg(long imm, Register reg);
+    void xor_imm_reg(int64_t imm, Register reg);
     void xor_reg_reg(Register src, Register dest);
     void xor_mem_reg(long offset, Register src, Register dest);
     void not_reg(Register reg);
 
     // add instructions
-    void add_imm_mem(long imm, long offset, Register dest);
-    void add_imm_reg(long imm, Register reg);
+    void add_imm_mem(int64_t imm, long offset, Register dest);
+    void add_imm_reg(int64_t imm, Register reg);
     void add_freg_freg(Register src, Register dest);
     void add_mem_reg(long offset, Register src, Register dest);
     void add_reg_reg(Register src, Register dest);
 
     // sub instructions
     void sub_freg_freg(Register src, Register dest);
-    void sub_imm_reg(long imm, Register reg);
-    void sub_imm_mem(long imm, long offset, Register dest);
+    void sub_imm_reg(int64_t imm, Register reg);
+    void sub_imm_mem(int64_t imm, long offset, Register dest);
     void sub_reg_reg(Register src, Register dest);
     void sub_mem_reg(long offset, Register src, Register dest);
 
     // mul instructions
     void mul_freg_freg(Register src, Register dest);
-    void mul_imm_reg(long imm, Register reg);
+    void mul_imm_reg(int64_t imm, Register reg);
     void mul_reg_reg(Register src, Register dest);
     void mul_mem_reg(long offset, Register src, Register dest);
 
     // div instructions
     void div_freg_freg(Register src, Register dest);
-    void div_imm_reg(long imm, Register reg, bool is_mod = false);
+    void div_imm_reg(int64_t imm, Register reg, bool is_mod = false);
     void div_reg_reg(Register src, Register dest, bool is_mod = false);
     void div_mem_reg(long offset, Register src, Register dest, bool is_mod = false);
     
@@ -756,7 +756,7 @@ namespace Runtime {
     // compare instructions
     void cmp_reg_reg(Register src, Register dest);
     void cmp_mem_reg(long offset, Register src, Register dest);
-    void cmp_imm_reg(long imm, Register reg);
+    void cmp_imm_reg(int64_t imm, Register reg);
 
     // CBZ/CBNZ: Compare and Branch if Zero/Non-Zero (optimized for zero comparisons)
     void cbz_reg(Register reg);   // Branch if reg == 0
@@ -776,11 +776,11 @@ namespace Runtime {
     // shift instructions
     void shl_reg_reg(Register src, Register dest);
     void shl_mem_reg(long offset, Register src, Register dest);
-    void shl_imm_reg(long value, Register dest);
+    void shl_imm_reg(int64_t value, Register dest);
 
     void shr_reg_reg(Register src, Register dest);
     void shr_mem_reg(long offset, Register src, Register dest);
-    void shr_imm_reg(long value, Register dest);
+    void shr_imm_reg(int64_t value, Register dest);
 
     // push/pop instructions
     void push_imm(int32_t value);


### PR DESCRIPTION
Root cause of the `unsigned_ops` failures found by #661's newly-enabled Windows ARM64 test run.

## The symptom

`unsigned_ops` fails **14 of 44** assertions on `windows-arm64`, and passes everywhere else:

| leg | result |
|---|---|
| linux-arm64 | PASS |
| macos-arm64 | PASS |
| windows-x64 | PASS |
| **windows-arm64** | **14 failures** |

Everything unsigned is wrong — `>>>`, `DivideUnsigned`, `ModUnsigned`, `ToUnsignedString`, unsigned literals:

```
FAIL: -8 >>> 3                   FAIL: DivideUnsigned(-1, 3)
FAIL: -1 >>> 63                  FAIL: ModUnsigned(-1, 10)
FAIL: variable shift count       FAIL: ToUnsignedString(-1)
FAIL: '>>>' inside an expression FAIL: unsigned literal round-trip
                                 30 passed, 14 failed
```

That the failures pass on the *same ARM64 JIT* under Linux and macOS rules out the backend's logic, and passing on windows-x64 rules out MSVC generally. What is left is the intersection: **MSVC + ARM64**.

## Root cause

Every one of those functions funnels through a single `lang.obs` primitive, and its shape is the whole story:

```objeck
function : native : ShiftRightUnsigned(v : Int, count : Int) ~ Int {
  ...
  return ((v >> 1) and 0x7FFFFFFFFFFFFFFF) >> (count - 1);
}
```

`native` forces JIT compilation, and that mask needs all 64 bits.

The AMD64 backend types every immediate emitter `int64_t`. The ARM64 backend typed **all fifteen of the same functions `long`**:

| emitter | AMD64 | ARM64 (before) |
|---|---|---|
| `and_imm_reg` | `int64_t` | `long` |
| `cmp_imm_reg`, `add_imm_reg`, `sub_imm_reg`, … | `int64_t` | `long` |

**Windows is LLP64** — `long` is 32 bits. Linux and macOS are LP64, where it is 64. So `0x7FFFFFFFFFFFFFFF` survived everywhere except the one platform nobody had ever executed, where it truncated to `0xFFFFFFFF` and took every unsigned operation down with it.

The clincher: `move_imm_reg` already carries an `#ifdef _WIN64` typing it `int64_t` on Windows, **on both backends**. So this exact hazard was known and handled in one place. The other fourteen were widened on AMD64 and left behind on ARM64 — which stayed invisible because no Windows ARM64 build had ever run a line of JIT-compiled code.

## The fix

Widen the same fourteen on ARM64 to match AMD64: `move_imm_mem`, `math_imm_reg`, `and_imm_reg`, `or_imm_reg`, `xor_imm_reg`, `add_imm_mem`, `add_imm_reg`, `sub_imm_reg`, `sub_imm_mem`, `mul_imm_reg`, `div_imm_reg`, `cmp_imm_reg`, `shl_imm_reg`, `shr_imm_reg`.

**On Linux and macOS ARM64 `int64_t` IS `long`**, so those platforms see no change at all — the diff is a no-op for them by construction. Only Windows ARM64 stops truncating.

## Testing

No new test. `programs/regression/unsigned_ops.obs` already covers this precisely; it has simply never run on the affected platform. That is what **#661** changes, and the two together are what turn this from invisible into gated.

Until #661 lands, the check is manual: build ARM64 and run `unsigned_ops`, which should go from 30/44 to 44/44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
