### PR TITLE
feat(web-server): reimplement Web.Server in pure Objeck over Web.HTTP.Server

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -555,7 +555,7 @@ jobs:
         $OBC -src lib_src/net_h2.obs -tar lib -lib net,gen_collect,cipher -opt s3 -dest ../lib/net_h2.obl
         $OBC -src lib_src/net_quic.obs -tar lib -lib net,gen_collect,cipher -opt s3 -dest ../lib/net_quic.obl
         $OBC -src lib_src/net_server.obs -tar lib -lib net,json,gen_collect,cipher -opt s3 -dest ../lib/net_server.obl
-        $OBC -src lib_src/web_server.obs -lib gen_collect,net -tar lib -opt s3 -dest ../lib/web_server.obl
+        $OBC -src lib_src/web_server.obs -lib gen_collect,net,net_server,json,cipher -tar lib -opt s3 -dest ../lib/web_server.obl
         $OBC -src lib_src/json_rpc.obs -tar lib -lib json,net -opt s3 -dest ../lib/json_rpc.obl
         $OBC -src lib_src/misc.obs -lib gen_collect,net,json -tar lib -opt s3 -dest ../lib/misc.obl
         $OBC -src lib_src/rss.obs -tar lib -lib xml,gen_collect,net,cipher -opt s3 -dest ../lib/rss.obl

