### PR TITLE
fix(windows): vcpkg root probe missed ~/vcpkg, and vcpkg zlib shadowed the vendored one

### DIFF
--- a/core/build/vcpkg.props
+++ b/core/build/vcpkg.props
@@ -27,18 +27,51 @@
       that copy usually has nothing installed while the developer's real tree is
       elsewhere. Preferring VCPKG_ROOT blindly fails on any machine where both
       exist, which is the common case; it failed on the box this was written on.
+
+      %USERPROFILE%\vcpkg is probed too. It is what `git clone` of vcpkg gives
+      you by default, it is where this repo's own ARM64 box keeps it, and a
+      developer who cloned there has no reason to guess that an unset
+      VCPKG_ROOT plus a hard-coded C:\vcpkg is what stands between them and
+      "mbedTLS not found". CI still installs to C:\vcpkg and matches the first
+      two probes, so its behaviour is unchanged.
     -->
     <VcpkgProbe>installed\$(VcpkgTriplet)\include\mbedtls\build_info.h</VcpkgProbe>
     <VcpkgRootDir Condition="'$(VcpkgRootDir)' == '' and '$(VCPKG_ROOT)' != '' and Exists('$(VCPKG_ROOT)\$(VcpkgProbe)')">$(VCPKG_ROOT)</VcpkgRootDir>
     <VcpkgRootDir Condition="'$(VcpkgRootDir)' == '' and Exists('C:\vcpkg\$(VcpkgProbe)')">C:\vcpkg</VcpkgRootDir>
+    <VcpkgRootDir Condition="'$(VcpkgRootDir)' == '' and '$(USERPROFILE)' != '' and Exists('$(USERPROFILE)\vcpkg\$(VcpkgProbe)')">$(USERPROFILE)\vcpkg</VcpkgRootDir>
     <VcpkgRootDir Condition="'$(VcpkgRootDir)' == '' and '$(VCPKG_ROOT)' != ''">$(VCPKG_ROOT)</VcpkgRootDir>
     <VcpkgRootDir Condition="'$(VcpkgRootDir)' == ''">C:\vcpkg</VcpkgRootDir>
 
     <VcpkgInstalledDir>$(VcpkgRootDir)\installed\$(VcpkgTriplet)</VcpkgInstalledDir>
   </PropertyGroup>
 
+  <!--
+    The vendored zlib MUST precede the vcpkg include root.
+
+    $(VcpkgInstalledDir)\include is a shared tree: it holds the headers of every
+    package installed for the triplet, not just the two wanted here. If anything
+    else in it has pulled in zlib (opencv, libpng and protobuf all do), then
+    its zlib.h/zconf.h shadow core\lib\zlib\win, because every project appends
+    its own zlib path AFTER $(IncludePath).
+
+    That is not a harmless duplicate. vcpkg patches the guard in zconf.h from
+    "#ifdef ZLIB_DLL" to "#if 1", so its header declares every zlib entry point
+    __declspec(dllimport) unconditionally, while these projects link the
+    vendored STATIC libz-static.lib. The result is ten unresolved __imp_ symbols
+    (uncompress, inflate, deflate, crc32, ...) at link time in obr.exe and
+    obd.exe, with nothing in the log pointing at an include path.
+
+    Found on a developer box whose vcpkg tree is shared with other projects,
+    but CI is NOT immune. release-build.yml installs opencv4:arm64-windows into
+    C:\vcpkg before the build step, and opencv4 pulls zlib in through libpng,
+    libtiff and protobuf. That step is guarded by a cache hit on a static key
+    (opencv-4.12.0-win-arm64-dlls), so it is skipped almost every run; on a
+    miss (7-day eviction, a purge, a key change) the windows-arm64 release leg
+    would fail to link with those __imp_ errors. ci-build.yml is unaffected: it
+    takes OpenCV from a downloaded release installer, not from vcpkg.
+  -->
   <PropertyGroup>
-    <IncludePath>$(VcpkgInstalledDir)\include;$(IncludePath)</IncludePath>
+    <IncludePath>$(MSBuildThisFileDirectory)..\lib\zlib\win;$(VcpkgInstalledDir)\include;$(IncludePath)</IncludePath>
     <LibraryPath>$(VcpkgInstalledDir)\lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
 
@@ -49,6 +82,6 @@
   -->
   <Target Name="VerifyVcpkgDependencies" BeforeTargets="ClCompile">
     <Error Condition="!Exists('$(VcpkgInstalledDir)\include\mbedtls\build_info.h')"
-           Text="mbedTLS not found at $(VcpkgInstalledDir). Install it with:  vcpkg install mbedtls:$(VcpkgTriplet) nghttp2:$(VcpkgTriplet)   (set VCPKG_ROOT if your vcpkg is not at C:\vcpkg)" />
+           Text="mbedTLS not found at $(VcpkgInstalledDir). Install it with:  vcpkg install mbedtls:$(VcpkgTriplet) nghttp2:$(VcpkgTriplet)   -- run that from a directory with no vcpkg.json in it, or vcpkg switches to manifest mode, rejects the package arguments and installs to a vcpkg_installed\ tree nothing here reads. Probed: %VCPKG_ROOT%, C:\vcpkg, %USERPROFILE%\vcpkg; set VCPKG_ROOT if yours is elsewhere." />
   </Target>
 </Project>

