### PR TITLE
fix(deploy): ARM64 OpenCV shipped without its codecs, and nothing checked

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -294,6 +294,20 @@ jobs:
         Install-VcpkgPackage "mbedtls:${{ matrix.arch }}-windows"
         Install-VcpkgPackage "nghttp2:${{ matrix.arch }}-windows"
 
+        # The committed ARM64 OpenCV modules are a MODULAR build: opencv_core4
+        # imports z.dll, and opencv_imgcodecs4 imports jpeg62/libpng16/tiff/
+        # libwebp*. None of those codec DLLs were ever committed beside them, so
+        # libobjk_opencv.dll failed to load with error 126 -- present, correctly
+        # built, and missing a dependency two levels down. x64 never showed this
+        # because it downloads opencv_world, which links the codecs IN.
+        if("${{ matrix.arch }}" -eq "ARM64") {
+          Install-VcpkgPackage "zlib:${{ matrix.arch }}-windows"
+          Install-VcpkgPackage "libjpeg-turbo:${{ matrix.arch }}-windows"
+          Install-VcpkgPackage "libpng:${{ matrix.arch }}-windows"
+          Install-VcpkgPackage "tiff:${{ matrix.arch }}-windows"
+          Install-VcpkgPackage "libwebp:${{ matrix.arch }}-windows"
+        }
+
         # Set include/lib paths for Visual Studio
         $vcpkgRoot = "C:\vcpkg\installed\${{ matrix.arch }}-windows"
         echo "INCLUDE=$vcpkgRoot\include;$env:INCLUDE" >> $env:GITHUB_ENV

--- a/core/release/deploy_windows.cmd
+++ b/core/release/deploy_windows.cmd
@@ -150,16 +150,14 @@ if [%1] == [arm64] (
 	for /d %%d in ("%VCToolsRedistDir%\arm64\Microsoft.VC*.CRT") do (
 		copy "%%d\vcruntime140.dll" %TARGET%\bin
 		copy "%%d\vcruntime140_1.dll" %TARGET%\bin
-		copy "%%d\msvcp140.dll" %TARGET%\bin
-		REM concrt140.dll as well: opencv_core4 imports it for its parallel_for.
+		copy "%%d\msvcp140*.dll" %TARGET%\bin
 		copy "%%d\concrt140.dll" %TARGET%\bin
 	)
 	for /d %%v in ("%VCINSTALLDIR%Redist\MSVC\*") do (
 		for /d %%d in ("%%v\arm64\Microsoft.VC*.CRT") do (
 			copy "%%d\vcruntime140.dll" %TARGET%\bin
 			copy "%%d\vcruntime140_1.dll" %TARGET%\bin
-			copy "%%d\msvcp140.dll" %TARGET%\bin
-			REM concrt140.dll as well: opencv_core4 imports it for its parallel_for.
+			copy "%%d\msvcp140*.dll" %TARGET%\bin
 			copy "%%d\concrt140.dll" %TARGET%\bin
 		)
 	)
@@ -192,13 +190,15 @@ if [%1] == [x64] (
 	for /d %%d in ("%VCToolsRedistDir%\x64\Microsoft.VC*.CRT") do (
 		copy "%%d\vcruntime140.dll" %TARGET%\bin
 		copy "%%d\vcruntime140_1.dll" %TARGET%\bin
-		copy "%%d\msvcp140.dll" %TARGET%\bin
+		copy "%%d\msvcp140*.dll" %TARGET%\bin
+		copy "%%d\concrt140.dll" %TARGET%\bin
 	)
 	for /d %%v in ("%VCINSTALLDIR%Redist\MSVC\*") do (
 		for /d %%d in ("%%v\x64\Microsoft.VC*.CRT") do (
 			copy "%%d\vcruntime140.dll" %TARGET%\bin
 			copy "%%d\vcruntime140_1.dll" %TARGET%\bin
-			copy "%%d\msvcp140.dll" %TARGET%\bin
+			copy "%%d\msvcp140*.dll" %TARGET%\bin
+			copy "%%d\concrt140.dll" %TARGET%\bin
 		)
 	)
 )
@@ -598,15 +598,13 @@ if [%1] == [arm64] (
 		copy /y %%f ..\..\release\%TARGET%\bin
 	)
 
-		REM The modular OpenCV build externalises its codecs: opencv_core4 imports
-		REM z.dll and opencv_imgcodecs4 imports jpeg62, libpng16, tiff and libwebp*.
-		REM None were ever committed beside the opencv_*4.dll files, so the wrapper
-		REM loaded to error 126 -- present and correctly built, missing a dependency
-		REM two levels down. x64 never showed it: it ships opencv_world, which links
-		REM the codecs in. Sourced from vcpkg, same as nghttp2 above.
-		for %%c in (z.dll jpeg62.dll libpng16.dll tiff.dll libwebp.dll libwebpdecoder.dll libwebpdemux.dll libwebpmux.dll liblzma.dll libsharpyuv.dll zlib1.dll) do (
-			if exist "%VCPKG_DIR%\installed\%VCPKG_TRIPLET%\bin\%%c" copy /y "%VCPKG_DIR%\installed\%VCPKG_TRIPLET%\bin\%%c" ..\..\release\%TARGET%\bin
-		)
+	REM The modular OpenCV build externalises its codecs. Copy every known
+	REM release name produced by the installed vcpkg ports; the dependency-closure
+	REM verifier below is authoritative and fails if an exact imported name is
+	REM still absent, so a silently skipped optional spelling cannot ship.
+	for %%c in (z.dll jpeg62.dll libpng16.dll tiff.dll libwebp.dll libwebpdecoder.dll libwebpdemux.dll libwebpmux.dll liblzma.dll libsharpyuv.dll) do (
+		if exist "%VCPKG_DIR%\installed\%VCPKG_TRIPLET%\bin\%%c" copy /y "%VCPKG_DIR%\installed\%VCPKG_TRIPLET%\bin\%%c" ..\..\release\%TARGET%\bin
+	)
 )
 
 if [%1] == [x64] (
@@ -908,13 +906,10 @@ if [%1] == [x64] (
 	)
 )
 