--- a/core/compiler/lib_src/net_server.obs
+++ b/core/compiler/lib_src/net_server.obs
@@ -15,6 +15,10 @@ bundle Web.HTTP.Server {
 		@server_config : static : WebServerConfig;
 		@is_debug : static : Bool;
 
+		# Port passed to Serve. WebServer is already entirely static, so this adds
+		# no limitation that was not already present: one server per process.
+		@bound_port : static : Int;
+
 		#~
 		Starts a HTTPS server that listens for requests
 		@param filename configuration file (an <a href='https://github.com/objeck/objeck-web-server/blob/master/config/weather_config.json' target='_blank'>example</a>)
@@ -32,6 +36,7 @@ bundle Web.HTTP.Server {
 			if(@server_config->Load()) {
 				callback := @server_config->GetClass();
 				port := @server_config->GetPort();
+				@bound_port := port;
 				cert := @server_config->GetCertPath();
 				cert_key := @server_config->GetCertKeyPath();
 				cert_key_passwd := @server_config->GetCertPassword();
@@ -142,6 +147,14 @@ bundle Web.HTTP.Server {
 		}
 
 		#~
+		Gets the port this server was asked to bind to.
+		@return bound port, or 0 if no server has been started
+		~#
+		function : GetBoundPort() ~ Int {
+			return @bound_port;
+		}
+
+		#~
 		Starts a HTTP server that listens for requests
 		@param callback class inherited from 'HttpRequestHandler'
 		@param port server port
@@ -150,6 +163,8 @@ bundle Web.HTTP.Server {
 		function : Serve(callback : Class, port : Int, is_debug : Bool) ~ Nil {
 			@server := TCPSocketServer->New(port);
 			@is_debug := is_debug;
+
+			@bound_port := port;
 
 			Runtime->SetSignal(Runtime->Signal->SIGINT, Shutdown(Int) ~ Nil);
 			# Keep the accept queue large enough for the bounded thread-per-connection
@@ -879,6 +894,12 @@ bundle Web.HTTP.Server {
 		@cookies : Map<String, Cookie>;
 		@content : Byte[];
 
+		# Connection metadata. Set by the server after construction rather than
+		# through a constructor, so every existing caller is unaffected.
+		@request_verb : String;
+		@remote_address : String;
+		@local_port : Int;
+
 		#~
 		Constructor
 		@param request_line HTTP request line
@@ -910,6 +931,45 @@ bundle Web.HTTP.Server {
 			@request_line := request_line;
 			@request_headers := request_headers;
 			@content := content;
+		}
+
+		#~
+		Sets connection metadata. Called by the server immediately after the
+		request is constructed; handlers should treat these as read-only.
+		@param request_verb HTTP verb, e.g. GET or POST
+		@param remote_address address of the connected peer
+		@param local_port port this server is bound to
+		~#
+		method : public : SetConnectionInfo(request_verb : String, remote_address : String, local_port : Int) ~ Nil {
+			@request_verb := request_verb;
+			@remote_address := remote_address;
+			@local_port := local_port;
+		}
+
+		#~
+		Gets the HTTP verb. The verb is parsed by the server to choose a handler
+		method; this exposes it to handlers that need it directly.
+		@return HTTP verb, or Nil if the server did not supply one
+		~#
+		method : public : GetMethod() ~ String {
+			return @request_verb;
+		}
+
+		#~
+		Gets the address of the connected peer.
+		@return peer address, or Nil if the server did not supply one
+		~#
+		method : public : GetRemoteAddress() ~ String {
+			return @remote_address;
+		}
+
+		#~
+		Gets the port this server is bound to. This is the port passed to
+		Serve, not a socket-level lookup of the accepted connection.
+		@return local port, or 0 if the server did not supply one
+		~#
+		method : public : GetLocalPort() ~ Int {
+			return @local_port;
 		}
 
 		#~
@@ -2087,6 +2147,10 @@ class RequestHandler from HttpsRequestHandler {
 
 					# write response
 					http_request := Request->New(request_path, request_headers);
+					# The verb and peer address are known here and were previously discarded:
+					# the verb only chose a handler method, and the address was read solely
+					# under @is_debug. Handlers need both.
+					http_request->SetConnectionInfo(request_verb, @client->GetAddress(), WebServer->GetBoundPort());
 					http_response := Response->New(@server_config, http_request->GetPath());
 
 					if(ProcessGet(http_request, http_response) & @server_config <> Nil & @server_config->IsHandlingFiles()) {
@@ -2103,6 +2167,10 @@ class RequestHandler from HttpsRequestHandler {
 
 					# write response
 					http_request := Request->New(request_path, request_headers, buffer);
+					# The verb and peer address are known here and were previously discarded:
+					# the verb only chose a handler method, and the address was read solely
+					# under @is_debug. Handlers need both.
+					http_request->SetConnectionInfo(request_verb, @client->GetAddress(), WebServer->GetBoundPort());
 					http_response := Response->New(@server_config, http_request->GetPath());
 
 					if(request_verb->Equals("POST")) {
@@ -2515,6 +2583,10 @@ class RequestHandler from HttpsRequestHandler {
 
 					# write response
 					http_request := Request->New(request_path, request_headers);
+					# The verb and peer address are known here and were previously discarded:
+					# the verb only chose a handler method, and the address was read solely
+					# under @is_debug. Handlers need both.
+					http_request->SetConnectionInfo(request_verb, @client->GetAddress(), WebServer->GetBoundPort());
 					http_response := Response->New(@server_config, http_request->GetPath());
 					
 					if(ProcessGet(http_request, http_response) & @server_config <> Nil & @server_config->IsHandlingFiles()) {
@@ -2531,6 +2603,10 @@ class RequestHandler from HttpsRequestHandler {
 
 					# write response
 					http_request := Request->New(request_path, request_headers, buffer);
+					# The verb and peer address are known here and were previously discarded:
+					# the verb only chose a handler method, and the address was read solely
+					# under @is_debug. Handlers need both.
+					http_request->SetConnectionInfo(request_verb, @client->GetAddress(), WebServer->GetBoundPort());
 					http_response := Response->New(@server_config, http_request->GetPath());
 
 					if(request_verb->Equals("POST")) {

--- a/core/compiler/lib_src/web_server.obs
+++ b/core/compiler/lib_src/web_server.obs
@@ -1,39 +1,18 @@
-use Collection;
+use Collection, Web.HTTP.Server;
 
 #~
 Lightweight embedded web server. Handles inbound HTTP requests with typed access to method, path, headers, and body; Response supports content-type, compression, redirects, and cookies. Compile with -lib net_server.
 ~#
 bundle Web.Server {
-	class : private: Proxy {
-		@lib_proxy : static : System.API.DllProxy;
-		
-		function : GetDllProxy() ~ System.API.DllProxy {
-			if(@lib_proxy = Nil) {
-				# shared library native implementation (for Nginix, IIS and Apache) fetched from configuration
-				@lib_proxy := System.API.DllProxy->New(Runtime->GetProperty("OBJECK_LIB_WEB_SERVER"));
-			};
-
-			return @lib_proxy;
-		}
-	}
-
 	#~
 	Web request
 	~#
 	class Request {
-		# Native entry-point names, held rather than written at each call
-		# site: a string literal is materialised into a fresh String every
-		# time it is evaluated, which on a hot path is an allocation and a
-		# copy per call. Static because these are class-wide constants and a
-		# static function cannot read an instance field.
-		@fn_web_request_get_header : static : String;
-		@fn_web_request_get_method : static : String;
-		@fn_web_request_local_address : static : String;
-		@fn_web_request_read_body : static : String;
-		@fn_web_request_remote_address : static : String;
-		@fn_web_request_request_url : static : String;
-		@request : Int;
-		@response : Int;
+		# Backed by Web.HTTP.Server.Request. This class used to call a native
+		# library named by the OBJECK_LIB_WEB_SERVER property. No such library was
+		# ever built or shipped, and nothing set that property, so none of these
+		# methods could run. See docs/web_server_design.md.
+		@http_request : Web.HTTP.Server.Request;
 
 		#~
 		Web request method
@@ -48,6 +27,14 @@ bundle Web.Server {
 			OPTIONS,
 			TRACE,
 			PATCH
+		}
+
+		#~
+		Constructor
+		@param http_request underlying server request
+		~#
+		New(http_request : Web.HTTP.Server.Request) {
+			@http_request := http_request;
 		}
 
 		#~
@@ -66,13 +53,12 @@ bundle Web.Server {
 		```
 		~#
 		method : public : GetMethod() ~ Request->Method {
-			array_args := Base->New[2];
-			array_args[0] := Nil;
-			array_args[1] := IntRef->New(@request);
-
-			if(@fn_web_request_get_method = Nil) { @fn_web_request_get_method := "web_request_get_method"; };
-			Proxy->GetDllProxy()->CallFunction(@fn_web_request_get_method, array_args);
-			req_method := array_args[0]->As(String);
+			req_method := @http_request->GetMethod();
+			if(req_method = Nil) {
+				# The server always supplies a verb. This guards a Request built by
+				# hand rather than handed over by the server.
+				return Request->Method->GET;
+			};
 
 			# TODO: faster way put into a hash, Nginx uses a integer value
 			if(req_method->Equals("GET")) {
@@ -115,14 +101,7 @@ bundle Web.Server {
 		```
 		~#
 		method : public : GetRequestUrl() ~ String {
-			array_args := Base->New[2];
-			array_args[0] := Nil;
-			array_args[1] := IntRef->New(@request);
-
-			if(@fn_web_request_request_url = Nil) { @fn_web_request_request_url := "web_request_request_url"; };
-			Proxy->GetDllProxy()->CallFunction(@fn_web_request_request_url, array_args);
-
-			return array_args[0]->As(String);
+			return @http_request->GetRequestLine();
 		}
 
 		#~
@@ -135,14 +114,7 @@ bundle Web.Server {
 		```
 		~#
 		method : public : GetRemoteAddress() ~ String {
-			array_args := Base->New[2];
-			array_args[0] := Nil;
-			array_args[1] := IntRef->New(@request);
-
-			if(@fn_web_request_remote_address = Nil) { @fn_web_request_remote_address := "web_request_remote_address"; };
-			Proxy->GetDllProxy()->CallFunction(@fn_web_request_remote_address, array_args);
-
-			return array_args[0]->As(String);
+			return @http_request->GetRemoteAddress();
 		}
 
 		#~
@@ -155,14 +127,23 @@ bundle Web.Server {
 		```
 		~#
 		method : public : GetLocalAddress() ~ String {
-			array_args := Base->New[2];
-			array_args[0] := Nil;
-			array_args[1] := IntRef->New(@request);
+			# There is no socket-level local-address lookup: GetAddress on an accepted
+			# socket is the PEER (SockTcpAccept fills it from the client). So the port
+			# comes from Serve, and the host from the Host header the client dialled.
+			# See docs/web_server_design.md.
+			port := @http_request->GetLocalPort();
 
-			if(@fn_web_request_local_address = Nil) { @fn_web_request_local_address := "web_request_local_address"; };
-			Proxy->GetDllProxy()->CallFunction(@fn_web_request_local_address, array_args);
+			host := @http_request->GetHeader("host");
+			if(host <> Nil & <>host->IsEmpty()) {
+				colon := host->Find(':');
+				if(colon > 0) {
+					host := host->SubString(colon);
+				};
 
-			return array_args[0]->As(String);
+				return "{$host}:{$port}";
+			};
+
+			return "0.0.0.0:{$port}";
 		}
 
 		#~
@@ -178,15 +159,13 @@ bundle Web.Server {
 		```
 		~#
 		method : public : GetHeader(name : String) ~ String {
-			array_args := Base->New[3];
-			array_args[0] := Nil;
-			array_args[1] := IntRef->New(@request);
-			array_args[2] := name;
+			# The server stores request header names lower-cased, and its GetHeader
+			# does a raw lookup, so "Content-Type" would otherwise miss.
+			if(name = Nil) {
+				return Nil;
+			};
 
-			if(@fn_web_request_get_header = Nil) { @fn_web_request_get_header := "web_request_get_header"; };
-			Proxy->GetDllProxy()->CallFunction(@fn_web_request_get_header, array_args);
-
-			return array_args[0]->As(String);
+			return @http_request->GetHeader(name->ToLower());
 		}
 
 		#~
@@ -202,20 +181,7 @@ bundle Web.Server {
 		```
 		~#
 		method : public : ReadBody() ~ Byte[] {
-			array_args := Base->New[3];
-			array_args[0] := Nil;
-			array_args[1] := IntRef->New(@request);
-			array_args[2] := IntRef->New(@response);
-
-			if(@fn_web_request_read_body = Nil) { @fn_web_request_read_body := "web_request_read_body"; };
-			Proxy->GetDllProxy()->CallFunction(@fn_web_request_read_body, array_args);
-
-			value := array_args[0]->As(ByteArrayRef);
-			if(value <> Nil) {
-				return value->Get();
-			};
-			
-			return Nil;
+			return @http_request->GetContentBytes();
 		}
 
 		#~
@@ -440,19 +406,55 @@ bundle Web.Server {
 	Web Response 
 	~#
 	class Response {
-		# Native entry-point names, held rather than written at each call
-		# site: a string literal is materialised into a fresh String every
-		# time it is evaluated, which on a hot path is an allocation and a
-		# copy per call. Static because these are class-wide constants and a
-		# static function cannot read an instance field.
-		@fn_web_response_append_bytes : static : String;
-		@fn_web_response_append_string : static : String;
-		@fn_web_response_clear_all : static : String;
-		@fn_web_response_redirect : static : String;
-		@fn_web_response_remove_header : static : String;
-		@fn_web_response_set_content_type : static : String;
-		@fn_web_response_set_header : static : String;
-		@response : Int;
+		# Backed by Web.HTTP.Server.Response. See the note on Request and
+		# docs/web_server_design.md for why the native path was removed.
+		@http_response : Web.HTTP.Server.Response;
+
+		# WriteBody APPENDS, while the underlying SetContent REPLACES, so the
+		# accumulated body is kept here and pushed through on every write.
+		@body : Byte[];
+
+		#~
+		Constructor
+		@param http_response underlying server response
+		~#
+		New(http_response : Web.HTTP.Server.Response) {
+			@http_response := http_response;
+
+			# The underlying response defaults to 400, and the server only serialises
+			# headers and a body when the code is 200 -- anything else becomes a
+			# bodyless status line. A handler that writes a body and sets no code is
+			# expressing success, so start at 200 and let Redirect move it.
+			@http_response->SetCode(200);
+		}
+
+		#~
+		Appends to the accumulated body
+		@param data bytes to append
+		@return number of bytes appended
+		~#
+		method : Append(data : Byte[]) ~ Int {
+			if(data = Nil | data->Size() = 0) {
+				return 0;
+			};
+
+			if(@body = Nil) {
+				@body := Byte->New[data->Size()];
+				Runtime->Copy(@body, 0, data, 0, data->Size());
+			}
+			else {
+				merged := Byte->New[@body->Size() + data->Size()];
+				Runtime->Copy(merged, 0, @body, 0, @body->Size());
+				Runtime->Copy(merged, @body->Size(), data, 0, data->Size());
+				@body := merged;
+			};
+
+			# Pushed on every write: a handler may return at any point and the
+			# server serialises whatever the response holds at that moment.
+			@http_response->SetContent(@body);
+
+			return data->Size();
+		}
 		
 		#~
 		Set the content type
@@ -464,12 +466,7 @@ bundle Web.Server {
 		```
 		~#
 		method : public : SetContentType(type : String) ~ Nil {
-			array_args := Base->New[2];
-			array_args[0] := IntRef->New(@response);
-			array_args[1] := type;
-
-			if(@fn_web_response_set_content_type = Nil) { @fn_web_response_set_content_type := "web_response_set_content_type"; };
-			Proxy->GetDllProxy()->CallFunction(@fn_web_response_set_content_type, array_args);
+			@http_response->SetHeader("Content-Type", type);
 		}
 
 		#~
@@ -484,16 +481,11 @@ bundle Web.Server {
 		```
 		~#
 		method : public : WriteBody(data : String) ~ Int {
-			array_args := Base->New[3];
-			array_args[0] := IntRef->New();
-			array_args[1] := IntRef->New(@response);
-			array_args[2] := data;
+			if(data = Nil) {
+				return 0;
+			};
 
-			if(@fn_web_response_append_string = Nil) { @fn_web_response_append_string := "web_response_append_string"; };
-			Proxy->GetDllProxy()->CallFunction(@fn_web_response_append_string, array_args);
-
-			value := array_args[0]->As(IntRef);
-			return value->Get();
+			return Append(data->ToByteArray());
 		}
 
 		#~
@@ -508,16 +500,7 @@ bundle Web.Server {
 		```
 		~#
 		method : public : WriteBody(data : Byte[]) ~ Int {
-			array_args := Base->New[3];
-			array_args[0] := IntRef->New();
-			array_args[1] := IntRef->New(@response);
-			array_args[2] := ByteArrayRef->New(data);
-
-			if(@fn_web_response_append_bytes = Nil) { @fn_web_response_append_bytes := "web_response_append_bytes"; };
-			Proxy->GetDllProxy()->CallFunction(@fn_web_response_append_bytes, array_args);
-
-			value := array_args[0]->As(IntRef);
-			return value->Get();
+			return Append(data);
 		}
 
 		#~
@@ -531,16 +514,17 @@ bundle Web.Server {
 		```
 		~#
 		method : public : Redirect (url : String) ~ Bool {
-			array_args := Base->New[3];
-			array_args[0] := IntRef->New();
-			array_args[1] := IntRef->New(@response);
-			array_args[2] := url;
+			if(url = Nil | url->IsEmpty()) {
+				return false;
+			};
 
-			if(@fn_web_response_redirect = Nil) { @fn_web_response_redirect := "web_response_redirect"; };
-			Proxy->GetDllProxy()->CallFunction(@fn_web_response_redirect, array_args);
+			# The server takes the Location value from GetReason on a 302, not from a
+			# Location header: see ProcessResponse's 302 label in net_server.obs. A
+			# header here would be dropped, because the non-200 path emits none.
+			@http_response->SetCode(302);
+			@http_response->SetReason(url);
 
-			value := array_args[0]->As(IntRef);
-			return value->Get() = 0 ? false : true;
+			return true;
 		}
 
 		#~
@@ -556,17 +540,13 @@ bundle Web.Server {
 		```
 		~#
 		method : public : SetHeader(name : String, value : String) ~ Bool {
-			array_args := Base->New[4];
-			array_args[0] := IntRef->New();
-			array_args[1] := IntRef->New(@response);
-			array_args[2] := name;
-			array_args[3] := value;
+			if(name = Nil) {
+				return false;
+			};
 
-			if(@fn_web_response_set_header = Nil) { @fn_web_response_set_header := "web_response_set_header"; };
-			Proxy->GetDllProxy()->CallFunction(@fn_web_response_set_header, array_args);
+			@http_response->SetHeader(name, value);
 
-			result := array_args[0]->As(IntRef);
-			return result->Get() = 0 ? false : true;
+			return true;
 		}
 
 		#~
@@ -581,16 +561,13 @@ bundle Web.Server {
 		```
 		~#
 		method : public : RemoveHeader(name : String) ~ Bool {
-			array_args := Base->New[3];
-			array_args[0] := IntRef->New();
-			array_args[1] := IntRef->New(@response);
-			array_args[2] := name;
+			if(name = Nil) {
+				return false;
+			};
 
-			if(@fn_web_response_remove_header = Nil) { @fn_web_response_remove_header := "web_response_remove_header"; };
-			Proxy->GetDllProxy()->CallFunction(@fn_web_response_remove_header, array_args);
+			@http_response->RemoveHeader(name);
 
-			result := array_args[0]->As(IntRef);
-			return result->Get() = 0 ? false : true;
+			return true;
 		}
 
 		#~
@@ -603,10 +580,75 @@ bundle Web.Server {
 		```
 		~#
 		method : public : ClearAll() ~ Nil {
-			array_args := Base->New[1];
-			array_args[0] := IntRef->New(@response);
-			if(@fn_web_response_clear_all = Nil) { @fn_web_response_clear_all := "web_response_clear_all"; };
-			Proxy->GetDllProxy()->CallFunction(@fn_web_response_clear_all, array_args);
+			# Body-scoped, as the documented example above implies: discard a draft
+			# body and write a final one. Headers are left alone.
+			@body := Nil;
+			@http_response->SetContent(Byte->New[0]);
+		}
+	}
+
+	#~
+	Serves Web.Server handlers on the Web.HTTP.Server engine.
+
+	Subclass and override Process. The adapter wraps the server's request and
+	response so handler code sees the Web.Server API.
+
+	```
+	class MyHandler from Web.Server.Handler {
+	  New() { Parent(); }
+
+	  method : public : Process(request : Web.Server.Request, response : Web.Server.Response) ~ Bool {
+	    response->SetContentType("text/plain");
+	    response->WriteBody("hello");
+	    return false;
+	  }
+	}
+
+	Web.Server.Handler->Serve(MyHandler->New()->GetClass(), 8080);
+	```
+	~#
+	class Handler from Web.HTTP.Server.HttpRequestHandler {
+		New() {
+			Parent();
+		}
+
+		#~
+		Starts a server that dispatches to a Web.Server handler
+		@param handler handler class
+		@param port port to bind
+		~#
+		function : Serve(handler : Class, port : Int) ~ Nil {
+			Web.HTTP.Server.WebServer->Serve(handler, port, false);
+		}
+
+		#~
+		Starts a server that dispatches to a Web.Server handler
+		@param handler handler class
+		@param port port to bind
+		@param is_debug true for debug output
+		~#
+		function : Serve(handler : Class, port : Int, is_debug : Bool) ~ Nil {
+			Web.HTTP.Server.WebServer->Serve(handler, port, is_debug);
+		}
+
+		#~
+		Handles a request. Subclasses must implement this.
+
+		Declared virtual, which in Objeck is a declaration without a body: a
+		concrete method here would be bound statically from ProcessGet below, so a
+		subclass override would never run.
+		@param request request
+		@param response response
+		@return true to continue processing, false otherwise
+		~#
+		method : public : virtual : Process(request : Request, response : Response) ~ Bool;
+
+		method : ProcessGet(request : Web.HTTP.Server.Request, response : Web.HTTP.Server.Response) ~ Bool {
+			return Process(Request->New(request), Response->New(response));
+		}
+
+		method : ProcessPost(request : Web.HTTP.Server.Request, response : Web.HTTP.Server.Response) ~ Bool {
+			return Process(Request->New(request), Response->New(response));
 		}
 	}
 }

--- a/core/compiler/update_version.sh
+++ b/core/compiler/update_version.sh
@@ -26,7 +26,7 @@ make -f make/Makefile.amd64
 ./obc -src lib_src/net_h2.obs -tar lib -lib net,gen_collect,cipher -opt s3 -dest ../lib/net_h2.obl
 ./obc -src lib_src/net_quic.obs -tar lib -lib net,gen_collect,cipher -opt s3 -dest ../lib/net_quic.obl
 ./obc -src lib_src/net_server.obs -tar lib -lib net,json,gen_collect,cipher -opt s3 -dest ../lib/net_server.obl
-./obc -src lib_src/web_server.obs -lib gen_collect,net -tar lib -opt s3 -dest ../lib/web_server.obl
+./obc -src lib_src/web_server.obs -lib gen_collect,net,net_server,json,cipher -tar lib -opt s3 -dest ../lib/web_server.obl
 ./obc -src lib_src/json_rpc.obs -tar lib -lib json,net -opt s3 -dest ../lib/json_rpc.obl
 ./obc -src lib_src/misc.obs -lib gen_collect,net,json -tar lib -opt s3 -dest ../lib/misc.obl
 ./obc -src lib_src/rss.obs -tar lib -lib xml,gen_collect,net,cipher -opt s3 -dest ../lib/rss.obl

--- a/core/compiler/update_version_arm.sh
+++ b/core/compiler/update_version_arm.sh
@@ -26,7 +26,7 @@ make -f make/Makefile.arm64
 ./obc -src lib_src/net_h2.obs -tar lib -lib net,gen_collect,cipher -opt s3 -dest ../lib/net_h2.obl
 ./obc -src lib_src/net_quic.obs -tar lib -lib net,gen_collect,cipher -opt s3 -dest ../lib/net_quic.obl
 ./obc -src lib_src/net_server.obs -tar lib -lib net,json,gen_collect,cipher -opt s3 -dest ../lib/net_server.obl
-./obc -src lib_src/web_server.obs -lib gen_collect,net -tar lib -opt s3 -dest ../lib/web_server.obl
+./obc -src lib_src/web_server.obs -lib gen_collect,net,net_server,json,cipher -tar lib -opt s3 -dest ../lib/web_server.obl
 ./obc -src lib_src/json_rpc.obs -tar lib -lib json,net -opt s3 -dest ../lib/json_rpc.obl
 ./obc -src lib_src/misc.obs -lib gen_collect,net,json -tar lib -opt s3 -dest ../lib/misc.obl
 ./obc -src lib_src/rss.obs -tar lib -lib xml,gen_collect,net,cipher -opt s3 -dest ../lib/rss.obl

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,7 +70,7 @@ graph TB
 
     subgraph "CI/CD"
         GHA["GitHub Actions<br/>Multi-platform Matrix"]
-        Tests["Regression Tests<br/>(204 automated)"]
+        Tests["Regression Tests<br/>(205 automated)"]
         Artifacts["Build Artifacts"]
     end
 
@@ -793,10 +793,10 @@ graph TB
 
 | Platform | Runner | Architecture | Compiler | Tests |
 |----------|--------|--------------|----------|-------|
-| **Linux** | `ubuntu-latest` | x64 | GCC | 204 regression |
-| **Linux** | `ubuntu-24.04-arm` | ARM64 | GCC | 204 regression |
-| **macOS** | `macos-15` | ARM64 (Apple silicon) | Clang | 204 regression |
-| **Windows** | `windows-2025-vs2026` | x64 | MSVC (v145) | 204 regression |
+| **Linux** | `ubuntu-latest` | x64 | GCC | 205 regression |
+| **Linux** | `ubuntu-24.04-arm` | ARM64 | GCC | 205 regression |
+| **macOS** | `macos-15` | ARM64 (Apple silicon) | Clang | 205 regression |
+| **Windows** | `windows-2025-vs2026` | x64 | MSVC (v145) | 205 regression |
 | **Windows** | `windows-2025-vs2026` | ARM64 | MSVC (v145) | build only &mdash; see below |
 
 The Windows ARM64 leg is **cross-compiled on an x64 host, so it cannot execute what it
@@ -831,13 +831,13 @@ graph LR
 
 ### Regression Test Suite
 
-204 tests under `programs/regression/`, grouped by the prefix on each filename.
+205 tests under `programs/regression/`, grouped by the prefix on each filename.
 Counts are the file count per prefix, not a sample.
 
 ```mermaid
 mindmap
     root((Regression Tests
-    204 total))
+    205 total))
         Language core (42)
             core_*
                 Arithmetic, arrays, classes, generics, strings
@@ -862,7 +862,7 @@ mindmap
         ARM64 specific (5)
             arm64_*
                 Bitwise, char arrays, 64-bit immediates, multiply
-        Networking and web (14)
+        Networking and web (15)
             http_* mcp_* xml_* json_* api_*
                 Clients, servers, serialisation
         Remainder (47)

--- a/docs/web_server_design.md
+++ b/docs/web_server_design.md
@@ -1,0 +1,153 @@
+# Web.Server: reimplementation over Web.HTTP.Server
+
+Status: design, 2026-08-30. Supersedes the native-bridge design for issue #654.
+
+## Why this exists
+
+`Web.Server` shipped as `web_server.obl` in every release and could not be used
+by anyone. Three independently fatal reasons:
+
+1. **No implementation exists.** Its 13 native entry points appear in exactly one
+   file in this repository -- `core/compiler/lib_src/web_server.obs`, the binding
+   itself. Verified with `rg --no-ignore` across the whole tree. There is no
+   `.cpp`, no build target, and no `libobjk_web_server` in any deploy, on any
+   platform.
+2. **Nothing sets `OBJECK_LIB_WEB_SERVER`**, which is the property the `DllProxy`
+   is constructed from.
+3. **`Request` and `Response` declare no constructor.** Every method reads an
+   `@request`/`@response` Int handle that only a native host can supply, so a
+   program cannot obtain an instance. Confirmed by compiling one: it fails.
+
+## Why "just write the native library" was not the fix
+
+The design is a **per-host bridge**, not a missing file. `DllProxy->New(...)`
+takes the library name from a runtime property, and the doc comment names the
+intended hosts: Nginx, IIS and Apache. The opaque Int handle is a pointer into
+whichever host owns the request, and those hosts have entirely different request
+structures (`ngx_http_request_t`, `IHttpContext`, `request_rec`).
+
+So the design requires **one bridge library per host**, each compiled against
+that host's SDK. A single generic `libobjk_web_server` is not a thing that can
+exist. That is why none was ever written.
+
+Meanwhile `Web.HTTP.Server` in `net_server.obs` already provides a complete,
+working, tested `Request`/`Response` -- params, cookies, headers, content,
+compression, forwarding, status codes -- in pure Objeck, exercised by the
+regression suite today. `Web.Server` was a strictly smaller, non-functional
+parallel API to it.
+
+## Decision
+
+Reimplement `Web.Server` in pure Objeck as an adapter over `Web.HTTP.Server`.
+
+- keeps the `Web.Server` bundle, class names and method signatures, so existing
+  source against the published API still compiles
+- deletes the native indirection entirely: no native library, no new build
+  targets, no new CI legs, no release risk
+- makes the API genuinely usable and testable end to end against real HTTP
+
+Rejected: shipping a mock native library (verifies the binding, not any
+behaviour, and still adds a native artifact to five platform legs); shipping a
+real host bridge (delivers the original intent but needs a host SDK and cannot
+be tested in CI without running the host); retiring the API outright.
+
+## Gap analysis
+
+The adapter is a delegation for most of the surface. Three methods have no data
+source in the underlying server today, established by reading the code:
+
+| Method | Source | Resolution |
+|---|---|---|
+| `GetHeader`, `ReadBody`, `SetContentType`, `WriteBody` x2, `Redirect`, `SetHeader`, `RemoveHeader`, `ClearAll` | present on `Web.HTTP.Server.Request`/`Response` | direct delegation |
+| `GetMethod` | **absent.** The verb is parsed in `ServeOne` and used to dispatch to `ProcessGet`/`ProcessPost`, but never stored: `Request` holds only the path | thread the verb into `Request` at its four construction sites, via a new overloaded constructor |
+| `GetRemoteAddress` | **available but discarded.** `@client->GetAddress()` is read at `net_server.obs:2015` only inside `if(@is_debug)`. `SockTcpAccept` (`common.cpp:4537`) sets `sock_obj[1]` to the client address and `sock_obj[2]` to the client port, so on an accepted socket these are genuinely the peer | thread into `Request` alongside the verb |
+| `GetLocalAddress` | **no source.** `TCPSocket` exposes `GetAddress()`/`GetPort()`, which on an accepted socket are the *remote* end. There is no `getsockname` accessor | see below |
+
+### GetLocalAddress
+
+The honest options are:
+
+1. add a `getsockname` trap and a `TCPSocket` accessor -- correct, but
+   `TCPSocket` lives in `lang.obs`, so it drags in the `lang.obl` bootstrap
+   asymmetry that has reddened master before. **Not during a release.**
+2. thread the bound port from `WebServer->Serve(callback, port, ...)`, which is
+   authoritative for the port but has no host part
+3. derive from the `Host` request header -- zero plumbing, but client-controlled
+   and therefore not trustworthy as the server's own identity
+
+**Chosen: 2, falling back to 3 for the host part**, and documented precisely as
+"the address this server is bound to" rather than implying a socket-level
+answer. Option 1 is the correct long-term fix and should follow as its own PR
+after the release, where a red windows-x64 leg is diagnosable in isolation.
+
+## Phases
+
+1. **Plumbing in `net_server.obs`** (additive, backward compatible): carry the
+   request verb and peer address into `Web.HTTP.Server.Request` through a new
+   overloaded constructor; existing constructors keep working unchanged. Add
+   `GetMethod()` and `GetRemoteAddress()` accessors.
+2. **Rewrite `web_server.obs`** as delegating adapters. Remove the `Proxy`
+   class, the 13 `@fn_*` name fields and every `CallFunction`. Add constructors
+   taking the underlying `Web.HTTP.Server` objects.
+3. **A handler adapter** so a `Web.Server`-style handler can be served by the
+   existing `WebServer`, making the API reachable without any new server.
+4. **Regression test** driving real HTTP through the adapter and asserting on
+   every method, replacing 0-of-13 coverage.
+5. **Docs**: update the bundle doc comment, and note the `Web.HTTP.Server`
+   relationship so the two APIs are not mistaken for competitors.
+
+## Compatibility
+
+`web_server.obl` keeps its name, bundle and method signatures. Source written
+against the published API continues to compile. Nothing that worked before
+breaks, because nothing worked before.
+
+## Release impact
+
+None by construction. No native artifact, no build-system change, no
+bootstrap-library change. Lands on its own branch and gates on its own CI.
+
+## Implementation findings
+
+Four things surfaced while building this that were not visible from reading, and
+each cost a wrong assumption first.
+
+**1. `virtual` in Objeck is a declaration, not a modifier.** `Handler.Process`
+was first written as a concrete method returning false, for subclasses to
+override. It is bound statically from `ProcessGet`, so the override never ran:
+every response came back 200 with an empty body and the handler was never
+entered. Declaring it `method : public : virtual : Process(...) ~ Bool;` with no
+body is what produces dynamic dispatch. Every assertion in the test failed until
+this changed, which is why the test asserts on values rather than on completion.
+
+**2. The server only serialises a full response for code 200.**
+`ProcessResponse` builds headers and a body under `if(response->GetCode() = 200)`
+and otherwise falls to a select that writes a bodyless status line. The
+underlying `Response` defaults to **400**, so an adapter that sets no code
+produces `400 Bad Request` with `Content-Length: 0` no matter what it wrote. The
+adapter now sets 200 in its constructor.
+
+**3. A 302 takes its `Location` from `GetReason()`, not from a header.** The 302
+branch writes `Location: {reason}` by hand and emits no application headers, so
+`SetHeader("Location", url)` is silently dropped. `Redirect` uses `SetReason`.
+
+**4. `GetHeader` does a raw lookup against lower-cased keys.** Request header
+names are stored lower-cased at parse time, so `GetHeader("Content-Type")` would
+miss. The adapter normalises.
+
+## Two pre-existing defects found, not caused by this work
+
+**A server program segfaults on exit.** Any program that starts
+`WebServer->Serve` on a thread and then returns from `Main` dies with SIGSEGV
+during teardown, with the server thread parked in `Accept`. Reproduced on
+**pristine master** with an unmodified `net_server.obs` and no `Web.Server`
+involved, 3 runs of 3. No in-tree test caught this because no test both starts
+the server and exits normally. The regression test calls `Runtime->Exit(0)` to
+avoid scoring a passing test as a crash, and the crash is filed separately.
+
+**The accepted socket class can be dropped by the linker.** `SockTcpAccept`
+allocates the client socket natively through `GetSocketObjectId()`, so there is
+no static reference for the linker to follow. A program that uses the server
+without otherwise mentioning `TCPSocket` fails at runtime with
+`unable to find class: System.IO.Net.TCPSocket` -- and in one arrangement
+crashed outright rather than reporting that. Filed with the above.

--- a/programs/regression/TESTS.md
+++ b/programs/regression/TESTS.md
@@ -13,7 +13,7 @@ python gen_manifest.py
 ```
 
 
-**Total runtime tests: 204** (plus 14 debugger tests, see below).
+**Total runtime tests: 205** (plus 14 debugger tests, see below).
 
 
 ## Tests by Category
@@ -21,7 +21,7 @@ python gen_manifest.py
 | Category | Count |
 |----------|-------|
 | Core Language | 38 |
-| Other | 28 |
+| Other | 29 |
 | AMD64/JIT | 21 |
 | Negative | 21 |
 | Bug Fix | 13 |
@@ -254,10 +254,11 @@ python gen_manifest.py
 | 198 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
 | 199 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
 | 200 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
-| 201 | `websocket_test.obs` | Networking | websocket test | ✅ |
-| 202 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
-| 203 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
-| 204 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
+| 201 | `web_server_test.obs` | Other | Web.Server end-to-end coverage. Every method on Web.Server.Request and Response used to call a na... | ✅ |
+| 202 | `websocket_test.obs` | Networking | websocket test | ✅ |
+| 203 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
+| 204 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
+| 205 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
 
 ## Debugger Tests (`run_debugger_tests.sh`)
 

--- a/programs/regression/web_server_test.obs
+++ b/programs/regression/web_server_test.obs
@@ -1,0 +1,318 @@
+#~
+# Web.Server end-to-end coverage.
+#
+# Every method on Web.Server.Request and Response used to call a native library
+# that has never existed in this repository, so the whole API was executed by
+# nothing (issue #654). It is now implemented over Web.HTTP.Server, and this
+# drives it through real HTTP on the loopback interface.
+#
+# The handler echoes what it observed back to the client, so each assertion
+# checks a value rather than merely that a request completed.
+# EXTRA_LIBS: net,net_server,web_server,gen_collect
+~#
+
+use Collection, System.Concurrency, System.IO.Net, Web.Server;
+
+class EchoHandler from Web.Server.Handler {
+	New() { Parent(); }
+
+	method : public : Process(request : Request, response : Response) ~ Bool {
+		url := request->GetRequestUrl();
+		if(url = Nil) { url := ""; };
+
+		if(url->Equals("/method")) {
+			verb := request->GetMethod();
+			if(verb = Request->Method->GET) {
+				response->WriteBody("GET");
+			}
+			else if(verb = Request->Method->POST) {
+				response->WriteBody("POST");
+			}
+			else {
+				response->WriteBody("OTHER");
+			};
+		}
+		else if(url->Equals("/url")) {
+			response->WriteBody(url);
+		}
+		else if(url->Equals("/remote")) {
+			addr := request->GetRemoteAddress();
+			if(addr = Nil) { addr := "<Nil>"; };
+			response->WriteBody(addr);
+		}
+		else if(url->Equals("/local")) {
+			addr := request->GetLocalAddress();
+			if(addr = Nil) { addr := "<Nil>"; };
+			response->WriteBody(addr);
+		}
+		else if(url->Equals("/header")) {
+			value := request->GetHeader("X-Test");
+			if(value = Nil) { value := "<Nil>"; };
+			response->WriteBody(value);
+		}
+		else if(url->Equals("/echo")) {
+			body := request->ReadBody();
+			if(body = Nil) {
+				response->WriteBody("<Nil>");
+			}
+			else {
+				response->WriteBody(String->New(body));
+			};
+		}
+		else if(url->Equals("/append")) {
+			response->WriteBody("aa");
+			response->WriteBody("bb");
+		}
+		else if(url->Equals("/bytes")) {
+			data := Byte->New[3];
+			data[0] := 'x'; data[1] := 'y'; data[2] := 'z';
+			response->WriteBody(data);
+		}
+		else if(url->Equals("/clear")) {
+			response->WriteBody("draft");
+			response->ClearAll();
+			response->WriteBody("final");
+		}
+		else if(url->Equals("/type")) {
+			response->SetContentType("application/json");
+			response->WriteBody("{}");
+		}
+		else if(url->Equals("/setheader")) {
+			response->SetHeader("X-Keep", "kept");
+			response->SetHeader("X-Drop", "dropped");
+			response->RemoveHeader("X-Drop");
+			response->WriteBody("headers");
+		}
+		else if(url->Equals("/redirect")) {
+			response->Redirect("/moved");
+		}
+		else {
+			response->WriteBody("notfound");
+		};
+
+		return false;
+	}
+}
+
+class Reply {
+	@code : Int;
+	@headers : Map<String, String>;
+	@body : String;
+
+	New(code : Int, headers : Map<String, String>, body : String) {
+		@code := code; @headers := headers; @body := body;
+	}
+
+	method : public : GetCode() ~ Int { return @code; }
+	method : public : GetBody() ~ String { return @body; }
+
+	method : public : GetHeader(name : String) ~ String {
+		return @headers->Find(name->ToLower());
+	}
+}
+
+class WebServerTest {
+	@failures : Int;
+	@port : Int;
+
+	function : Main(args : String[]) ~ Nil {
+		t := WebServerTest->New();
+		t->Run();
+	}
+
+	New() {
+		@failures := 0;
+		@port := 19881;
+	}
+
+	method : Check(what : String, got : String, expect : String) ~ Nil {
+		if(got = Nil) {
+			"FAIL: {$what}: got <Nil>, expected '{$expect}'"->PrintLine();
+			@failures += 1;
+		}
+		else if(<>got->Equals(expect)) {
+			"FAIL: {$what}: got '{$got}', expected '{$expect}'"->PrintLine();
+			@failures += 1;
+		};
+	}
+
+	method : CheckTrue(what : String, ok : Bool) ~ Nil {
+		if(<>ok) {
+			"FAIL: {$what}"->PrintLine();
+			@failures += 1;
+		};
+	}
+
+	#~
+	Raw HTTP/1.1 client. HttpClient cannot be used for most of these assertions:
+	its Response exposes only GetType, GetContent and GetCode, with no access to
+	arbitrary headers, so SetHeader, RemoveHeader and Redirect's Location would
+	be unverifiable through it.
+
+	The request deliberately does NOT send "Connection: close". The server keeps
+	the connection open, this side reads by Content-Length and then closes, so
+	the CLIENT owns the teardown -- see docs/windows_loopback_sockets.md.
+	~#
+	method : Send(verb : String, path : String, extra : String, body : String) ~ Reply {
+		port := @port;
+		sock := TCPSocket->New("127.0.0.1", port);
+		if(<>sock->IsOpen()) {
+			return Nil;
+		};
+
+		req := "{$verb} {$path} HTTP/1.1\r\nHost: 127.0.0.1:{$port}\r\n";
+		if(extra <> Nil) {
+			req += extra;
+		};
+		if(body <> Nil) {
+			len := body->Size();
+			req += "Content-Type: text/plain\r\nContent-Length: {$len}\r\n";
+		};
+		req += "\r\n";
+		if(body <> Nil) {
+			req += body;
+		};
+		sock->WriteString(req);
+
+		status := sock->ReadLine();
+		if(status = Nil | status->IsEmpty()) {
+			sock->Close();
+			return Nil;
+		};
+
+		code := 0;
+		status_parts := status->Split(" ");
+		if(status_parts->Size() > 1) {
+			code := status_parts[1]->Trim()->ToInt();
+		};
+
+		headers := Map->New()<String, String>;
+		line := sock->ReadLine();
+		while(line <> Nil & line->Size() > 0) {
+			colon := line->Find(':');
+			if(colon > 0) {
+				name := line->SubString(colon)->ToLower()->Trim();
+				value := line->SubString(colon + 1, line->Size() - colon - 1)->Trim();
+				headers->Insert(name, value);
+			};
+			line := sock->ReadLine();
+		};
+
+		content := "";
+		length_text := headers->Find("content-length");
+		if(length_text <> Nil & length_text->IsNumeric()) {
+			remaining := length_text->ToInt();
+			buffer := Byte->New[512];
+			while(remaining > 0) {
+				amount := remaining;
+				if(amount > buffer->Size()) { amount := buffer->Size(); };
+				read := sock->ReadBuffer(0, amount, buffer);
+				if(read <= 0) {
+					remaining := 0;
+				}
+				else {
+					chunk := Byte->New[read];
+					Runtime->Copy(chunk, 0, buffer, 0, read);
+					content += String->New(chunk);
+					remaining -= read;
+				};
+			};
+		};
+
+		sock->Close();
+
+		return Reply->New(code, headers, content);
+	}
+
+	method : Get(path : String) ~ Reply {
+		return Send("GET", path, Nil, Nil);
+	}
+
+	method : BodyOf(reply : Reply) ~ String {
+		if(reply = Nil) { return Nil; };
+		return reply->GetBody();
+	}
+
+	method : Run() ~ Nil {
+		port := @port;
+		server := Thread->New() {
+			New() { Parent() }
+			method : public : Run(arg : System.Base) ~ Nil {
+				Web.Server.Handler->Serve(EchoHandler->New()->GetClass(), 19881);
+			}
+		};
+		server->Execute(Nil);
+		Thread->Sleep(800);
+
+		# Request: verb, url, addresses
+		Check("GetMethod", BodyOf(Get("/method")), "GET");
+		Check("GetRequestUrl", BodyOf(Get("/url")), "/url");
+		Check("GetRemoteAddress", BodyOf(Get("/remote")), "127.0.0.1");
+		Check("GetLocalAddress", BodyOf(Get("/local")), "127.0.0.1:{$port}");
+
+		# Request: headers
+		Check("GetHeader", BodyOf(Send("GET", "/header", "X-Test: probe-value\r\n", Nil)), "probe-value");
+
+		# Request: body
+		Check("ReadBody", BodyOf(Send("POST", "/echo", Nil, "payload-42")), "payload-42");
+		Check("GetMethod POST", BodyOf(Send("POST", "/method", Nil, "x")), "POST");
+
+		# Response: append semantics
+		Check("WriteBody appends", BodyOf(Get("/append")), "aabb");
+		Check("WriteBody(Byte[])", BodyOf(Get("/bytes")), "xyz");
+		Check("ClearAll discards body", BodyOf(Get("/clear")), "final");
+
+		# Response: content type
+		type_reply := Get("/type");
+		Check("SetContentType body", BodyOf(type_reply), "{}");
+		if(type_reply <> Nil) {
+			ctype := type_reply->GetHeader("Content-Type");
+			CheckTrue("SetContentType header", ctype <> Nil & ctype->Has("application/json"));
+		}
+		else {
+			CheckTrue("SetContentType response", false);
+		};
+
+		# Response: headers
+		hdr_reply := Get("/setheader");
+		Check("SetHeader body", BodyOf(hdr_reply), "headers");
+		if(hdr_reply <> Nil) {
+			kept := hdr_reply->GetHeader("X-Keep");
+			dropped := hdr_reply->GetHeader("X-Drop");
+			CheckTrue("SetHeader kept", kept <> Nil & kept->Equals("kept"));
+			CheckTrue("RemoveHeader dropped", dropped = Nil);
+		}
+		else {
+			CheckTrue("SetHeader response", false);
+		};
+
+		# Response: redirect
+		redir := Get("/redirect");
+		if(redir <> Nil) {
+			code := redir->GetCode();
+			CheckTrue("Redirect code is 302 (got {$code})", code = 302);
+			loc := redir->GetHeader("Location");
+			CheckTrue("Redirect Location header", loc <> Nil & loc->Equals("/moved"));
+		}
+		else {
+			CheckTrue("Redirect response", false);
+		};
+
+		if(@failures > 0) {
+			"---"->PrintLine();
+			failures := @failures;
+			"{$failures} failed"->PrintLine();
+			Runtime->Exit(1);
+		};
+
+		"PASS: Web.Server request and response API verified over real HTTP"->PrintLine();
+
+		# Explicit exit. A program that starts WebServer->Serve and then returns from
+		# Main segfaults during teardown with the server thread parked in Accept.
+		# That is PRE-EXISTING on master -- reproduced with an unmodified
+		# net_server.obs and no Web.Server involved at all, 3 runs of 3 -- and is
+		# filed separately. Without this the suite would score a passing test as a
+		# crash, since it scores by exit code.
+		Runtime->Exit(0);
+	}
+}


### PR DESCRIPTION
Closes #654.

## The problem

`Web.Server` shipped as `web_server.obl` in every release and **could not be used by anyone**:

1. Its 13 native entry points appear in exactly one file in this repo — the binding itself. Verified with `rg --no-ignore`: no `.cpp`, no build target, no `libobjk_web_server` in any deploy, on any platform.
2. Nothing anywhere sets `OBJECK_LIB_WEB_SERVER`, the property the `DllProxy` is built from.
3. `Request`/`Response` declared **no constructor**, so a program could not obtain an instance. Confirmed by compiling one — it fails.

## Why "write the missing native library" wasn't the fix

The design is a **per-host bridge**, not a missing file. `DllProxy` takes the library name from a runtime property, and the doc comment names the hosts: Nginx, IIS, Apache — whose request structures (`ngx_http_request_t`, `IHttpContext`, `request_rec`) are entirely different. It needs one bridge per host, so a single generic `libobjk_web_server` **is not a thing that can exist**. That's why none was ever written.

Meanwhile `Web.HTTP.Server` already ships a complete, tested `Request`/`Response` in pure Objeck. `Web.Server` was a strictly smaller, non-functional parallel API to it.

## The change

Reimplemented as an adapter over `Web.HTTP.Server`. Same bundle, class names and method signatures. No native library, no new build target, **no new CI leg**. Full rationale in `docs/web_server_design.md`.

`net_server.obs` gains additive plumbing: the request verb and peer address were both known during dispatch and both thrown away — the verb only picked a handler method, the address was read solely under `@is_debug`. Both now reach `Request`, with the bound port, so `GetMethod`/`GetRemoteAddress`/`GetLocalAddress` have real sources.

## Four things that cost an assumption

- **`virtual` in Objeck is a declaration, not a modifier.** `Handler.Process` was first concrete, so `ProcessGet` bound it statically and subclass overrides never ran — every response came back **200 with an empty body**. All 16 assertions failed until it became a bodyless `virtual` declaration.
- **The server only serialises a full response for code 200**, and `Response` defaults to **400** — so an adapter setting no code returns `400`/`Content-Length: 0` regardless of what it wrote.
- **A 302 takes `Location` from `GetReason()`, not a header.** The non-200 path emits no application headers, so `SetHeader("Location", ...)` was silently dropped.
- **Request header names are stored lower-cased and looked up raw**, so `GetHeader("Content-Type")` missed.

## Testing

`web_server_test.obs` drives all 13 entry points over real HTTP and **asserts on values, not on completion** — the static-dispatch bug produced a well-formed 200 for every route, so a test that only checked requests succeeded would have passed against a handler that never ran.

It uses a raw HTTP client because `HttpClient`'s `Response` exposes only `GetType`, `GetContent`, `GetCode` — leaving `SetHeader`, `RemoveHeader` and `Redirect` unverifiable through it.

Coverage **0 of 13 → 13 of 13**. 5 runs of 5 green. Full suite: **202 passed / 3 skipped / 0 failed**.

## Two pre-existing defects found, filed as #681

Neither is caused by this work:

- **A program that starts `WebServer->Serve` and returns from `Main` segfaults on exit.** Reproduced on pristine master with an unmodified `net_server.obs` and no `Web.Server` involved — **3 of 3**. No in-tree test caught it because none both starts the server and exits normally. The new test calls `Runtime->Exit(0)` so the suite doesn't score a fully passing test as a crash.
- **The linker can drop `System.IO.Net.TCPSocket`**, because `SockTcpAccept` allocates it natively by class id with no static reference. Surfaces as `unable to find class`, and in one arrangement as an outright segfault.

## Build

`web_server.obl` now depends on `net_server`, so the three places that build it gain the dependency. It was already ordered after `net_server` everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)