### PR TITLE
fix: core_http_server lost its 16KB body one run in four

### DIFF
--- a/core/vm/common.cpp
+++ b/core/vm/common.cpp
@@ -4185,7 +4185,22 @@ static bool GetRuntimeStat(const std::wstring& key, std::wstring& out)
     { L"runtime.gc.nursery.used",  []() -> size_t { return MemoryManager::GetNurseryUsed(); } },
     { L"runtime.gc.nursery.occupancy_permille", []() -> size_t {
                                                     const size_t cap = MemoryManager::GetNurseryCapacity();
-                                                    return cap ? (MemoryManager::GetNurseryUsed() * 1000 / cap) : 0; } },
+                                                    if(cap == 0) {
+                                                      return 0;
+                                                    }
+                                                    const size_t used = MemoryManager::GetNurseryUsed();
+                                                    // Saturate rather than report >100%: used can exceed cap
+                                                    // transiently while a collection is in flight.
+                                                    if(used >= cap) {
+                                                      return 1000;
+                                                    }
+                                                    // used * 1000 overflows once used passes SIZE_MAX/1000. That
+                                                    // needs an ~18PB nursery, so it cannot happen -- but nothing
+                                                    // here enforced it, and "cannot happen" is not the same as
+                                                    // "cannot overflow". Scale the divisor instead of the dividend
+                                                    // in that range so neither branch can wrap.
+                                                    return (cap > (SIZE_MAX / 1000)) ? (used / (cap / 1000))
+                                                                                     : ((used * 1000) / cap); } },
     { L"runtime.gc.remembered",    []() -> size_t { return MemoryManager::GetRememberedCount(); } },
     { L"runtime.gc.pause.last_us", []() -> size_t { return (size_t)MemoryManager::GetPauseLastUs(); } },
     { L"runtime.gc.pause.max_us",  []() -> size_t { return (size_t)MemoryManager::GetPauseMaxUs(); } },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,7 +70,7 @@ graph TB
 
     subgraph "CI/CD"
         GHA["GitHub Actions<br/>Multi-platform Matrix"]
-        Tests["Regression Tests<br/>(201 automated)"]
+        Tests["Regression Tests<br/>(204 automated)"]
         Artifacts["Build Artifacts"]
     end
 
@@ -793,10 +793,10 @@ graph TB
 
 | Platform | Runner | Architecture | Compiler | Tests |
 |----------|--------|--------------|----------|-------|
-| **Linux** | `ubuntu-latest` | x64 | GCC | 201 regression |
-| **Linux** | `ubuntu-24.04-arm` | ARM64 | GCC | 201 regression |
-| **macOS** | `macos-15` | ARM64 (Apple silicon) | Clang | 201 regression |
-| **Windows** | `windows-2025-vs2026` | x64 | MSVC (v145) | 201 regression |
+| **Linux** | `ubuntu-latest` | x64 | GCC | 204 regression |
+| **Linux** | `ubuntu-24.04-arm` | ARM64 | GCC | 204 regression |
+| **macOS** | `macos-15` | ARM64 (Apple silicon) | Clang | 204 regression |
+| **Windows** | `windows-2025-vs2026` | x64 | MSVC (v145) | 204 regression |
 | **Windows** | `windows-2025-vs2026` | ARM64 | MSVC (v145) | build only &mdash; see below |
 
 The Windows ARM64 leg is **cross-compiled on an x64 host, so it cannot execute what it
@@ -831,13 +831,13 @@ graph LR
 
 ### Regression Test Suite
 
-201 tests under `programs/regression/`, grouped by the prefix on each filename.
+204 tests under `programs/regression/`, grouped by the prefix on each filename.
 Counts are the file count per prefix, not a sample.
 
 ```mermaid
 mindmap
     root((Regression Tests
-    201 total))
+    204 total))
         Language core (42)
             core_*
                 Arithmetic, arrays, classes, generics, strings
@@ -862,10 +862,10 @@ mindmap
         ARM64 specific (5)
             arm64_*
                 Bitwise, char arrays, 64-bit immediates, multiply
-        Networking and web (10)
+        Networking and web (14)
             http_* mcp_* xml_* json_* api_*
                 Clients, servers, serialisation
-        Remainder (48)
+        Remainder (47)
             closure_* ai_* dap_* regex_* trap_* native_* and others
                 Closures, AI bindings, debugger, GC barriers
 ```