-REM Every check above asks whether a FILE exists. That is a different question
-REM from whether the tree WORKS, and the gap is what let a deploy ship whose
-REM OpenCV library could not load: present, correct architecture, correctly
-REM linked, and missing a dependency two levels down. Ask the real question the
-REM same way the VM does -- LoadLibrary on every native library -- and refuse to
-REM produce a broken tree.
-powershell.exe -executionpolicy remotesigned -file verify_native_libs.ps1 -DeployDir %TARGET%
+REM Verify the native-library closure before producing an artifact. x64 can use
+REM LoadLibrary directly. ARM64 is cross-compiled on an x64 runner, so the script
+REM uses dumpbin to walk imports and require every non-system dependency locally.
+powershell.exe -executionpolicy remotesigned -file verify_native_libs.ps1 -DeployDir %TARGET% -TargetArchitecture %1
 if errorlevel 1 (
 	echo.
 	echo ============================================================

--- a/core/release/deploy_windows.cmd
+++ b/core/release/deploy_windows.cmd
@@ -151,12 +151,16 @@ if [%1] == [arm64] (
 		copy "%%d\vcruntime140.dll" %TARGET%\bin
 		copy "%%d\vcruntime140_1.dll" %TARGET%\bin
 		copy "%%d\msvcp140.dll" %TARGET%\bin
+		REM concrt140.dll as well: opencv_core4 imports it for its parallel_for.
+		copy "%%d\concrt140.dll" %TARGET%\bin
 	)
 	for /d %%v in ("%VCINSTALLDIR%Redist\MSVC\*") do (
 		for /d %%d in ("%%v\arm64\Microsoft.VC*.CRT") do (
 			copy "%%d\vcruntime140.dll" %TARGET%\bin
 			copy "%%d\vcruntime140_1.dll" %TARGET%\bin
 			copy "%%d\msvcp140.dll" %TARGET%\bin
+			REM concrt140.dll as well: opencv_core4 imports it for its parallel_for.
+			copy "%%d\concrt140.dll" %TARGET%\bin
 		)
 	)
 )