--- a/core/release/deploy_windows.cmd
+++ b/core/release/deploy_windows.cmd
@@ -26,6 +26,11 @@ if not "%VCPKG_ROOT%" == "" (
 if "%VCPKG_DIR%" == "" (
 	if exist "C:\vcpkg\installed\%VCPKG_TRIPLET%\include\mbedtls\build_info.h" set VCPKG_DIR=C:\vcpkg
 )
+REM %USERPROFILE%\vcpkg is the default `git clone` location, and where this
+REM repo's ARM64 box keeps it. Kept in step with core\build\vcpkg.props.
+if "%VCPKG_DIR%" == "" (
+	if exist "%USERPROFILE%\vcpkg\installed\%VCPKG_TRIPLET%\include\mbedtls\build_info.h" set VCPKG_DIR=%USERPROFILE%\vcpkg
+)
 
 if "%VCPKG_DIR%" == "" (
 	echo.
@@ -36,9 +41,13 @@ if "%VCPKG_DIR%" == "" (
 	echo Install it with:
 	echo     vcpkg install mbedtls:%VCPKG_TRIPLET% nghttp2:%VCPKG_TRIPLET%
 	echo.
-	echo Set VCPKG_ROOT if your vcpkg is not at C:\vcpkg. Note that Visual
-	echo Studio ships its own vcpkg and points VCPKG_ROOT at it; that copy
-	echo usually has nothing installed.
+	echo Run that from a directory with no vcpkg.json in it. Otherwise vcpkg
+	echo switches to manifest mode, rejects the package arguments outright,
+	echo and installs to a vcpkg_installed\ tree that nothing here reads.
+	echo.
+	echo Probed: %%VCPKG_ROOT%%, C:\vcpkg, %%USERPROFILE%%\vcpkg. Set VCPKG_ROOT
+	echo if yours is elsewhere. Note that Visual Studio ships its own vcpkg and
+	echo points VCPKG_ROOT at it; that copy usually has nothing installed.
 	echo.
 	goto end
 )


### PR DESCRIPTION
Two problems, both introduced or left latent by ff16931a2.

## 1. The vcpkg root probe missed `%USERPROFILE%\vcpkg`

The probe tried `%VCPKG_ROOT%` then a hard-coded `C:\vcpkg`. Neither matches a default `git clone` of vcpkg, which lands in `%USERPROFILE%\vcpkg` — including on this repo's own ARM64 box. With `VCPKG_ROOT` unset there, every ARM64 build of the six projects that import the sheet died in `VerifyVcpkgDependencies` with "mbedTLS not found", pointing at a `C:\vcpkg` that does not exist.

Probed **third**, after the two existing entries, so CI's `C:\vcpkg` still wins and its behaviour is unchanged.

## 2. vcpkg's zlib shadowed the vendored one

Fixing the probe exposed this at link time: ten unresolved `__imp_` symbols (`uncompress`, `inflate`, `deflate`, `crc32`, ...) in `obr.exe` and `obd.exe`.

`$(VcpkgInstalledDir)\include` is a shared tree holding every package installed for the triplet, and it was prepended to `$(IncludePath)` while each project appends its own zlib path *after* it. So once anything in that tree pulled in zlib, vcpkg's `zlib.h`/`zconf.h` shadowed `core\lib\zlib\win`.

That is not a benign duplicate. vcpkg patches the guard in `zconf.h`:

```c
#  if 1                                   /* was: #ifdef ZLIB_DLL */
#    ifdef ZLIB_INTERNAL
#      define ZEXTERN extern __declspec(dllexport)
#    else
#      define ZEXTERN extern __declspec(dllimport)
```

declaring every entry point `dllimport`, while these projects link the vendored **static** `libz-static.lib`. Nothing in the link log points at an include path.

The vendored zlib now precedes the vcpkg include root. It is the only vendored include directory among the six projects, so nothing else is shadowed.

### CI is not immune to this one

`release-build.yml` installs `opencv4:arm64-windows` into the vcpkg tree before the build step, and opencv4 pulls zlib via libpng, libtiff and protobuf. That step is guarded by a cache hit on a static key (`opencv-4.12.0-win-arm64-dlls`), so it is skipped almost every run; on a miss (7-day eviction, a purge, a key change) the `windows-arm64` release leg would have failed to link. `ci-build.yml` takes OpenCV from a downloaded release installer and was never at risk.

## Also

`deploy_windows.cmd` carries the same third probe, and both error messages now warn that the install must be run from a directory with **no `vcpkg.json`** in it — otherwise vcpkg switches to manifest mode, rejects the package arguments and installs to a `vcpkg_installed\` tree nothing here reads.

## Verification

Local, on ARM64 Windows:

| Check | Result |
|---|---|
| `objeck.sln` ARM64 Release rebuild | clean — `obc.exe`, `obr.exe`, `obd.exe`, `obi.exe`, `objeck.lib` |
| `objeck.sln` x64 Release rebuild | clean, 0 warnings |
| `obc` + `obr` round-trip a compiled `.obe` | correct output, exit 0 |

The `.obe` format is zlib-compressed, so that round-trip exercises the exact path that was broken.

**Note on these checks:** `ci-build.yml` installs only mbedtls and nghttp2 into a clean tree, so it matches probe 2 and never pulls zlib. The checks on this PR confirm **no regression**; they do not exercise either fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