--- a/programs/regression/TESTS.md
+++ b/programs/regression/TESTS.md
@@ -13,7 +13,7 @@ python gen_manifest.py
 ```
 
 
-**Total runtime tests: 203** (plus 14 debugger tests, see below).
+**Total runtime tests: 204** (plus 14 debugger tests, see below).
 
 
 ## Tests by Category
@@ -21,7 +21,7 @@ python gen_manifest.py
 | Category | Count |
 |----------|-------|
 | Core Language | 38 |
-| Other | 27 |
+| Other | 28 |
 | AMD64/JIT | 21 |
 | Negative | 21 |
 | Bug Fix | 13 |
@@ -240,23 +240,24 @@ python gen_manifest.py
 | 184 | `regex_bench.obs` | Regex | regex bench | ✅ |
 | 185 | `regex_dfa_test.obs` | Regex | regex dfa test | ✅ |
 | 186 | `runtime_feature_test.obs` | Other | Regression tests for the "runtime.feature.*" properties, which report which optional protocol eng... | ✅ |
-| 187 | `select_dispatch_test.obs` | Control Flow | Single-case, linear (2-5 cases), jump-table (dense >=6), and binary-tree (sparse) paths | ✅ |
-| 188 | `string_find_ops.obs` | Strings | string find ops | ✅ |
-| 189 | `string_format_ops.obs` | Strings | Verifies String->Format() positional substitution. | ✅ |
-| 190 | `string_number_conv.obs` | Strings | string number conv | ✅ |
-| 191 | `string_replace_ops.obs` | Strings | string replace ops | ✅ |
-| 192 | `string_split_ops.obs` | Strings | string split ops | ✅ |
-| 193 | `task_scope.obs` | Other | Regression for a structured-concurrency nursery (TaskScope) built purely on the existing System.C... | ✅ |
-| 194 | `tco_receiver.obs` | Other | Tail-call optimization must respect the receiver. TCO used to fire on matching class-id and metho... | ✅ |
-| 195 | `trap_array_barrier_test.obs` | Other | A String[] returned by a VM trap must survive a collection. Every trap that returns an array of o... | ✅ |
-| 196 | `trap_array_mt_barrier_test.obs` | Other | A trap-returned array must survive ANOTHER THREAD's allocation. trap_array_barrier_test.obs cover... | ✅ |
-| 197 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
-| 198 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
-| 199 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
-| 200 | `websocket_test.obs` | Networking | websocket test | ✅ |
-| 201 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
-| 202 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
-| 203 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
+| 187 | `runtime_gc_stats.obs` | Other | The runtime.* GC statistics must stay inside their own stated ranges. runtime.gc.nursery.occupanc... | ✅ |
+| 188 | `select_dispatch_test.obs` | Control Flow | Single-case, linear (2-5 cases), jump-table (dense >=6), and binary-tree (sparse) paths | ✅ |
+| 189 | `string_find_ops.obs` | Strings | string find ops | ✅ |
+| 190 | `string_format_ops.obs` | Strings | Verifies String->Format() positional substitution. | ✅ |
+| 191 | `string_number_conv.obs` | Strings | string number conv | ✅ |
+| 192 | `string_replace_ops.obs` | Strings | string replace ops | ✅ |
+| 193 | `string_split_ops.obs` | Strings | string split ops | ✅ |
+| 194 | `task_scope.obs` | Other | Regression for a structured-concurrency nursery (TaskScope) built purely on the existing System.C... | ✅ |
+| 195 | `tco_receiver.obs` | Other | Tail-call optimization must respect the receiver. TCO used to fire on matching class-id and metho... | ✅ |
+| 196 | `trap_array_barrier_test.obs` | Other | A String[] returned by a VM trap must survive a collection. Every trap that returns an array of o... | ✅ |
+| 197 | `trap_array_mt_barrier_test.obs` | Other | A trap-returned array must survive ANOTHER THREAD's allocation. trap_array_barrier_test.obs cover... | ✅ |
+| 198 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
+| 199 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
+| 200 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
+| 201 | `websocket_test.obs` | Networking | websocket test | ✅ |
+| 202 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
+| 203 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
+| 204 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
 
 ## Debugger Tests (`run_debugger_tests.sh`)
 

--- a/programs/regression/core_http_server.obs
+++ b/programs/regression/core_http_server.obs
@@ -7,86 +7,139 @@
 
 use System.Concurrency, System.IO.Net, Web.HTTP;
 
+#~
+# The mock server must not be the side that tears the connection down.
+#
+# Windows loopback discards buffered data when the SENDER closes while bytes are
+# still in flight (#669): the RST flushes the receiver's kernel buffer. A server
+# that writes a response and immediately closes therefore loses it. The 16KB
+# /large response failed this way in roughly one run in four -- the client saw
+# 200 OK with a zero-length body, because the headers had already been copied out
+# but the body had not.
+#
+# That is the exact shape PR #672 fixed in Web.HTTP.Server, and this mirrors it:
+# responses advertise keep-alive, and before closing we drain until the peer goes
+# away so the CLIENT owns the first teardown. The drain is the part that actually
+# matters; the header alone would not be enough.
+#
+# Note this bug is invisible to the GetDelivered retry below, which only retries
+# a response that never arrived (code 0). A 200 with a truncated body is a real
+# failure and still fails the test.
+~#
 class MockServer from Thread {
 	@port : Int;
+	@client : TCPSocket;
+	@stop : Bool;
 
 	New(port : Int) {
 		Parent("mock-server");
 		@port := port;
+		@stop := false;
 	}
 
 	method : public : Run(param : Base) ~ Nil {
 		server := TCPSocketServer->New(@port);
 		if(server->Listen(5)) {
-			done := false;
-			while(<>done) {
-				client := server->Accept();
-				if(client <> Nil & client->IsOpen()) {
-					# Read request line
-					request_line := client->ReadLine();
+			while(<>@stop) {
+				@client := server->Accept();
+				if(@client <> Nil & @client->IsOpen()) {
+					# Bounds a peer that goes idle without closing. The client here is
+					# one-shot, so in practice this never fires.
+					@client->SetRecvTimeout(2000);
 
-					# Read headers
-					content_length := 0;
-					do {
-						header := client->ReadLine();
-						if(header->Size() > 0) {
-							colon := header->Find(':');
-							if(colon > 0) {
-								name := header->SubString(colon)->ToLower();
-								value := header->SubString(colon + 1, header->Size() - colon - 1)->Trim();
-								if(name->Equals("content-length")) {
-									content_length := value->ToInt();
-								};
-							};
-						};
-					}
-					while(header->Size() > 0);
-
-					# Read body if present
-					body := "";
-					if(content_length > 0) {
-						buf := Byte->New[content_length];
-						client->ReadBuffer(0, content_length, buf);
-						body := String->New(buf);
+					served := 0;
+					alive := true;
+					while(alive & <>@stop & served < 100 & @client->IsOpen()) {
+						alive := ServeOne();
+						served += 1;
 					};
 
-					# Route responses
-					if(request_line->Has("/hello")) {
-						response := "Hello World";
-						client->WriteString("HTTP/1.1 200 OK\r\nContent-Length: {$response->Size()}\r\nConnection: close\r\n\r\n{$response}");
-					}
-					else if(request_line->Has("/echo")) {
-						client->WriteString("HTTP/1.1 200 OK\r\nContent-Length: {$body->Size()}\r\nConnection: close\r\n\r\n{$body}");
-					}
-					else if(request_line->Has("/colon-header")) {
-						# Echo back the Authorization header value
-						# (re-read not possible, just send a known response)
-						response := "colon-ok";
-						client->WriteString("HTTP/1.1 200 OK\r\nContent-Length: {$response->Size()}\r\nX-Custom: value:with:colons\r\nConnection: close\r\n\r\n{$response}");
-					}
-					else if(request_line->Has("/large")) {
-						# Send a 16KB response to test ReadLength with larger buffers
-						large := Byte->New[16384];
-						each(i : large) {
-							large[i] := 'A';
-						};
-						size := large->Size();
-						client->WriteString("HTTP/1.1 200 OK\r\nContent-Length: {$size}\r\nConnection: close\r\n\r\n");
-						client->WriteBuffer(large);
-					}
-					else if(request_line->Has("/stop")) {
-						client->WriteString("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
-						done := true;
-					}
-					else {
-						client->WriteString("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
-					};
-
-					client->Close();
+					# Let the peer consume the final response and close first.
+					@client->SetRecvTimeout(1000);
+					drain := Byte->New[4096];
+					while(@client->ReadBuffer(0, drain->Size(), drain) > 0) {};
+					@client->Close();
 				};
 			};
 			server->Close();
 		};
+	}
+
+	#~
+	Serves one request on the already-open connection.
+	@return true if the connection should stay open for another request
+	~#
+	method : ServeOne() ~ Bool {
+		request_line := @client->ReadLine();
+		if(request_line = Nil | request_line->Size() = 0) {
+			# Peer closed, or the receive timeout fired.
+			return false;
+		};
+
+		# Read headers
+		content_length := 0;
+		do {
+			header := @client->ReadLine();
+			if(header = Nil) {
+				return false;
+			};
+			if(header->Size() > 0) {
+				colon := header->Find(':');
+				if(colon > 0) {
+					name := header->SubString(colon)->ToLower();
+					value := header->SubString(colon + 1, header->Size() - colon - 1)->Trim();
+					if(name->Equals("content-length")) {
+						content_length := value->ToInt();
+					};
+				};
+			};
+		}
+		while(header->Size() > 0);
+
+		# Read body if present
+		body := "";
+		if(content_length > 0) {
+			buf := Byte->New[content_length];
+			@client->ReadBuffer(0, content_length, buf);
+			body := String->New(buf);
+		};
+
+		# Route responses
+		if(request_line->Has("/hello")) {
+			response := "Hello World";
+			@client->WriteString("HTTP/1.1 200 OK\r\nContent-Length: {$response->Size()}\r\nConnection: keep-alive\r\n\r\n{$response}");
+		}
+		else if(request_line->Has("/echo")) {
+			@client->WriteString("HTTP/1.1 200 OK\r\nContent-Length: {$body->Size()}\r\nConnection: keep-alive\r\n\r\n{$body}");
+		}
+		else if(request_line->Has("/colon-header")) {
+			# Echo back a known response carrying a colon-bearing header value
+			response := "colon-ok";
+			@client->WriteString("HTTP/1.1 200 OK\r\nContent-Length: {$response->Size()}\r\nX-Custom: value:with:colons\r\nConnection: keep-alive\r\n\r\n{$response}");
+		}
+		else if(request_line->Has("/large")) {
+			# 16KB response, to test ReadLength with larger buffers. This is the
+			# request that exposed #669 when the server closed straight after writing.
+			large := Byte->New[16384];
+			each(i : large) {
+				large[i] := 'A';
+			};
+			size := large->Size();
+			@client->WriteString("HTTP/1.1 200 OK\r\nContent-Length: {$size}\r\nConnection: keep-alive\r\n\r\n");
+			@client->WriteBuffer(large);
+		}
+		else if(request_line->Has("/stop")) {
+			# Shutting down, so close is honest here -- the drain in Run still lets
+			# the client read this response before the socket goes away.
+			@client->WriteString("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+			@stop := true;
+			return false;
+		}
+		else {
+			@client->WriteString("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n");
+		};
+
+		return true;
 	}
 }
 

--- a/programs/regression/runtime_gc_stats.obs
+++ b/programs/regression/runtime_gc_stats.obs
@@ -1,0 +1,101 @@
+#~
+# The runtime.* GC statistics must stay inside their own stated ranges.
+#
+# runtime.gc.nursery.occupancy_permille computed used * 1000 / cap, which wraps
+# once used passes SIZE_MAX/1000, and said nothing about used > cap -- a state
+# that occurs transiently while a collection is in flight and used to report a
+# permille above 1000.
+#
+# NOTE: this is NOT the Coverity finding. CID 1677221 is runtime.memory.overhead
+# on the row above, and it is a false positive -- its r > a guard already prevents
+# the underflow Coverity claims. The overflow fixed here is a real one Coverity did
+# not flag, found while reading the neighbouring row.
+#
+# These properties are read through Runtime->GetProperty and are the only way a
+# program can see collector state, so a garbage value here is silently wrong
+# rather than loud.
+~#
+
+# Objects, not arrays. Arrays are born OLD (AllocateArray never uses the nursery),
+# so an array-allocating loop leaves nursery occupancy pinned at 0 and the range
+# assertions below never see a non-zero value to check.
+class Cell {
+	@a : Int; @b : Int; @c : Int;
+	New(v : Int) { @a := v; @b := v; @c := v; }
+	method : public : A() ~ Int { return @a; }
+}
+
+class RuntimeGcStats {
+	@failures : Int;
+
+	function : Main(args : String[]) ~ Nil {
+		t := RuntimeGcStats->New();
+		t->Run();
+	}
+
+	New() {
+		@failures := 0;
+	}
+
+	method : Check(what : String, ok : Bool) ~ Nil {
+		if(<>ok) {
+			"FAIL: {$what}"->PrintLine();
+			@failures += 1;
+		};
+	}
+
+	method : Permille() ~ Int {
+		text := Runtime->GetProperty("runtime.gc.nursery.occupancy_permille");
+		if(text = Nil) {
+			return -1;
+		};
+		return text->ToInt();
+	}
+
+	method : Run() ~ Nil {
+		# Sampled while allocating, so the nursery is genuinely filling and being
+		# collected underneath -- including the used >= cap window.
+		lowest := 100000;
+		highest := -1;
+		samples := 0;
+
+		for(i := 0; i < 400000; i += 1;) {
+			cell := Cell->New(i);
+			if(cell->A() < 0) { "unreachable"->PrintLine(); };
+
+			if(i % 4000 = 0) {
+				permille := Permille();
+				Check("occupancy is readable (got {$permille})", permille >= 0);
+				Check("occupancy {$permille} is not above 1000", permille <= 1000);
+				if(permille >= 0) {
+					samples += 1;
+					if(permille < lowest) { lowest := permille; };
+					if(permille > highest) { highest := permille; };
+				};
+			};
+		};
+
+		Check("occupancy was sampled at all", samples > 0);
+
+		# The other counters are monotonic and must not read as absurd values.
+		minor := Runtime->GetProperty("runtime.gc.minor");
+		major := Runtime->GetProperty("runtime.gc.major");
+		Check("runtime.gc.minor is present", minor <> Nil);
+		Check("runtime.gc.major is present", major <> Nil);
+		if(minor <> Nil & major <> Nil) {
+			Check("minor count is not negative", minor->ToInt() >= 0);
+			Check("major count is not negative", major->ToInt() >= 0);
+		};
+
+		used := Runtime->GetProperty("runtime.gc.nursery.used");
+		Check("runtime.gc.nursery.used is present", used <> Nil);
+
+		if(@failures > 0) {
+			"---"->PrintLine();
+			"{$@failures} failed"->PrintLine();
+			Runtime->Exit(1);
+		};
+
+		"PASS: {$samples} occupancy samples in [{$lowest}, {$highest}] permille"->PrintLine();
+	}
+}


### PR DESCRIPTION
## The failure

`core_http_server` failed **4 of 15** local runs, always identically:

```
FAIL: Large response size=0, expected 16384
```

Status line arrived (200 OK), body did not. This is **#669**: on Windows loopback, closing while bytes are still in flight sends an RST that flushes the receiver's kernel buffer. The mock server wrote its 16KB response and closed immediately, so the client had copied the headers out but not the body.

The existing `GetDelivered` retry could never have caught this — it only retries a response that *never arrived* (`code = 0`). This one arrives with a 200 and a truncated body.

## The fix

Same shape as PR #672 used for `Web.HTTP.Server`:

- responses advertise `Connection: keep-alive`
- request handling moves into `ServeOne()` so a connection can carry more than one request
- `Run` drains until the peer goes away before closing, so the **client** owns the first teardown

The drain is the part that actually matters — the keep-alive header alone would not be enough. That's written into the comment so it doesn't get simplified away later.

Bounded so keep-alive can't park the test: 100-request cap, 2s idle receive timeout, 1s drain timeout.

## Evidence

| | before | after |
|---|---|---|
| `core_http_server` | 11/15 (~27% fail) | **30/30** |
| full suite | 201 pass / 1 fail | **202 pass / 0 fail** |

At the old rate, 30 clean runs is ~1-in-8,000.

**Negative control** — because "flaky test now passes" is the shape a vacuous test has. Halving the response body to 8192 still fails loudly:

```
FAIL: Large response size=8192, expected 16384   (exit 1)
```

So the assertion is live; this is not papering over the platform bug by no longer checking for it.

## Also included

Found while reading the `runtime.*` statistics for an unrelated Coverity finding (which turned out to be a false positive):

`runtime.gc.nursery.occupancy_permille` computed `used * 1000 / cap`, which wraps once `used` passes `SIZE_MAX/1000`, and said nothing about `used > cap` — a real transient state mid-collection that produced a permille above 1000. Now saturates at 1000 and scales the divisor in the range where the dividend would overflow. **Coverity did not flag this one.**

`runtime_gc_stats.obs` covers it. Note it allocates **objects, not arrays** — arrays are born old-generation and never touch the nursery, so an array-allocating loop leaves occupancy pinned at 0 and asserts nothing. My first version did exactly that and passed while checking nothing.

## Docs

`TESTS.md` regenerated (203 → 204). `architecture.md`'s counts were **already stale by two** before this test; corrected to the real 204, and the mindmap's per-prefix groups recomputed from disk (networking 10 → 14, remainder 48 → 47) since they still summed to the old total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)