### PR TITLE
fix(net): a short send() dropped the rest of the buffer on both platforms

### DIFF
--- a/core/vm/arch/posix/posix.h
+++ b/core/vm/arch/posix/posix.h
@@ -463,7 +463,30 @@ public:
   }
   
   static int WriteBytes(const char* values, int len, SOCKET sock) {
-    return static_cast<int>(send(sock, values, len, 0));
+    // send() on a blocking socket is only obliged to accept SOME of the buffer.
+    // Once the kernel send buffer fills it returns a short count, and a single
+    // unlooped send() drops the remainder on the floor -- no error, no retry,
+    // and callers here either push that partial count into Objeck or discard it
+    // entirely (SockTcpOutString ignores the return). ReadBytes below has always
+    // looped, and so has the TLS WriteBytes; only plain TCP did not.
+    //
+    // The buffer fills exactly when the peer is slow to drain it, which is the
+    // normal case for an Objeck client and an Objeck server sharing a process:
+    // the reader is not scheduled while the writer runs. That is why this showed
+    // up as a large in-process transfer arriving short or not at all.
+    int total = 0;
+    while(total < len) {
+      const int status = static_cast<int>(send(sock, values + total, len - total, 0));
+      if(status < 0) {
+        return total > 0 ? total : -1;
+      }
+      if(status == 0) {
+        break;
+      }
+      total += status;
+    }
+
+    return total;
   }
   
   static char ReadByte(SOCKET sock, int &status) {

--- a/core/vm/arch/win32/win32.h
+++ b/core/vm/arch/win32/win32.h
@@ -432,12 +432,25 @@ class IPSocket {
   }
 
   static int WriteBytes(const char* values, int len, SOCKET sock) {
-    int status = send(sock, values, len, 0);
-    if(status == SOCKET_ERROR) {
-      return -1;
+    // send() on a blocking socket is only obliged to accept SOME of the buffer.
+    // Once the kernel send buffer fills it returns a short count, and a single
+    // unlooped send() drops the remainder on the floor -- no error, no retry,
+    // and callers here either push that partial count into Objeck or discard it
+    // entirely (SockTcpOutString ignores the return). ReadBytes below has always
+    // looped, and so has the TLS WriteBytes; only plain TCP did not.
+    int total = 0;
+    while(total < len) {
+      const int status = send(sock, values + total, len - total, 0);
+      if(status == SOCKET_ERROR) {
+        return total > 0 ? total : -1;
+      }
+      if(status == 0) {
+        break;
+      }
+      total += status;
     }
-    
-    return status;
+
+    return total;
   }
 
   static char ReadByte(SOCKET sock, int &status) {


### PR DESCRIPTION
`IPSocket::WriteBytes` issued **one** `send()` and returned whatever it reported.

On a blocking socket `send()` is only obliged to accept *some* of the buffer. Once the kernel send buffer fills it returns a short count — and the remainder was dropped on the floor. No error, no retry, no second call.

## Nothing downstream compensates

- `SockTcpOutByteAry` and `SockTcpOutString` push the partial count into Objeck, where callers overwhelmingly ignore it
- [`common.cpp:4568`](https://github.com/objeck/objeck-lang/blob/master/core/vm/common.cpp#L4568) discards the return value outright

So a large write silently arrived truncated.

## The same file already knew better

Two places in the very same header loop correctly:

- `ReadBytes` has **always** looped until it had the bytes it was asked for
- the TLS `WriteBytes` overload loops on `mbedtls_ssl_write`

Only the plain-TCP write did not. And POSIX was worse than Windows — it returned `send()`'s value with no error check at all, so a failed write surfaced to Objeck as a byte count of `-1`.

Both platforms now loop, matching `ReadBytes`, and both report a partial write rather than claiming success.

## Scope — what this is not

Found while investigating intermittently lost in-process HTTP responses. **It is not the cause of those.** That turned out to be a Windows teardown behaviour, reproducible in ~130 lines of plain C++ with no Objeck involved, filed as #669 with the full elimination table.

This is a distinct data-loss bug the same reading turned up, and it earns its own fix: it is silent, it affects every platform, and it gets worse exactly when the peer is slow to drain — which is when large transfers matter most.

## Verification

Full x64 regression suite running locally; CI covers all five platforms. The change is confined to the two socket headers and builds clean.
