### PR TITLE
fix(jit): AMD64 truncated 64-bit immediates for and, or, xor, add and sub

### DIFF
--- a/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
+++ b/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
@@ -4004,6 +4004,19 @@ void JitAmd64::add_imm_reg(int64_t imm, Register reg) {
   if(imm == 0) { return; }
   if(imm == 1) { inc_reg(reg); return; }
   if(imm == -1) { dec_reg(reg); return; }
+  // x86-64 has no ADD with a 64-bit immediate. The 0x81 group takes an imm32
+  // that is SIGN-EXTENDED to 64 bits, so a wider value silently loses its high
+  // half: 0x7FFFFFFFFFFFFFFF became 0xFFFFFFFF, sign-extended back to -1, and
+  // the operation turned into a no-op. Materialise it and use the register
+  // form. move_imm_reg emits a mov, which leaves FLAGS alone, and the reg-reg
+  // form sets them exactly as the immediate form would.
+  if(imm < INT32_MIN || imm > INT32_MAX) {
+    RegisterHolder* imm_holder = GetRegister();
+    move_imm_reg(imm, imm_holder->GetRegister());
+    add_reg_reg(imm_holder->GetRegister(), reg);
+    ReleaseRegister(imm_holder);
+    return;
+  }
   if(imm >= INT8_MIN && imm <= INT8_MAX) {
 #ifdef _DEBUG_JIT
     std::wcout << L"  " << (++instr_count) << L": [addq $" << imm << L", %"
@@ -4278,6 +4291,19 @@ void JitAmd64::sub_imm_reg(int64_t imm, Register reg) {
   if(imm == 0) { return; }
   if(imm == 1) { dec_reg(reg); return; }
   if(imm == -1) { inc_reg(reg); return; }
+  // x86-64 has no SUB with a 64-bit immediate. The 0x81 group takes an imm32
+  // that is SIGN-EXTENDED to 64 bits, so a wider value silently loses its high
+  // half: 0x7FFFFFFFFFFFFFFF became 0xFFFFFFFF, sign-extended back to -1, and
+  // the operation turned into a no-op. Materialise it and use the register
+  // form. move_imm_reg emits a mov, which leaves FLAGS alone, and the reg-reg
+  // form sets them exactly as the immediate form would.
+  if(imm < INT32_MIN || imm > INT32_MAX) {
+    RegisterHolder* imm_holder = GetRegister();
+    move_imm_reg(imm, imm_holder->GetRegister());
+    sub_reg_reg(imm_holder->GetRegister(), reg);
+    ReleaseRegister(imm_holder);
+    return;
+  }
   if(imm >= INT8_MIN && imm <= INT8_MAX) {
 #ifdef _DEBUG_JIT
     std::wcout << L"  " << (++instr_count) << L": [subq $" << imm << L", %"
@@ -5045,6 +5071,19 @@ void JitAmd64::cvt_mem_xreg(long offset, Register src, Register dest) {
 void JitAmd64::and_imm_reg(int64_t imm, Register reg) {
   if(imm == 0) { move_imm_reg(0, reg); return; }
   if(imm == -1) { return; }
+  // x86-64 has no AND with a 64-bit immediate. The 0x81 group takes an imm32
+  // that is SIGN-EXTENDED to 64 bits, so a wider value silently loses its high
+  // half: 0x7FFFFFFFFFFFFFFF became 0xFFFFFFFF, sign-extended back to -1, and
+  // the operation turned into a no-op. Materialise it and use the register
+  // form. move_imm_reg emits a mov, which leaves FLAGS alone, and the reg-reg
+  // form sets them exactly as the immediate form would.
+  if(imm < INT32_MIN || imm > INT32_MAX) {
+    RegisterHolder* imm_holder = GetRegister();
+    move_imm_reg(imm, imm_holder->GetRegister());
+    and_reg_reg(imm_holder->GetRegister(), reg);
+    ReleaseRegister(imm_holder);
+    return;
+  }
   if(imm >= INT8_MIN && imm <= INT8_MAX) {
 #ifdef _DEBUG_JIT
     std::wcout << L"  " << (++instr_count) << L": [andq $" << imm << L", %"
@@ -5113,6 +5152,19 @@ void JitAmd64::not_reg(Register reg) {
 void JitAmd64::or_imm_reg(int64_t imm, Register reg) {
   if(imm == 0) { return; }
   if(imm == -1) { move_imm_reg(-1, reg); return; }
+  // x86-64 has no OR with a 64-bit immediate. The 0x81 group takes an imm32
+  // that is SIGN-EXTENDED to 64 bits, so a wider value silently loses its high
+  // half: 0x7FFFFFFFFFFFFFFF became 0xFFFFFFFF, sign-extended back to -1, and
+  // the operation turned into a no-op. Materialise it and use the register
+  // form. move_imm_reg emits a mov, which leaves FLAGS alone, and the reg-reg
+  // form sets them exactly as the immediate form would.
+  if(imm < INT32_MIN || imm > INT32_MAX) {
+    RegisterHolder* imm_holder = GetRegister();
+    move_imm_reg(imm, imm_holder->GetRegister());
+    or_reg_reg(imm_holder->GetRegister(), reg);
+    ReleaseRegister(imm_holder);
+    return;
+  }
   if(imm >= INT8_MIN && imm <= INT8_MAX) {
 #ifdef _DEBUG_JIT
     std::wcout << L"  " << (++instr_count) << L": [orq $" << imm << L", %"
@@ -5170,6 +5222,19 @@ void JitAmd64::or_mem_reg(long offset, Register src, Register dest) {
 void JitAmd64::xor_imm_reg(int64_t imm, Register reg) {
   if(imm == 0) { return; }
   if(imm == -1) { not_reg(reg); return; }
+  // x86-64 has no XOR with a 64-bit immediate. The 0x81 group takes an imm32
+  // that is SIGN-EXTENDED to 64 bits, so a wider value silently loses its high
+  // half: 0x7FFFFFFFFFFFFFFF became 0xFFFFFFFF, sign-extended back to -1, and
+  // the operation turned into a no-op. Materialise it and use the register
+  // form. move_imm_reg emits a mov, which leaves FLAGS alone, and the reg-reg
+  // form sets them exactly as the immediate form would.
+  if(imm < INT32_MIN || imm > INT32_MAX) {
+    RegisterHolder* imm_holder = GetRegister();
+    move_imm_reg(imm, imm_holder->GetRegister());
+    xor_reg_reg(imm_holder->GetRegister(), reg);
+    ReleaseRegister(imm_holder);
+    return;
+  }
   if(imm >= INT8_MIN && imm <= INT8_MAX) {
 #ifdef _DEBUG_JIT
     std::wcout << L"  " << (++instr_count) << L": [xorq $" << imm << L", %"


### PR DESCRIPTION
Found by running the x64 suite against `master` after cebbf0e994 landed. **`arm64_imm64_ops` fails on x64** — and it is right to.

## The failure

```
FAIL: AndMask(-4)      FAIL: AndMask(-1)      FAIL: OrHigh(0)
8 passed, 3 failed
```

`AndMask(42)` passes. Everything that fails produces a result **wider than 32 bits**.

## Root cause

x86-64 has **no form of these instructions that takes a 64-bit immediate**. The `0x81` group takes an `imm32` which is *sign-extended* to 64 bits, and the emitters ended with `AddImm((long)imm)` regardless of the value's width:

```cpp
AddMachineCode(0x81);          // AND r/m64, imm32  (sign-extended!)
...
AddImm((long)imm);             // 0x7FFFFFFFFFFFFFFF -> 0xFFFFFFFF -> -1
```

So `v and 0x7FFFFFFFFFFFFFFF` became `v and -1` — a no-op returning `v`. For `or`/`xor`/`add`/`sub`, a high-half-only constant truncates to `0` and the operation likewise vanishes.

## Not a guess — the same source compiled twice

The only difference is whether the function is marked `native` (which forces JIT compilation):

| | `and` | `or` |
|---|---|---|
| interpreted | 9223372036854775807 ✓ | 9223090561878065152 ✓ |
| JIT | **-1** | **0** |

**A warning worth recording:** `OBJECK_JIT_THRESHOLD` does *not* settle this. `native` forces JIT compilation whatever the threshold, so raising it leaves these functions JIT-compiled and the failure identical — which reads as "not the JIT" and is wrong. I nearly drew that conclusion. The `native` / non-`native` pair is the experiment that actually works.

## Scope — probed, not assumed

| emitter | 64-bit immediate |
|---|---|
| `and_imm_reg`, `or_imm_reg`, `xor_imm_reg`, `add_imm_reg`, `sub_imm_reg` | **truncates** |
| `mul_imm_reg`, `cmp_imm_reg` | correct |

Eleven emitters share the `imm32` encoding (`move_imm_mem`, `cmp_imm_mem`, `add_imm_mem`, `sub_imm_mem` among them). The ones not touched here are **latent, not proven safe** — they simply are not reachable with a wide immediate by anything in the suite today.

## The fix

When the immediate does not fit a sign-extended `imm32`, materialise it with `move_imm_reg` and use the register form. `move_imm_reg` emits a `mov`, so **FLAGS survive** — the file already carries a comment warning that `XOR reg,reg` would not, and these emitters sit in front of comparisons that depend on them.

## Verification

| | before | after |
|---|---|---|
| `arm64_imm64_ops` (x64) | 8 passed, 3 failed | **11 passed, 0 failed** |
| 7-op probe (and/or/xor/add/sub/mul/cmp) | 5 failed | **7 ok** |
| x64 regression suite | 194 / 3 / 2 | **195 / 3 / 1** |

The one remaining failure, `mcp_debug_test`, fails the same way on this box without this change and is unrelated.

## Why this survived so long

This has been wrong on x64 in **every release** — any JIT-compiled method doing `v and <64-bit mask>` silently returned `v`. It surfaced only because the ARM64 work put a test for 64-bit immediates into the shared suite. The ARM64 bug was the same *class* (truncation to 32 bits) reached by a different route: there it was `long` being 32-bit on LLP64; here it is an encoding limit that applies on every platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