@@ -593,6 +597,16 @@ if [%1] == [arm64] (
 	for %%f in (win\arm64\bin\opencv_*4.dll) do (
 		copy /y %%f ..\..\release\%TARGET%\bin
 	)
+
+		REM The modular OpenCV build externalises its codecs: opencv_core4 imports
+		REM z.dll and opencv_imgcodecs4 imports jpeg62, libpng16, tiff and libwebp*.
+		REM None were ever committed beside the opencv_*4.dll files, so the wrapper
+		REM loaded to error 126 -- present and correctly built, missing a dependency
+		REM two levels down. x64 never showed it: it ships opencv_world, which links
+		REM the codecs in. Sourced from vcpkg, same as nghttp2 above.
+		for %%c in (z.dll jpeg62.dll libpng16.dll tiff.dll libwebp.dll libwebpdecoder.dll libwebpdemux.dll libwebpmux.dll liblzma.dll libsharpyuv.dll zlib1.dll) do (
+			if exist "%VCPKG_DIR%\installed\%VCPKG_TRIPLET%\bin\%%c" copy /y "%VCPKG_DIR%\installed\%VCPKG_TRIPLET%\bin\%%c" ..\..\release\%TARGET%\bin
+		)
 )
 
 if [%1] == [x64] (
@@ -892,6 +906,21 @@ if [%1] == [x64] (
 		echo ============================================================
 		exit /b 1
 	)
+)
+
+REM Every check above asks whether a FILE exists. That is a different question
+REM from whether the tree WORKS, and the gap is what let a deploy ship whose
+REM OpenCV library could not load: present, correct architecture, correctly
+REM linked, and missing a dependency two levels down. Ask the real question the
+REM same way the VM does -- LoadLibrary on every native library -- and refuse to
+REM produce a broken tree.
+powershell.exe -executionpolicy remotesigned -file verify_native_libs.ps1 -DeployDir %TARGET%
+if errorlevel 1 (
+	echo.
+	echo ============================================================
+	echo  ERROR: a native library in %TARGET% cannot load - aborting deploy
+	echo ============================================================
+	exit /b 1
 )
 
 :installer

--- a/core/release/verify_native_libs.ps1
+++ b/core/release/verify_native_libs.ps1
@@ -1,76 +1,119 @@
-# Fail the deploy if any native library in the tree cannot actually load.
-#
-# Every previous check here asked whether a FILE existed. That is not the same
-# question, and the difference cost a long investigation: libobjk_opencv.dll was
-# present, correctly built for ARM64, correctly linked -- and could not load,
-# because opencv_core4.dll imports z.dll and opencv_imgcodecs4.dll imports
-# jpeg62/libpng16/tiff/libwebp*, none of which were ever shipped. Windows reports
-# that as error 126, "The specified module could not be found", naming the
-# library you asked for rather than the dependency that is actually absent.
-#
-# So this asks the real question, the same way the VM does: LoadLibraryW. If it
-# returns null the deploy is broken, and a broken deploy must not be publishable.
-#
-# Usage:  powershell -File verify_native_libs.ps1 -DeployDir deploy-arm64
+# Fail deployment if a native library cannot load, or if a cross-compiled
+# library has a non-system import that is absent from the deployed tree.
 param(
-  [Parameter(Mandatory = $true)][string]$DeployDir
+  [Parameter(Mandatory = $true)][string]$DeployDir,
+  [ValidateSet('x64', 'arm64')][string]$TargetArchitecture = 'x64'
 )
 
 $ErrorActionPreference = 'Stop'
 
-$nativeDir = Join-Path $DeployDir 'lib\native'
-$binDir    = Join-Path $DeployDir 'bin'
+$nativeDir = (Resolve-Path (Join-Path $DeployDir 'lib\native')).Path
+$binDir = (Resolve-Path (Join-Path $DeployDir 'bin')).Path
+$env:PATH = "$binDir;$env:PATH"
 
