### PR TITLE
fix(net): one failed name lookup could shut down Winsock for the whole process

### DIFF
--- a/core/vm/arch/posix/posix.h
+++ b/core/vm/arch/posix/posix.h
@@ -332,9 +332,10 @@ public:
   static  std::vector<std::string> Resolve(const char* address) {
     std::vector<std::string> addresses;
 
-    struct addrinfo* result;
+    // getaddrinfo does not assign result unless it succeeds, so freeing it on the
+    // failure path handed freeaddrinfo an uninitialised pointer.
+    struct addrinfo* result = nullptr;
     if(getaddrinfo(address, nullptr, nullptr, &result)) {
-      freeaddrinfo(result);
       return  std::vector<std::string>();
     }
 

--- a/core/vm/arch/win32/win32.cpp
+++ b/core/vm/arch/win32/win32.cpp
@@ -46,7 +46,12 @@ SOCKET IPSocket::Open(const char* address, const int port) {
 
   std::string port_str = std::to_string(port);
   if(getaddrinfo(address, port_str.c_str(), &hints, &result) != 0) {
-    WSACleanup();
+    // No WSACleanup() here. WSAStartup runs once, in win_main, so a WSACleanup on
+    // this path drops the refcount to zero and shuts Winsock down for the WHOLE
+    // PROCESS -- every open socket on every other thread included, over one failed
+    // name lookup on one connection. OpenWithTimeout below has always just
+    // returned; this matches it. (Dormant in practice: getaddrinfo on a literal
+    // address does not fail, which is why it survived.)
     return -1;
   }
 
@@ -83,9 +88,10 @@ SOCKET IPSocket::Open(const char* address, const int port) {
 std::vector<std::string> IPSocket::Resolve(const char* address) {
  std::vector<std::string> addresses;
 
-	struct addrinfo* result;
+	// getaddrinfo does not assign result unless it succeeds, so freeing it on the
+	// failure path handed freeaddrinfo an uninitialised pointer.
+	struct addrinfo* result = nullptr;
 	if(getaddrinfo(address, nullptr, nullptr, &result)) {
-		freeaddrinfo(result);
 		return std::vector<std::string>();
 	}
 

--- a/programs/regression/net_resolve_failure.obs
+++ b/programs/regression/net_resolve_failure.obs
@@ -1,0 +1,81 @@
+#~
+# TCPSocket->Resolve failure-path test
+#
+# Resolve() freed its addrinfo result on the FAILURE path, where getaddrinfo had
+# never assigned it -- freeaddrinfo was handed an uninitialised pointer on every
+# lookup that did not resolve. Undefined behaviour, on both platforms, reachable
+# from Objeck by resolving any name that does not exist.
+#
+# Nothing exercised it: Resolve is exposed on TCPSocket and no regression test
+# called it, which is how it survived.
+#
+# BE CLEAR ABOUT WHAT THIS TEST DOES AND DOES NOT DO. It was run against a VM
+# built with the pre-fix Resolve and passed 8 times out of 8 -- freeing a wild
+# pointer is undefined behaviour, and on this platform it simply does not fault.
+# So this test does NOT demonstrate the bug and must not be cited as proof the
+# fix works. What it does is cover a reachable API that had no coverage at all,
+# and catch a future regression that does fault.
+#
+# ".invalid" is reserved by RFC 2606 and is guaranteed never to resolve, so this
+# needs no network and cannot be flaky on a runner without DNS.
+# EXTRA_LIBS: net
+~#
+
+use Collection, System.IO.Net;
+
+class NetResolveFailureTest {
+	function : Main(args : String[]) ~ Nil {
+		"Testing TCPSocket->Resolve failure path..."->PrintLine();
+
+		passed := 0;
+		failed := 0;
+		result : String[];
+
+		# The fixed path: a name that cannot resolve. Before the fix this freed an
+		# uninitialised pointer; the observable requirement is simply that we get
+		# here at all, with an empty result rather than a crash.
+		result := TCPSocket->Resolve("objeck-no-such-host-12345.invalid");
+		if(result = Nil) {
+			passed += 1;
+		}
+		else if(result->Size() = 0) {
+			passed += 1;
+		}
+		else {
+			size := result->Size();
+			"FAIL: unresolvable name returned {$size} addresses"->PrintLine();
+			failed += 1;
+		};
+
+		# Repeat it. A single free of a wild pointer can go unnoticed; several in a
+		# row on the same heap is what turns it into a visible corruption.
+		each(i : 20) {
+			result := TCPSocket->Resolve("objeck-no-such-host-12345.invalid");
+			if(result <> Nil & result->Size() <> 0) {
+				"FAIL: unresolvable name resolved on repeat {$i}"->PrintLine();
+				failed += 1;
+				break;
+			};
+		};
+		if(failed = 0) {
+			passed += 1;
+		};
+
+		# An empty name must not resolve either, and must not crash.
+		result := TCPSocket->Resolve("");
+		if(result = Nil | result->Size() = 0) {
+			passed += 1;
+		}
+		else {
+			passed += 1;    # a platform that resolves "" is odd but not this bug
+		};
+
+		if(failed > 0) {
+			"---"->PrintLine();
+			"{$passed} passed, {$failed} failed"->PrintLine();
+			Runtime->Exit(1);
+		};
+
+		"{$passed} passed, 0 failed"->PrintLine();
+	}
+}


### PR DESCRIPTION
Two latent defects in the socket layer, found while investigating #669 and deliberately kept out of that work rather than folded into an unrelated fix.

## 1. `WSACleanup()` in a per-connection error path

`IPSocket::Open` called `WSACleanup()` when `getaddrinfo` failed.

`WSAStartup` runs **exactly once**, in `win_main`. So that call drops the refcount to zero and shuts Winsock down **for the entire process** — every open socket on every other thread included — over one failed name lookup on one connection.

Its sibling `OpenWithTimeout` has always just returned `-1`; this now matches it. The shape is Microsoft's `getaddrinfo` sample, where `WSACleanup` is correct because the sample *is* a whole program. It isn't correct inside a library function.

## 2. `Resolve()` freed an uninitialised pointer

```cpp
struct addrinfo* result;                          // never assigned on failure
if(getaddrinfo(address, nullptr, nullptr, &result)) {
    freeaddrinfo(result);                         // <-- UB
```

`getaddrinfo` does not assign `result` unless it succeeds. Undefined behaviour on **every lookup that did not resolve**, on **both** platforms — `posix.h` had it identically.

## Both are dormant, not theoretical

I instrumented the `WSACleanup` path during the #669 investigation and it never fired, because `getaddrinfo` on a literal address doesn't fail. `Resolve` is reachable from Objeck as `TCPSocket->Resolve` and **no test called it** — which is how it survived.

## About the new test — read this before trusting it

`programs/regression/net_resolve_failure.obs` covers `Resolve`'s failure path, which previously had no coverage at all.

**It does not demonstrate the bug.** I built a VM with the pre-fix `Resolve` and ran the test against it: **8 passes out of 8.** Freeing a wild pointer is undefined behaviour, and on this platform it simply doesn't fault.

The test earns its place by covering a reachable API that had none, and by catching a future regression that *does* fault — not by proving this fix. Its header says so in as many words. Given the suite already had 125 tests asserting things they couldn't actually check (#668), quietly implying power this one lacks seemed like the wrong habit to start.

## Verification

Full x64 suite with the fixes: **197 passed, 3 skipped, 0 failed**. CI covers the POSIX `Resolve` change on Linux and macOS.
