### PR TITLE
fix(vm): don't free the program while a thread is parked in a syscall

### DIFF
--- a/core/vm/interpreter.h
+++ b/core/vm/interpreter.h
@@ -557,8 +557,14 @@ namespace Runtime {
     // true if drained, false on timeout (a worker blocked in a syscall may not
     // observe Halt; the caller proceeds anyway). Pair with HaltAllExcept.
     static bool WaitForThreadsToDrain(StackInterpreter* self, long timeout_ms) {
-      long waited_ms = 0;
-      while(waited_ms < timeout_ms) {
+      // Measure real elapsed time. Counting iterations and assuming each
+      // sleep_for(1ms) costs 1ms overshoots badly on Windows, where the default
+      // timer granularity is ~15.6ms: a nominal 2000ms budget took 20-30s of
+      // wall clock, so every program with a live thread at exit hung for half a
+      // minute before terminating.
+      const std::chrono::steady_clock::time_point deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+      while(std::chrono::steady_clock::now() < deadline) {
         size_t remaining;
 #ifdef _WIN32
         EnterCriticalSection(&intpr_threads_cs);
@@ -579,7 +585,6 @@ namespace Runtime {
           return true;
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        waited_ms++;
       }
       return false;
     }

--- a/core/vm/loader.h
+++ b/core/vm/loader.h
@@ -55,6 +55,7 @@ class Loader {
   int start_method_id;
   std::map<const std::wstring, const int> params;
   bool from_mem;
+  bool abandoned;
   
   // Bounds guard for the raw deserialization cursor. Bytecode (.obe/.obl) is
   // untrusted input; a truncated or crafted file must never drive a read past the
@@ -181,6 +182,7 @@ class Loader {
 public:
   Loader(char* b, std::vector<std::wstring> &a) {
     from_mem = true;
+    abandoned = false;
     arguments = a;
     LoadOperInstrs();
 
@@ -195,6 +197,7 @@ public:
 
   Loader(const wchar_t* arg) {
     from_mem = false;
+    abandoned = false;
     filename = arg;
     if(!::EndsWith(filename, L".obe")) {
       filename += L".obe";
@@ -208,6 +211,7 @@ public:
 
   Loader(const int argc, wchar_t** argv) {
     from_mem = false;
+    abandoned = false;
     filename = argv[1];
     if(!::EndsWith(filename, L".obe")) {
       filename += L".obe";
@@ -222,7 +226,23 @@ public:
     program = new StackProgram;
   }
 
+  // Relinquish ownership of the program image, its backing buffer and the cached
+  // instructions, so that ~Loader frees nothing.
+  //
+  // Used at process exit when the VM threads could not be drained. A thread parked
+  // in a blocking syscall (accept, recv) never observes Halt, so it is still live
+  // when Execute returns; freeing the program hands that thread a dangling
+  // StackProgram the moment anything wakes it. The leak is deliberate and bounded:
+  // the process is exiting and the OS reclaims the address space regardless.
+  void Abandon() {
+    abandoned = true;
+  }
+
   ~Loader() {
+    if(abandoned) {
+      return;
+    }
+
     if(!from_mem && alloc_buffer) {
       free(alloc_buffer);
       alloc_buffer = nullptr;

--- a/core/vm/vm.cpp
+++ b/core/vm/vm.cpp
@@ -104,7 +104,15 @@ int Execute(int argc, const char* argv[], size_t gc_threshold)
     // frees them -> use-after-free crash at exit. Halt the others (not `intpr`,
     // which is this thread) and wait briefly for them to unwind and deregister.
     Runtime::StackInterpreter::HaltAllExcept(intpr);
-    Runtime::StackInterpreter::WaitForThreadsToDrain(intpr, 2000);
+    if(!Runtime::StackInterpreter::WaitForThreadsToDrain(intpr, 2000)) {
+      // A thread did not drain -- it is parked in a blocking syscall (a server
+      // thread in accept(), a reader in recv()) where it cannot observe Halt, and
+      // it is still live. Do not free the program out from under it: anything that
+      // later wakes it -- on Windows the WSACleanup that used to run on the way
+      // out of win_main -- would send it executing against a freed StackProgram.
+      // Leak the image instead and let process teardown reclaim it.
+      loader.Abandon();
+    }
 
 #ifdef _DEBUG
     std::wcout << L"# final std::stack: pos=" << (*stack_pos) << L" #" << std::endl;

--- a/core/vm/win_main.cpp
+++ b/core/vm/win_main.cpp
@@ -179,8 +179,15 @@ static int objeck_main(const int argc, const char* argv[])
       }
     }
 
-    // release Winsock
-    WSACleanup();
+    // No WSACleanup() here. The process is exiting, so Windows reclaims every
+    // Winsock resource regardless -- but WSACleanup also unblocks threads still
+    // parked in accept()/recv(), which is precisely the wrong thing to do on the
+    // way out: such a thread wakes into VM code and runs against a program image
+    // that teardown has already released. That was the whole of issue #681 (a
+    // server started with WebServer->Serve, then a normal return from Main):
+    // 8 segfaults in 8 runs became 0 in 8 with this single call removed, and it
+    // is why the same program was always clean on Linux, which has no equivalent.
+    // Same reasoning as the getaddrinfo failure path in arch/win32/win32.cpp.
     return status;
   }
   else {

--- a/programs/regression/TESTS.md
+++ b/programs/regression/TESTS.md
@@ -13,7 +13,7 @@ python gen_manifest.py
 ```
 
 
-**Total runtime tests: 205** (plus 14 debugger tests, see below).
+**Total runtime tests: 206** (plus 14 debugger tests, see below).
 
 
 ## Tests by Category
@@ -21,7 +21,7 @@ python gen_manifest.py
 | Category | Count |
 |----------|-------|
 | Core Language | 38 |
-| Other | 29 |
+| Other | 30 |
 | AMD64/JIT | 21 |
 | Negative | 21 |
 | Bug Fix | 13 |
@@ -249,16 +249,17 @@ python gen_manifest.py
 | 193 | `string_split_ops.obs` | Strings | string split ops | ✅ |
 | 194 | `task_scope.obs` | Other | Regression for a structured-concurrency nursery (TaskScope) built purely on the existing System.C... | ✅ |
 | 195 | `tco_receiver.obs` | Other | Tail-call optimization must respect the receiver. TCO used to fire on matching class-id and metho... | ✅ |
-| 196 | `trap_array_barrier_test.obs` | Other | A String[] returned by a VM trap must survive a collection. Every trap that returns an array of o... | ✅ |
-| 197 | `trap_array_mt_barrier_test.obs` | Other | A trap-returned array must survive ANOTHER THREAD's allocation. trap_array_barrier_test.obs cover... | ✅ |
-| 198 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
-| 199 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
-| 200 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
-| 201 | `web_server_test.obs` | Other | Web.Server end-to-end coverage. Every method on Web.Server.Request and Response used to call a na... | ✅ |
-| 202 | `websocket_test.obs` | Networking | websocket test | ✅ |
-| 203 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
-| 204 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
-| 205 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
+| 196 | `thread_accept_exit_test.obs` | Other | A thread parked in accept() must not take the VM down when Main returns (#681). The shape: one th... | ✅ |
+| 197 | `trap_array_barrier_test.obs` | Other | A String[] returned by a VM trap must survive a collection. Every trap that returns an array of o... | ✅ |
+| 198 | `trap_array_mt_barrier_test.obs` | Other | A trap-returned array must survive ANOTHER THREAD's allocation. trap_array_barrier_test.obs cover... | ✅ |
+| 199 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
+| 200 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
+| 201 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
+| 202 | `web_server_test.obs` | Other | Web.Server end-to-end coverage. Every method on Web.Server.Request and Response used to call a na... | ✅ |
+| 203 | `websocket_test.obs` | Networking | websocket test | ✅ |
+| 204 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
+| 205 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
+| 206 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
 
 ## Debugger Tests (`run_debugger_tests.sh`)
 

--- a/programs/regression/thread_accept_exit_test.obs
+++ b/programs/regression/thread_accept_exit_test.obs
@@ -1,0 +1,122 @@
+#~
+# A thread parked in accept() must not take the VM down when Main returns (#681).
+#
+# The shape: one thread is blocked in a socket accept() -- the normal state of any
+# server between requests -- and Main returns normally. On Windows that used to
+# segfault during teardown, 8 runs out of 8, losing all buffered output with it.
+#
+# The mechanism, and why it is worth a test of its own rather than living inside
+# web_server_test.obs. A thread blocked in a syscall never observes Halt, so the
+# drain in vm.cpp times out and teardown frees the program image anyway. Nothing
+# had woken that thread before, so the dangling StackProgram went unnoticed --
+# until WSACleanup on the way out of win_main unblocked every parked socket call
+# process-wide and sent this thread executing against freed memory. Linux was
+# always clean for exactly one reason: it has no equivalent call, so the thread
+# stayed blocked until exit().
+#
+# That makes this a VM teardown defect, not a web-server defect. It reproduces
+# with a raw TCPSocketServer and no HTTP anywhere, which is what this test uses --
+# web_server_test.obs covers the same teardown path incidentally, through the
+# library that first exposed it.
+#
+# The assertion is the exit code. The echo below is what proves the thread really
+# is parked in accept() at the end rather than having failed early: it accepted a
+# client, served it, and looped back into Accept() with nobody left to connect.
+# Without that check a server thread that died on its first syscall would produce
+# a clean exit and a green test.
+~#
+
+use System.Concurrency, System.IO.Net;
+
+#~
+Accepts one client, echoes its line back, then loops into Accept() and parks
+there for the rest of the process -- nothing ever connects a second time.
+~#
+class ParkedAcceptServer from Thread {
+	@port : Int;
+
+	New(port : Int) {
+		Parent("parked-accept");
+		@port := port;
+	}
+
+	method : public : Run(param : System.Base) ~ Nil {
+		server := TCPSocketServer->New(@port);
+		if(server->Listen(8) = false) {
+			return;
+		};
+
+		while(true) {
+			client := server->Accept();
+			if(client = Nil) {
+				return;
+			};
+
+			line := client->ReadLine();
+			if(line <> Nil) {
+				client->WriteString("echo:{$line}\r\n");
+				client->Flush();
+			};
+			client->Close();
+		};
+	}
+}
+
+class ThreadAcceptExitTest {
+	@failures : Int;
+
+	function : Main(args : String[]) ~ Nil {
+		test := ThreadAcceptExitTest->New();
+		test->Run();
+	}
+
+	New() {
+		@failures := 0;
+	}
+
+	method : CheckTrue(label_text : String, cond : Bool) ~ Nil {
+		if(cond) {
+			"  ok: {$label_text}"->PrintLine();
+		}
+		else {
+			"  FAIL: {$label_text}"->PrintLine();
+			@failures += 1;
+		};
+	}
+
+	method : Run() ~ Nil {
+		port := 19993;
+
+		server := ParkedAcceptServer->New(port);
+		server->Execute(Nil);
+		Thread->Sleep(700);
+
+		sock := TCPSocket->New("127.0.0.1", port);
+		CheckTrue("client connected to parked-accept server", sock->IsOpen());
+
+		if(sock->IsOpen()) {
+			sock->WriteString("ping\r\n");
+			sock->Flush();
+			reply := sock->ReadLine();
+			CheckTrue("server echoed the request (thread reached Accept)",
+				reply <> Nil & reply->Equals("echo:ping"));
+			sock->Close();
+		};
+
+		# Give the server thread time to loop back into Accept() and block there.
+		Thread->Sleep(300);
+
+		if(@failures > 0) {
+			failures := @failures;
+			"{$failures} failed"->PrintLine();
+			Runtime->Exit(1);
+		};
+
+		"PASS: VM tears down cleanly with a thread parked in accept()"->PrintLine();
+
+		# Deliberately no Runtime->Exit here. Returning normally from Main, with the
+		# server thread still blocked in Accept(), IS the assertion -- that return is
+		# what used to segfault. The suite scores by exit code, so a regression of
+		# #681 shows up as a failure of this test rather than as silence.
+	}
+}

--- a/programs/regression/web_server_test.obs
+++ b/programs/regression/web_server_test.obs
@@ -307,12 +307,11 @@ class WebServerTest {
 
 		"PASS: Web.Server request and response API verified over real HTTP"->PrintLine();
 
-		# Explicit exit. A program that starts WebServer->Serve and then returns from
-		# Main segfaults during teardown with the server thread parked in Accept.
-		# That is PRE-EXISTING on master -- reproduced with an unmodified
-		# net_server.obs and no Web.Server involved at all, 3 runs of 3 -- and is
-		# filed separately. Without this the suite would score a passing test as a
-		# crash, since it scores by exit code.
-		Runtime->Exit(0);
+		# Deliberately NO Runtime->Exit(0) here: this method returns to Main and Main
+		# returns normally, with the server thread still parked in Accept. That exact
+		# shape used to segfault during teardown (#681), so the suite -- which scores
+		# by exit code -- would have recorded this passing test as a crash. Returning
+		# normally is now the assertion: it keeps the teardown path covered, so any
+		# regression of #681 turns this test red instead of going unnoticed.
 	}
 }


### PR DESCRIPTION
Closes #681.

## Not a web-server bug

#681 was filed against `Web.Server`, but it reproduces with a raw `TCPSocketServer`
and no HTTP anywhere. The only requirement is that **some thread is blocked in
`accept()` when `Main` returns** — the resting state of every server ever written.

## Mechanism

1. A thread blocked in a syscall never observes `Halt`, so `WaitForThreadsToDrain`
   times out and teardown proceeds with that thread still live.
2. `~Loader` runs anyway, `free()`ing the bytecode buffer and deleting the
   `StackProgram` out from under it.
3. Nothing had ever *woken* such a thread, so the dangling program went unnoticed —
   until `WSACleanup`, on the way out of `win_main`, unblocked every parked socket
   call in the process.
4. The woken thread returns into `SockTcpAccept` and runs against freed memory.

Step 3 is the whole of the platform difference. Linux has no equivalent call, so the
thread stays blocked until `exit()` and the identical program is clean. The
underlying lifetime bug is cross-platform; only the trigger is Windows — which is
why a clean Linux run led the issue to be scoped as "Windows-only" rather than as
the lifetime bug it is.

## Three fixes, one per link

- **`vm.cpp` / `loader.h`** — when the drain times out, `Loader::Abandon()`
  relinquishes the program image so `~Loader` frees nothing. The leak is deliberate
  and bounded: the process is exiting and the OS reclaims the address space
  regardless. This is the fix that matters — handing a live thread a dangling
  `StackProgram` to save a `free()` at exit is not a trade worth making, and
  `WSACleanup` was only one of the things that could have woken it.
- **`win_main.cpp`** — no `WSACleanup` at exit. It cannot help (Windows reclaims
  Winsock on process teardown) and it actively unblocks parked socket calls at the
  worst possible moment. Same reasoning as the `getaddrinfo` failure path in
  `arch/win32/win32.cpp`.
- **`interpreter.h`** — `WaitForThreadsToDrain` measured its timeout by counting
  iterations of `sleep_for(1ms)` as 1ms each. Windows' default timer granularity is
  ~15.6ms, so the nominal 2000ms budget really took 20–30s: **every** program with a
  live thread at exit hung for half a minute first. Measured directly, a
  2000-iteration loop took **19,308ms**. Now uses `steady_clock`.

## Verification

| | Before | After |
|---|---|---|
| Windows #681 reproducer | 8/8 segfault, ~29s | **0/8, 2.83s** |
| Linux (WSL2, Ubuntu 24.04, gcc 13.3) | clean | **5/5 clean, 3.0s** |
| Regression suite (x64) | 202 / 3 / 0 | **203 passed / 3 skipped / 0 failed** |

Causation was established by A/B: with **only** the `WSACleanup` line removed and
nothing else changed, 8/8 segfaults became 0/8.

## Two things this also settles

- **The "linker drops `TCPSocket`" report in #681 appears to be the same bug.** That
  `unable to find class: System.IO.Net.TCPSocket` error only ever appeared *after*
  `Main` returned — i.e. once `GetSocketObjectId()` was reading freed memory. It
  disappears with this change and no linker work. Worth re-checking before any is
  done.
- **`web_server_test.obs` called `Runtime->Exit(0)` purely to dodge this crash**,
  since the suite scores by exit code and would otherwise have recorded a fully
  passing test as a failure. That workaround is gone — the test now returns normally
  from `Main` with the server thread parked, so the teardown path is covered rather
  than avoided.

`thread_accept_exit_test.obs` covers the general shape with no HTTP involved. It has
teeth: **6/6 segfaults against the unfixed VM, 6/6 clean against the fixed one**, so
a regression turns it red instead of going unnoticed.

## Not in scope

`core/debugger/debugger.cpp` still calls `WSACleanup()` on three exit paths and
hosts a VM, so it may have the same exposure. Left for separate investigation rather
than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