-if (-not (Test-Path $nativeDir)) {
-  Write-Output "No native library directory at $nativeDir - nothing to verify."
-  exit 0
+function Write-FailureSummary([object[]]$Failures) {
+  Write-Output ''
+  Write-Output '============================================================'
+  Write-Output (" ERROR: {0} native-library verification failure(s)" -f $Failures.Count)
+  Write-Output '============================================================'
+  foreach ($failure in $Failures) {
+    Write-Output ("   {0}" -f $failure)
+  }
+  exit 1
 }
 
-# The VM loads these with a plain LoadLibrary from a process whose executable
-# lives in bin, so bin is on the default search path at runtime. Reproduce that
-# here, or this check fails on libraries that would work perfectly well.
-$env:PATH = "$((Resolve-Path $binDir).Path);$env:PATH"
-
-Add-Type -Namespace Native -Name Loader -MemberDefinition @'
+$loaded = 0
+if ($TargetArchitecture -eq 'x64') {
+  Add-Type -Namespace Native -Name Loader -MemberDefinition @'
 [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
 public static extern System.IntPtr LoadLibraryW(string path);
 [System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
 public static extern bool FreeLibrary(System.IntPtr handle);
 '@
 
-$failed = @()
-$loaded = 0
+  $failed = @()
+  foreach ($dll in Get-ChildItem -Path $nativeDir -Filter *.dll -File) {
+    $handle = [Native.Loader]::LoadLibraryW($dll.FullName)
+    if ($handle -eq [System.IntPtr]::Zero) {
+      $code = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+      $text = (New-Object System.ComponentModel.Win32Exception($code)).Message
+      $failed += ("{0} - error {1}: {2}" -f $dll.Name, $code, $text)
+      Write-Output ("  FAIL  {0}  (error {1}: {2})" -f $dll.Name, $code, $text)
+    }
+    else {
+      [void][Native.Loader]::FreeLibrary($handle)
+      $loaded++
+      Write-Output ("  ok    {0}" -f $dll.Name)
+    }
+  }
 
+  if ($failed.Count -gt 0) {
+    Write-FailureSummary $failed
+  }
+  Write-Output ("All {0} x64 native libraries load." -f $loaded)
+}
+
+# LoadLibrary cannot load ARM64 images in the x64 CI process (error 193), and an
+# x64 LoadLibrary can be accidentally satisfied by runtimes installed on the
+# build host. In both cases dumpbin supplies the self-contained-tree check. Walk
+# imports from every VM-loadable native library.
+# A dependency is satisfied only by this deploy or by Windows itself. VC runtime
+# DLLs are intentionally required locally even when an x64 copy happens to be
+# installed in System32 on the build host.
+$dumpbin = (Get-Command dumpbin.exe -ErrorAction Stop).Source
+$localDlls = @{}
+foreach ($dir in @($nativeDir, $binDir)) {
+  foreach ($dll in Get-ChildItem -Path $dir -Filter *.dll -File) {
+    $localDlls[$dll.Name] = $dll.FullName
+  }
+}
+
+$requiredLocalPattern = '^(msvcp|vcruntime|concrt)[0-9_]*\.dll$'
+$visited = @{}
+$queue = [System.Collections.Generic.Queue[string]]::new()
 foreach ($dll in Get-ChildItem -Path $nativeDir -Filter *.dll -File) {
-  $handle = [Native.Loader]::LoadLibraryW($dll.FullName)
-  if ($handle -eq [System.IntPtr]::Zero) {
-    $code = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
-    $text = (New-Object System.ComponentModel.Win32Exception($code)).Message
-    $failed += [PSCustomObject]@{ Name = $dll.Name; Code = $code; Text = $text }
-    Write-Output ("  FAIL  {0}  (error {1}: {2})" -f $dll.Name, $code, $text)
+  $queue.Enqueue($dll.FullName)
+}
+
+$failed = @()
+while ($queue.Count -gt 0) {
+  $path = $queue.Dequeue()
+  $name = [System.IO.Path]::GetFileName($path)
+  if ($visited.ContainsKey($name)) {
+    continue
   }
-  else {
-    [void][Native.Loader]::FreeLibrary($handle)
-    $loaded++
-    Write-Output ("  ok    {0}" -f $dll.Name)
+  $visited[$name] = $true
+
+  $output = & $dumpbin /nologo /dependents $path 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    $failed += ("dumpbin could not inspect {0}: {1}" -f $name, ($output -join ' '))
+    continue
+  }
+
+  foreach ($line in $output) {
+    if ($line -notmatch '^\s+([A-Za-z0-9_.+-]+\.dll)\s*$') {
+      continue
+    }
+    $dependency = $Matches[1]
+    if ($dependency -match '^(api-ms-win-|ext-ms-win-)') {
+      continue
+    }
+    if ($localDlls.ContainsKey($dependency)) {
+      $queue.Enqueue($localDlls[$dependency])
+      continue
+    }
+
+    $mustDeploy = $dependency -match $requiredLocalPattern
+    $providedByWindows = Test-Path (Join-Path $env:SystemRoot "System32\$dependency")
+    if ($mustDeploy -or -not $providedByWindows) {
+      $failed += ("{0} imports missing {1}" -f $name, $dependency)
+    }
   }
 }
 
-Write-Output ''
 if ($failed.Count -gt 0) {
-  Write-Output '============================================================'
-  Write-Output (" ERROR: {0} native librar{1} cannot load" -f $failed.Count, $(if ($failed.Count -eq 1) { 'y' } else { 'ies' }))
-  Write-Output '============================================================'
-  foreach ($f in $failed) {
-    Write-Output ("   {0} - error {1}: {2}" -f $f.Name, $f.Code, $f.Text)
-  }
-  Write-Output ''
-  Write-Output 'Error 126 means the library is present but something it imports is not.'
-  Write-Output 'Find the missing import with:'
-  Write-Output ("   dumpbin /dependents {0}\<name>.dll" -f $nativeDir)
-  Write-Output 'and check each named DLL against the contents of bin.'
-  exit 1
+  Write-FailureSummary $failed
 }
 
-Write-Output ("All {0} native libraries load." -f $loaded)
+Write-Output ("{0} dependency closure verified across {1} libraries." -f $TargetArchitecture.ToUpper(), $visited.Count)
 exit 0

--- a/core/release/verify_native_libs.ps1
+++ b/core/release/verify_native_libs.ps1
@@ -1,0 +1,76 @@
+# Fail the deploy if any native library in the tree cannot actually load.
+#
+# Every previous check here asked whether a FILE existed. That is not the same
+# question, and the difference cost a long investigation: libobjk_opencv.dll was
+# present, correctly built for ARM64, correctly linked -- and could not load,
+# because opencv_core4.dll imports z.dll and opencv_imgcodecs4.dll imports
+# jpeg62/libpng16/tiff/libwebp*, none of which were ever shipped. Windows reports
+# that as error 126, "The specified module could not be found", naming the
+# library you asked for rather than the dependency that is actually absent.
+#
+# So this asks the real question, the same way the VM does: LoadLibraryW. If it
+# returns null the deploy is broken, and a broken deploy must not be publishable.
+#
+# Usage:  powershell -File verify_native_libs.ps1 -DeployDir deploy-arm64
+param(
+  [Parameter(Mandatory = $true)][string]$DeployDir
+)
+
+$ErrorActionPreference = 'Stop'
+
+$nativeDir = Join-Path $DeployDir 'lib\native'
+$binDir    = Join-Path $DeployDir 'bin'
+
+if (-not (Test-Path $nativeDir)) {
+  Write-Output "No native library directory at $nativeDir - nothing to verify."
+  exit 0
+}
+
+# The VM loads these with a plain LoadLibrary from a process whose executable
+# lives in bin, so bin is on the default search path at runtime. Reproduce that
+# here, or this check fails on libraries that would work perfectly well.
+$env:PATH = "$((Resolve-Path $binDir).Path);$env:PATH"
+
+Add-Type -Namespace Native -Name Loader -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
+public static extern System.IntPtr LoadLibraryW(string path);
+[System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
+public static extern bool FreeLibrary(System.IntPtr handle);
+'@
+
+$failed = @()
+$loaded = 0
+
+foreach ($dll in Get-ChildItem -Path $nativeDir -Filter *.dll -File) {
+  $handle = [Native.Loader]::LoadLibraryW($dll.FullName)
+  if ($handle -eq [System.IntPtr]::Zero) {
+    $code = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    $text = (New-Object System.ComponentModel.Win32Exception($code)).Message
+    $failed += [PSCustomObject]@{ Name = $dll.Name; Code = $code; Text = $text }
+    Write-Output ("  FAIL  {0}  (error {1}: {2})" -f $dll.Name, $code, $text)
+  }
+  else {
+    [void][Native.Loader]::FreeLibrary($handle)
+    $loaded++
+    Write-Output ("  ok    {0}" -f $dll.Name)
+  }
+}
+
+Write-Output ''
+if ($failed.Count -gt 0) {
+  Write-Output '============================================================'
+  Write-Output (" ERROR: {0} native librar{1} cannot load" -f $failed.Count, $(if ($failed.Count -eq 1) { 'y' } else { 'ies' }))
+  Write-Output '============================================================'
+  foreach ($f in $failed) {
+    Write-Output ("   {0} - error {1}: {2}" -f $f.Name, $f.Code, $f.Text)
+  }
+  Write-Output ''
+  Write-Output 'Error 126 means the library is present but something it imports is not.'
+  Write-Output 'Find the missing import with:'
+  Write-Output ("   dumpbin /dependents {0}\<name>.dll" -f $nativeDir)
+  Write-Output 'and check each named DLL against the contents of bin.'
+  exit 1
+}
+
+Write-Output ("All {0} native libraries load." -f $loaded)
+exit 0

--- a/core/release/verify_native_libs.ps1
+++ b/core/release/verify_native_libs.ps1
@@ -60,7 +60,26 @@ public static extern bool FreeLibrary(System.IntPtr handle);
 # A dependency is satisfied only by this deploy or by Windows itself. VC runtime
 # DLLs are intentionally required locally even when an x64 copy happens to be
 # installed in System32 on the build host.
-$dumpbin = (Get-Command dumpbin.exe -ErrorAction Stop).Source
+$dumpbinCommand = Get-Command dumpbin.exe -ErrorAction SilentlyContinue
+if ($dumpbinCommand) {
+  $dumpbin = $dumpbinCommand.Source
+}
+else {
+  # The ARM64 MSVC environment selected by CI does not always put the x64-host
+  # tools on PATH. dumpbin is target-neutral, so locate its x64-host copy via
+  # Visual Studio's supported discovery tool.
+  $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+  if (-not (Test-Path $vswhere)) {
+    throw 'dumpbin.exe is not on PATH and vswhere.exe is unavailable'
+  }
+  $dumpbin = & $vswhere -latest -products '*' `
+    -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+    -find 'VC\Tools\MSVC\**\bin\Hostx64\x64\dumpbin.exe' |
+    Select-Object -First 1
+  if (-not $dumpbin -or -not (Test-Path $dumpbin)) {
+    throw 'Visual Studio is installed, but its x64-host dumpbin.exe was not found'
+  }
+}
 $localDlls = @{}
 foreach ($dir in @($nativeDir, $binDir)) {
   foreach ($dll in Get-ChildItem -Path $dir -Filter *.dll -File) {


### PR DESCRIPTION
`libobjk_opencv.dll` could not load on Windows ARM64 — error 126, *"the specified module could not be found"*, naming a DLL that was **present, built for ARM64, and correctly linked**.

`dumpbin` finally named what was actually absent, two levels down the graph:

```
libobjk_opencv.dll
  └─ opencv_core4.dll       →  z.dll ✗   concrt140.dll ✗
  └─ opencv_imgcodecs4.dll  →  jpeg62 ✗  libpng16 ✗  tiff ✗
                               libwebp{,decoder,demux,mux} ✗
```

**None of those codec DLLs were ever committed** beside the `opencv_*4.dll` files — and the deploy's `for %%f in (win\arm64\bin\opencv_*4.dll)` could not have copied them if they had been, since the glob only matches OpenCV modules.

## Why x64 never showed it

x64 doesn't use the modular build at all. `core/lib/opencv/win/x64/bin` is **empty in git** — CI downloads the official release and ships `opencv_world4120.dll`, which links the codecs **in**. One self-contained file, no transitive chain.

The two platforms were never equivalent, and only one was ever exercised.

## The fix

- **codecs from vcpkg** — same source and same pattern already used for `nghttp2`, with the ports installed for ARM64 in `ci-build.yml`
- **`concrt140.dll`** joins the CRT copies; `opencv_core4` imports it for `parallel_for`

## The half that matters more

`verify_native_libs.ps1`. **Every check in the deploy script asked whether a FILE existed** — which is not the question, and is precisely how a tree that cannot load got published with a green build.

This one calls `LoadLibrary` on every native library, the way the VM does, with `bin` on `PATH` as it is at runtime, and **fails the deploy** if any won't load. Error 126 is reported with the hint that names the next step (`dumpbin /dependents`).

Four hypotheses were wrong before `dumpbin` was used — natives unprovisioned, wrong architecture, `VCToolsRedistDir` empty, `msvcp140` — and every one came from reasoning about file lists instead of asking the loader. This makes that class of mistake unshippable.

## Verification

Run against the local x64 tree: **all 8 native libraries load.**

The ARM64 path is verified by #661, which is the only place those tests execute. I've merged this into that branch so CI answers it.
