### PR TITLE
fix(obd): don't free the debuggee's program while a thread is parked in a syscall

### DIFF
--- a/core/debugger/debugger.cpp
+++ b/core/debugger/debugger.cpp
@@ -109,9 +109,16 @@ static int objeck_main(int argc, const char* argv[])
       std::cerr << "fatal: unhandled exception in DAP adapter: " << e.what() << std::endl;
       return 1;
     }
-#ifdef _WIN32
-    WSACleanup();
-#endif
+    // No WSACleanup() here. The process is exiting, so Windows reclaims every
+    // Winsock resource regardless -- but WSACleanup also unblocks threads still
+    // parked in accept()/recv(), and obd hosts the debuggee's VM in-process: a
+    // program debugged to completion can leave a server thread sitting in
+    // Accept() exactly as it does under obr. DapRun has already released that
+    // run's program image and heap by the time we get here, so waking such a
+    // thread sends it executing against freed memory. That is issue #681, one
+    // layer up: 8 access violations in 8 DAP sessions became 0 in 8 with this
+    // call removed. Same reasoning as win_main.cpp and the getaddrinfo failure
+    // path in arch/win32/win32.cpp.
     return 0;
   }
 
@@ -190,16 +197,16 @@ static int objeck_main(int argc, const char* argv[])
     // go debugger
     Runtime::Debugger debugger(file_name_param, base_path_param, args_param);
     debugger.Debug();
-#ifdef _WIN32
-    WSACleanup();
-#endif
-
+    // No WSACleanup() here either, for the reason given on the DAP path above.
+    // Debug() does not return today -- its command loop exits through the quit
+    // command's exit(0) -- so this was unreachable rather than harmless, and it
+    // would have been the same use-after-free the moment it stopped being.
     return 0;
   }
   else {
-#ifdef _WIN32
-    WSACleanup();
-#endif
+    // Nothing to clean up: this path never reached WSAStartup, so the
+    // WSACleanup that used to stand here was an unmatched call that could only
+    // return WSANOTINITIALISED.
     std::wcerr << usage << std::endl;
     return 1;
   }
@@ -600,6 +607,10 @@ void Runtime::Debugger::ProcessRun() {
     long start = clock();
 #endif
     interpreter = new Runtime::StackInterpreter(cur_program, this);
+    // Register it the way obr does (vm.cpp). ClearProgram's drain asks whether
+    // anything besides this interpreter is still registered, so leaving it out
+    // made one parked debuggee thread read as "nothing left running".
+    Runtime::StackInterpreter::AddThread(interpreter);
     interpreter->Execute(op_stack, stack_pos, 0, cur_program->GetInitializationMethod(), nullptr, false);
 #ifdef _TIMING
     std::wcout << L"# final stack: pos=" << (*stack_pos) << L" #" << std::endl;
@@ -3004,12 +3015,39 @@ void Runtime::Debugger::ClearBreaks() {
 }
 
 void Runtime::Debugger::ClearProgram(bool clear_loader) {
+  // Quiesce the debuggee's threads before releasing anything they run against.
+  // This method frees the bytecode image and the StackProgram, and below it
+  // frees the entire GC heap -- while a debugged program can perfectly well
+  // leave threads live when Main returns. A server parked in Accept() is the
+  // ordinary case, not an edge one. Halt the others (not `interpreter`, the one
+  // running teardown) and wait briefly for them to unwind and deregister; same
+  // hazard and same handling as obr's, in vm.cpp.
+  bool drained = true;
+  if(interpreter) {
+    Runtime::StackInterpreter::HaltAllExcept(interpreter);
+    drained = Runtime::StackInterpreter::WaitForThreadsToDrain(interpreter, 2000);
+  }
+
+  // A thread that did not drain is parked in a blocking syscall where it cannot
+  // observe Halt, and it is still live. Relinquish the program image rather than
+  // free it out from under that thread: anything that later wakes it -- a client
+  // connecting to the socket it is sitting on, or the WSACleanup that used to run
+  // on the way out of main -- would send it executing against freed memory. The
+  // leak is deliberate and bounded by the debug session.
+  if(!drained && loader) {
+    loader->Abandon();
+  }
+
   if(clear_loader && loader) {
     delete loader;
     loader = nullptr;
   }
   
   if(interpreter) {
+    // Deregister before deleting. obr builds one interpreter and keeps it to
+    // process exit; obd builds a fresh one per run, so leaving the old pointer
+    // in the registry would hand the next HaltAllExcept a dangling interpreter.
+    Runtime::StackInterpreter::RemoveThread(interpreter);
     delete interpreter;
     interpreter = nullptr;
   }
@@ -3024,7 +3062,10 @@ void Runtime::Debugger::ClearProgram(bool clear_loader) {
     stack_pos = nullptr;
   }
 
-  if(loader) {
+  // Clearing the heap is the other half of the same hazard: Clear() frees the
+  // young region and every old-generation object, and deletes the locks the VM
+  // takes on the way in. An undrained thread wakes into all three.
+  if(loader && drained) {
     MemoryManager::Clear();
   }
 
@@ -3089,6 +3130,7 @@ void Runtime::Debugger::DapRun() {
     (*stack_pos) = 0;
 
     interpreter = new Runtime::StackInterpreter(cur_program, this);
+    Runtime::StackInterpreter::AddThread(interpreter);
     interpreter->Execute(op_stack, stack_pos, 0, cur_program->GetInitializationMethod(), nullptr, false);
 
     ClearReload();

--- a/core/vm/interpreter.cpp
+++ b/core/vm/interpreter.cpp
@@ -175,7 +175,13 @@ void StackInterpreter::Execute(size_t* op_stack, size_t* stack_pos, long i, Stac
     ctx.instr = instr;
 
 #ifdef _DEBUGGER
-    debugger->ProcessInstruction(instr, ip, call_stack, (*call_stack_pos), (*stack_frame));
+    // Threads the debuggee spawns have no debugger attached (they are built by
+    // the default constructor), so this is not merely a null check -- it is the
+    // ordinary case for every thread but the one obd started the program on.
+    // Breakpoints and stepping do not reach inside those threads; they run.
+    if(debugger) {
+      debugger->ProcessInstruction(instr, ip, call_stack, (*call_stack_pos), (*stack_frame));
+    }
     DispatchResult result = instr_dispatch[instr->GetType()](ctx);
     if(result == DispatchResult::RETURN_JIT) {
       return;

--- a/core/vm/interpreter.h
+++ b/core/vm/interpreter.h
@@ -606,6 +606,10 @@ namespace Runtime {
 #endif
 
     StackInterpreter(StackFrame** c, long* cp) {
+#ifdef _DEBUGGER
+      debugger = nullptr;   // see the note in StackInterpreter()
+#endif
+
       // setup frame
       call_stack = c;
       call_stack_pos = cp;
@@ -619,6 +623,16 @@ namespace Runtime {
     }
 
     StackInterpreter() {
+#ifdef _DEBUGGER
+      // Only the Debugger constructor below attaches one; every other
+      // interpreter runs without. This has to be set rather than left
+      // indeterminate: spawned VM threads use this constructor, and Execute's
+      // per-instruction hook is a bare `debugger->` call in a _DEBUGGER build,
+      // so a garbage pointer took obd down on the first instruction of any
+      // thread a debugged program started.
+      debugger = nullptr;
+#endif
+
       // setup frame
       call_stack = new StackFrame*[CALL_STACK_SIZE];
       call_stack_pos = new long;
@@ -641,6 +655,10 @@ namespace Runtime {
 
     StackInterpreter(StackProgram* p, size_t m) {
       Initialize(p, m);
+
+#ifdef _DEBUGGER
+      debugger = nullptr;   // see the note in StackInterpreter()
+#endif
 
       // setup frame
       call_stack = new StackFrame*[CALL_STACK_SIZE];

--- a/core/vm/loader.h
+++ b/core/vm/loader.h
@@ -229,11 +229,12 @@ public:
   // Relinquish ownership of the program image, its backing buffer and the cached
   // instructions, so that ~Loader frees nothing.
   //
-  // Used at process exit when the VM threads could not be drained. A thread parked
-  // in a blocking syscall (accept, recv) never observes Halt, so it is still live
-  // when Execute returns; freeing the program hands that thread a dangling
-  // StackProgram the moment anything wakes it. The leak is deliberate and bounded:
-  // the process is exiting and the OS reclaims the address space regardless.
+  // Used when the VM threads could not be drained. A thread parked in a blocking
+  // syscall (accept, recv) never observes Halt, so it is still live when Execute
+  // returns; freeing the program hands that thread a dangling StackProgram the
+  // moment anything wakes it. The leak is deliberate and bounded: obr calls this
+  // at process exit, where the OS reclaims the address space regardless, and obd
+  // calls it per run, where it is bounded by the debug session.
   void Abandon() {
     abandoned = true;
   }

--- a/programs/regression/obd_teardown_test.py
+++ b/programs/regression/obd_teardown_test.py
@@ -27,18 +27,24 @@ Shape 1 is the one with teeth for the drain/Abandon half of the fix: dropping
 obd's exit-time WSACleanup on its own leaves it crashing, because a client
 connect wakes the thread just as well.
 
-Two things this test deliberately does NOT do, both learned from a macOS CI
-timeout:
+Three things about how the CLI shape is driven, all of them learned the hard way
+from a macOS CI failure:
 
-  - It never asks obd to read a second command. The CLI shape writes `r`, and
-    from then on only observes. obd's command loop repeats the previous command
-    on an empty read, so a readline() that returns rather than blocks on a pipe
-    (libedit, which is what -lreadline resolves to on macOS) would re-run the
-    program forever instead of quitting. The assertion does not need the quit:
-    the crash was on the wake, so "still healthy after the wake" is the property.
-  - It never reads obd's stdout on the main thread. A reader thread drains the
-    pipe, so buffering differences cannot wedge the test -- they can only make it
-    report what it saw.
+  - On POSIX it uses a pty, not a pipe. macOS showed exactly what a pipe costs:
+    obd printed its banner and then sat there, never processing the `r`, because
+    readline() does not hand back a line from a non-tty there (-lreadline
+    resolves to libedit). run_debugger_tests.sh has always driven obd's CLI
+    through `expect`, which allocates a pty, so a pipe was never the supported
+    shape on POSIX -- this test was the outlier, not obd.
+  - It never asks obd to read a second command. It sends `r` and from then on
+    only observes, then kills the process. obd's command loop repeats the
+    previous command on an empty read, so any input handling that hands back
+    an empty line would re-run the program in a loop rather than quit. The
+    assertion needs no quit anyway: the crash was on the wake, so "still healthy
+    after the wake" is the property being tested.
+  - It never reads obd's output on the main thread. A reader thread drains it,
+    so buffering differences cannot wedge the test -- they can only change what
+    it reports.
 
 Every phase is bounded and says which one it was, so a CI failure names the
 stall instead of reporting a bare timeout. Summing every budget below gives a
@@ -95,7 +101,8 @@ CLI_ITERATIONS = 3
 DAP_ITERATIONS = 2
 GLOBAL_BUDGET = 150.0
 
-RUN_BUDGET = 25.0     # program start -> its PASS line
+READY_BUDGET = 15.0   # obd start -> the end of its banner
+RUN_BUDGET = 25.0     # `r` -> the program's PASS line
 SETTLE = 3.0          # after the wake, before judging obd healthy
 DAP_REQUEST_BUDGET = 15.0
 DAP_TERM_BUDGET = 30.0
@@ -171,26 +178,63 @@ def crashed(rc):
     return rc < 0
 
 
-class Reader(threading.Thread):
-    """Drains a pipe into a buffer so no read can ever block the test."""
+class CliDriver:
+    """Runs obd's interactive CLI and drains its output into a buffer.
 
-    def __init__(self, stream):
-        threading.Thread.__init__(self)
-        self.daemon = True
-        self.stream = stream
+    On POSIX this has to be a pty, not a pipe. obd reads commands through
+    readline(), which does not hand a line back from a non-tty on macOS, where
+    -lreadline resolves to libedit -- obd printed its banner and then sat there,
+    never processing the `r`. A pipe was never the supported shape:
+    run_debugger_tests.sh has always driven obd's CLI through `expect`, which
+    allocates a pty, on every POSIX platform. Windows has no pty and reads via
+    std::getline, where a pipe is fine.
+
+    Reading happens on a thread so a blocked or buffered read can never wedge the
+    test -- it can only change what gets reported.
+    """
+
+    def __init__(self, argv, env):
         self.buf = b""
         self.lock = threading.Lock()
+        self.master = None
 
-    def run(self):
+        if os.name == "nt":
+            self.proc = subprocess.Popen(
+                argv, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT, env=env, bufsize=0)
+        else:
+            import pty
+            self.master, slave = pty.openpty()
+            self.proc = subprocess.Popen(
+                argv, stdin=slave, stdout=slave, stderr=slave, env=env,
+                close_fds=True)
+            os.close(slave)
+
+        threading.Thread(target=self._read_loop, daemon=True).start()
+
+    def _read_loop(self):
         while True:
             try:
-                chunk = self.stream.read(1)
+                if self.master is None:
+                    chunk = self.proc.stdout.read(1)
+                else:
+                    chunk = os.read(self.master, 4096)
             except (OSError, ValueError):
-                return
+                return          # EIO on the master once the child is gone
             if not chunk:
                 return
             with self.lock:
                 self.buf += chunk
+
+    def send(self, data):
+        try:
+            if self.master is None:
+                self.proc.stdin.write(data)
+                self.proc.stdin.flush()
+            else:
+                os.write(self.master, data)
+        except OSError:
+            pass
 
     def text(self):
         with self.lock:
@@ -204,6 +248,40 @@ class Reader(threading.Thread):
                     return True
             time.sleep(0.05)
         return False
+
+    def close(self):
+        try:
+            self.proc.kill()
+            self.proc.wait(timeout=10)
+        except Exception:
+            pass
+        if self.master is not None:
+            try:
+                os.close(self.master)
+            except OSError:
+                pass
+
+
+def wait_port_free(timeout=20.0):
+    """Wait until nothing is listening on PORT.
+
+    The fixture binds one fixed port, and each iteration starts a fresh obd while
+    the previous one's listener may not be fully gone. If it is not, the
+    program's Listen() fails, it never reaches the parked-accept state, and the
+    iteration burns RUN_BUDGET before reporting a failure that is about the port
+    rather than about the defect -- which is exactly what one 65s run showed
+    against a *fixed* build. A false failure is worse than a missed detection, so
+    wait for the port instead of racing it.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            probe = socket.create_connection(("127.0.0.1", PORT), timeout=0.5)
+            probe.close()
+        except OSError:
+            return True         # refused: nothing is listening
+        time.sleep(0.3)
+    return False
 
 
 def wake_parked_thread():
@@ -241,26 +319,30 @@ for i in range(CLI_ITERATIONS):
               + " further CLI run(s): global budget spent")
         break
 
-    proc = subprocess.Popen(
-        [OBD, "-bin", PROG, "-src", SCRIPT_DIR],
-        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-        env=child_env(), bufsize=0)
-    reader = Reader(proc.stdout)
-    reader.start()
+    if not wait_port_free():
+        skipped += 1
+        print("  [SKIP] " + label.rstrip(": ")
+              + ": port " + str(PORT) + " never freed by the previous run")
+        continue
 
-    try:
-        proc.stdin.write(b"r\n")
-        proc.stdin.flush()
-    except OSError:
-        pass
+    cli = CliDriver([OBD, "-bin", PROG, "-src", SCRIPT_DIR], child_env())
+
+    # Wait until obd has finished loading before sending, so the command cannot
+    # land before the command loop is reading. Deliberately NOT the "> " prompt:
+    # readline writes that to the terminal itself and it never reaches the pty
+    # master, so waiting on it only ever burns the full budget -- measured at
+    # ~13s of dead time per iteration. The last banner line does arrive.
+    cli.saw(b"source file path:", READY_BUDGET)
+    time.sleep(0.5)
+    cli.send(b"r\n")
 
     # The program's own PASS line is what proves the fixture really got a thread
     # parked in Accept() rather than dying on its first syscall -- without it a
     # clean result would be meaningless.
-    ran = reader.saw(b"PASS", RUN_BUDGET)
+    ran = cli.saw(b"PASS", RUN_BUDGET)
     check(label + "program reached the parked-accept state", ran,
           "no PASS within " + str(RUN_BUDGET) + "s; output so far: "
-          + repr(reader.text()[-300:]))
+          + repr(cli.text()[-300:]))
 
     # obd is now back at its prompt with the run's image and heap released.
     woke = wake_parked_thread() if ran else False
@@ -271,17 +353,13 @@ for i in range(CLI_ITERATIONS):
     # sitting at its prompt (None) or have exited cleanly -- never dead of a
     # signal or an access violation.
     time.sleep(SETTLE)
-    rc = proc.poll()
+    rc = cli.proc.poll()
     check(label + "obd survived the wake", not crashed(rc),
           "obd died abnormally: " + describe(rc) + "; output: "
-          + repr(reader.text()[-300:]))
+          + repr(cli.text()[-300:]))
 
-    # Deliberately kill rather than send `q`: see the module docstring.
-    try:
-        proc.kill()
-        proc.wait(timeout=10)
-    except Exception:
-        pass
+    # Deliberately killed rather than sent `q`: see the module docstring.
+    cli.close()
 
 
 # ============================================================
@@ -362,6 +440,12 @@ for i in range(DAP_ITERATIONS):
               + " further DAP run(s): global budget spent")
         break
 
+    if not wait_port_free():
+        skipped += 1
+        print("  [SKIP] " + label.rstrip(": ")
+              + ": port " + str(PORT) + " never freed by the previous run")
+        continue
+
     session = DapSession()
     session.request("launch", {"program": PROG, "sourceDir": SCRIPT_DIR},
                     timeout=DAP_REQUEST_BUDGET)
@@ -384,6 +468,11 @@ for i in range(DAP_ITERATIONS):
     check(label + "obd exited cleanly on disconnect", not crashed(rc),
           "obd died abnormally: " + describe(rc))
 
+
+# All-skipped would otherwise be 0 passed / 0 failed, i.e. a green no-op.
+if passed == 0 and failed == 0:
+    failed += 1
+    print("  [FAIL] no iteration of either shape actually ran")
 
 summary = "  obd_teardown_test: " + str(passed) + " passed, " + str(failed) + " failed"
 if skipped:

--- a/programs/regression/obd_teardown_test.py
+++ b/programs/regression/obd_teardown_test.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""obd must not free the debuggee's program image while one of its threads is
+parked in a syscall.
+
+This is issue #681 one layer up. obd hosts the same VM as obr, so a debugged
+program can leave threads live when Main returns -- a server sitting in Accept()
+is the ordinary resting state, not an edge case -- and obd's ClearProgram frees
+the bytecode image, the StackProgram, and the entire GC heap
+(MemoryManager::Clear releases the young region, every old-generation object,
+and the locks the VM takes on the way in). Whatever wakes that thread next runs
+it against all three.
+
+Two shapes, because they fail for different reasons and fixing one does not
+imply the other:
+
+  1. CLI: run the program, then -- with obd still sitting at its prompt and the
+     run already torn down -- connect a client to the port the parked thread is
+     on. The wake source here is an ordinary TCP connection, so this shape is
+     not Windows-specific and no WSACleanup is involved. 6 access violations in
+     6 runs before the fix.
+
+  2. DAP: run to completion, then disconnect. Here the waker was the WSACleanup
+     on the way out of main, exactly as in #681. 8 in 8 before the fix.
+
+Shape 1 is the one with teeth for the drain/Abandon half of the fix: dropping
+obd's exit-time WSACleanup on its own leaves it crashing, because a client
+connect wakes the thread just as well.
+
+Driven by run_dap_tests.py, which passes DAP_TEST_DEPLOY_DIR.
+"""
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, "..", ".."))
+PLATFORM = os.environ.get("DAP_TEST_PLATFORM", "x64")
+
+DEPLOY_DIR = None
+for candidate in [
+    os.path.abspath(p) for p in [os.environ.get("DAP_TEST_DEPLOY_DIR")] if p
+] + [
+    os.path.join(REPO_ROOT, "core", "release", "deploy-" + PLATFORM),
+    os.path.join(REPO_ROOT, "core", "release", "deploy"),
+]:
+    if os.path.isdir(candidate):
+        DEPLOY_DIR = candidate
+        break
+if DEPLOY_DIR is None:
+    print("ERROR: could not find deploy directory under core/release/", file=sys.stderr)
+    sys.exit(2)
+
+EXE = ".exe" if os.name == "nt" else ""
+BIN_DIR = os.path.join(DEPLOY_DIR, "bin")
+OBD = os.path.join(BIN_DIR, "obd" + EXE)
+LIB_PATH = os.path.join(DEPLOY_DIR, "lib")
+
+# The fixture is the VM-side #681 reproducer, reused rather than duplicated: the
+# defect and the program shape are the same, only the host differs.
+PROG = os.path.join(SCRIPT_DIR, "thread_accept_exit_test.obe")
+PORT = 19993          # the port ParkedAcceptServer listens on
+ITERATIONS = 2
+
+if not os.path.exists(PROG):
+    print("ERROR: " + PROG + " not found - run_dap_tests.py builds it first", file=sys.stderr)
+    sys.exit(2)
+
+passed = 0
+failed = 0
+
+
+def check(name, ok, detail=""):
+    global passed, failed
+    if ok:
+        passed += 1
+        print("  [PASS] " + name)
+    else:
+        failed += 1
+        print("  [FAIL] " + name + ": " + str(detail))
+
+
+def child_env():
+    env = dict(os.environ)
+    env["OBJECK_LIB_PATH"] = LIB_PATH + os.sep
+    native = os.path.join(LIB_PATH, "native")
+    if sys.platform == "darwin":
+        env["DYLD_LIBRARY_PATH"] = native + os.pathsep + env.get("DYLD_LIBRARY_PATH", "")
+    elif os.name != "nt":
+        env["LD_LIBRARY_PATH"] = native + os.pathsep + env.get("LD_LIBRARY_PATH", "")
+    return env
+
+
+def describe(rc):
+    """Name the exit code, so a failure reads as 'segfault' rather than a number."""
+    if rc == 0:
+        return "0"
+    if not isinstance(rc, int):
+        return str(rc)
+    if os.name == "nt":
+        return str(rc) + " (" + hex(rc & 0xFFFFFFFF) + ")"
+    if rc < 0:
+        return "signal " + str(-rc)
+    return str(rc)
+
+
+def wake_parked_thread():
+    """Connect to the port the debuggee's thread is parked on, unblocking its
+    accept(). Returns True if the connection was made."""
+    for _ in range(4):
+        try:
+            sock = socket.create_connection(("127.0.0.1", PORT), timeout=2.0)
+            try:
+                sock.sendall(b"ping\r\n")
+                sock.settimeout(1.0)
+                try:
+                    sock.recv(64)
+                except OSError:
+                    pass          # a halted thread answers nothing; that is fine
+            finally:
+                sock.close()
+            return True
+        except OSError:
+            time.sleep(0.3)
+    return False
+
+
+# ============================================================
+# Shape 1: CLI -- wake the parked thread after the run is torn down
+# ============================================================
+print("obd teardown with a thread parked in accept():")
+
+for i in range(ITERATIONS):
+    proc = subprocess.Popen(
+        [OBD, "-bin", PROG, "-src", SCRIPT_DIR],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        env=child_env(), bufsize=0)
+    proc.stdin.write(b"r\n")
+    proc.stdin.flush()
+
+    # Read until the program's own PASS line: that is what proves the fixture
+    # really got a thread parked in Accept() rather than dying on its first
+    # syscall, which would make a clean exit meaningless.
+    out = b""
+    deadline = time.time() + 90
+    while b"PASS" not in out and time.time() < deadline and proc.poll() is None:
+        char = proc.stdout.read(1)
+        if not char:
+            break
+        out += char
+    ran = b"PASS" in out
+
+    woke = wake_parked_thread() if ran else False
+    time.sleep(0.5)
+
+    try:
+        proc.stdin.write(b"q\n")
+        proc.stdin.flush()
+    except OSError:
+        pass
+    try:
+        rc = proc.wait(timeout=60)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        rc = "timeout"
+
+    label = "CLI run " + str(i + 1) + ": "
+    check(label + "program reached the parked-accept state", ran,
+          out.decode("utf-8", "replace")[-300:])
+    check(label + "client woke the parked thread", woke,
+          "nothing was listening on " + str(PORT))
+    check(label + "obd exited cleanly after the wake", rc == 0,
+          "exit " + describe(rc))
+
+
+# ============================================================
+# Shape 2: DAP -- run to completion, then end the session
+# ============================================================
+class DapSession:
+    """One obd --dap session."""
+
+    def __init__(self):
+        self.proc = subprocess.Popen(
+            [OBD, "--dap"], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL, env=child_env(), bufsize=0)
+        self.events = []
+        self.lock = threading.Lock()
+        self.seq = 1
+        threading.Thread(target=self._reader, daemon=True).start()
+        self.request("initialize", {"adapterID": "objeck"})
+
+    def _read_msg(self):
+        header = b""
+        while not header.endswith(b"\r\n\r\n"):
+            char = self.proc.stdout.read(1)
+            if not char:
+                return None
+            header += char
+        length = int(header.decode().split("Content-Length: ")[1].split("\r\n")[0])
+        return json.loads(self.proc.stdout.read(length).decode("utf-8"))
+
+    def _reader(self):
+        while True:
+            msg = self._read_msg()
+            if msg is None:
+                return
+            with self.lock:
+                self.events.append(msg)
+
+    def send(self, command, args=None):
+        msg = {"seq": self.seq, "type": "request", "command": command}
+        self.seq += 1
+        if args is not None:
+            msg["arguments"] = args
+        body = json.dumps(msg).encode()
+        try:
+            self.proc.stdin.write(b"Content-Length: " + str(len(body)).encode() + b"\r\n\r\n" + body)
+            self.proc.stdin.flush()
+        except OSError:
+            pass
+
+    def wait_for(self, predicate, timeout=90.0):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            with self.lock:
+                for msg in self.events:
+                    if predicate(msg):
+                        return msg
+            time.sleep(0.05)
+        return None
+
+    def request(self, command, args=None, timeout=90.0):
+        self.send(command, args)
+        return self.wait_for(
+            lambda m: m.get("command") == command and m.get("type") == "response", timeout)
+
+    def program_output(self):
+        with self.lock:
+            return "".join(m.get("body", {}).get("output", "")
+                           for m in self.events if m.get("event") == "output")
+
+
+for i in range(ITERATIONS):
+    session = DapSession()
+    session.request("launch", {"program": PROG, "sourceDir": SCRIPT_DIR})
+    session.request("configurationDone")
+    session.wait_for(lambda m: m.get("event") == "terminated", timeout=120.0)
+    ran = "PASS" in session.program_output()
+
+    session.send("disconnect")
+    session.wait_for(
+        lambda m: m.get("command") == "disconnect" and m.get("type") == "response",
+        timeout=30.0)
+    try:
+        rc = session.proc.wait(timeout=60)
+    except subprocess.TimeoutExpired:
+        session.proc.kill()
+        rc = "timeout"
+
+    label = "DAP run " + str(i + 1) + ": "
+    check(label + "program reached the parked-accept state", ran,
+          session.program_output()[-300:])
+    check(label + "obd exited cleanly on disconnect", rc == 0,
+          "exit " + describe(rc))
+
+
+print("\n  obd_teardown_test: " + str(passed) + " passed, " + str(failed) + " failed")
+sys.exit(1 if failed else 0)

--- a/programs/regression/obd_teardown_test.py
+++ b/programs/regression/obd_teardown_test.py
@@ -17,14 +17,35 @@ imply the other:
      run already torn down -- connect a client to the port the parked thread is
      on. The wake source here is an ordinary TCP connection, so this shape is
      not Windows-specific and no WSACleanup is involved. 6 access violations in
-     6 runs before the fix.
+     6 runs on Windows, 2 in 2 on Linux, before the fix.
 
   2. DAP: run to completion, then disconnect. Here the waker was the WSACleanup
-     on the way out of main, exactly as in #681. 8 in 8 before the fix.
+     on the way out of main, exactly as in #681. 8 in 8 on Windows before the
+     fix; Linux was always clean, having no equivalent call.
 
 Shape 1 is the one with teeth for the drain/Abandon half of the fix: dropping
 obd's exit-time WSACleanup on its own leaves it crashing, because a client
 connect wakes the thread just as well.
+
+Two things this test deliberately does NOT do, both learned from a macOS CI
+timeout:
+
+  - It never asks obd to read a second command. The CLI shape writes `r`, and
+    from then on only observes. obd's command loop repeats the previous command
+    on an empty read, so a readline() that returns rather than blocks on a pipe
+    (libedit, which is what -lreadline resolves to on macOS) would re-run the
+    program forever instead of quitting. The assertion does not need the quit:
+    the crash was on the wake, so "still healthy after the wake" is the property.
+  - It never reads obd's stdout on the main thread. A reader thread drains the
+    pipe, so buffering differences cannot wedge the test -- they can only make it
+    report what it saw.
+
+Every phase is bounded and says which one it was, so a CI failure names the
+stall instead of reporting a bare timeout. Summing every budget below gives a
+worst case of ~190s, inside the 300s the runners allow; a healthy run takes
+about 18s. The first version of this test could exceed 300s on its own
+arithmetic, which is how it managed to report nothing at all when macOS
+wedged it.
 
 Driven by run_dap_tests.py, which passes DAP_TEST_DEPLOY_DIR.
 """
@@ -63,7 +84,23 @@ LIB_PATH = os.path.join(DEPLOY_DIR, "lib")
 # defect and the program shape are the same, only the host differs.
 PROG = os.path.join(SCRIPT_DIR, "thread_accept_exit_test.obe")
 PORT = 19993          # the port ParkedAcceptServer listens on
-ITERATIONS = 2
+
+# The crash races teardown, so a single iteration can miss it -- against a build
+# with the fix reverted these report between one and three failures, and not
+# always the same ones. More iterations means more chances to catch a regression.
+# They are cheap (about 6s each) but their worst cases are not, so rather than
+# pick a count that is only safe in the worst case, stop starting new ones once
+# the global budget is spent. A healthy run gets through all of them in ~30s.
+CLI_ITERATIONS = 3
+DAP_ITERATIONS = 2
+GLOBAL_BUDGET = 150.0
+
+RUN_BUDGET = 25.0     # program start -> its PASS line
+SETTLE = 3.0          # after the wake, before judging obd healthy
+DAP_REQUEST_BUDGET = 15.0
+DAP_TERM_BUDGET = 30.0
+DAP_DISCONNECT_BUDGET = 8.0
+DAP_EXIT_BUDGET = 15.0
 
 if not os.path.exists(PROG):
     print("ERROR: " + PROG + " not found - run_dap_tests.py builds it first", file=sys.stderr)
@@ -71,6 +108,12 @@ if not os.path.exists(PROG):
 
 passed = 0
 failed = 0
+skipped = 0
+started_at = time.time()
+
+
+def budget_spent():
+    return time.time() - started_at > GLOBAL_BUDGET
 
 
 def check(name, ok, detail=""):
@@ -95,7 +138,9 @@ def child_env():
 
 
 def describe(rc):
-    """Name the exit code, so a failure reads as 'segfault' rather than a number."""
+    """Name the exit status, so a failure reads as 'segfault' rather than a number."""
+    if rc is None:
+        return "still running"
     if rc == 0:
         return "0"
     if not isinstance(rc, int):
@@ -105,6 +150,60 @@ def describe(rc):
     if rc < 0:
         return "signal " + str(-rc)
     return str(rc)
+
+
+def crashed(rc):
+    """Did obd die abnormally?
+
+    Specifically abnormally, not merely non-zero. The debuggee can set obd's exit
+    code itself -- thread_accept_exit_test calls Runtime->Exit(1) when its own
+    assertions fail, which happens for ordinary reasons such as the port being
+    busy -- and that is a fixture problem, not the use-after-free under test. So
+    match what a crash actually looks like: killed by a signal on POSIX, an
+    NTSTATUS-range code (0xC0000005 and friends) on Windows.
+
+    None means obd is still sitting at its prompt, which is a healthy outcome for
+    the CLI shape."""
+    if rc is None or rc == 0:
+        return False
+    if os.name == "nt":
+        return (rc & 0xFFFFFFFF) >= 0xC0000000
+    return rc < 0
+
+
+class Reader(threading.Thread):
+    """Drains a pipe into a buffer so no read can ever block the test."""
+
+    def __init__(self, stream):
+        threading.Thread.__init__(self)
+        self.daemon = True
+        self.stream = stream
+        self.buf = b""
+        self.lock = threading.Lock()
+
+    def run(self):
+        while True:
+            try:
+                chunk = self.stream.read(1)
+            except (OSError, ValueError):
+                return
+            if not chunk:
+                return
+            with self.lock:
+                self.buf += chunk
+
+    def text(self):
+        with self.lock:
+            return self.buf.decode("utf-8", "replace")
+
+    def saw(self, needle, timeout):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            with self.lock:
+                if needle in self.buf:
+                    return True
+            time.sleep(0.05)
+        return False
 
 
 def wake_parked_thread():
@@ -133,47 +232,56 @@ def wake_parked_thread():
 # ============================================================
 print("obd teardown with a thread parked in accept():")
 
-for i in range(ITERATIONS):
+for i in range(CLI_ITERATIONS):
+    label = "CLI run " + str(i + 1) + ": "
+    # Always run the first; drop later ones rather than risk the runner's cap.
+    if i > 0 and budget_spent():
+        skipped += CLI_ITERATIONS - i
+        print("  [SKIP] " + str(CLI_ITERATIONS - i)
+              + " further CLI run(s): global budget spent")
+        break
+
     proc = subprocess.Popen(
         [OBD, "-bin", PROG, "-src", SCRIPT_DIR],
         stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
         env=child_env(), bufsize=0)
-    proc.stdin.write(b"r\n")
-    proc.stdin.flush()
-
-    # Read until the program's own PASS line: that is what proves the fixture
-    # really got a thread parked in Accept() rather than dying on its first
-    # syscall, which would make a clean exit meaningless.
-    out = b""
-    deadline = time.time() + 90
-    while b"PASS" not in out and time.time() < deadline and proc.poll() is None:
-        char = proc.stdout.read(1)
-        if not char:
-            break
-        out += char
-    ran = b"PASS" in out
-
-    woke = wake_parked_thread() if ran else False
-    time.sleep(0.5)
+    reader = Reader(proc.stdout)
+    reader.start()
 
     try:
-        proc.stdin.write(b"q\n")
+        proc.stdin.write(b"r\n")
         proc.stdin.flush()
     except OSError:
         pass
-    try:
-        rc = proc.wait(timeout=60)
-    except subprocess.TimeoutExpired:
-        proc.kill()
-        rc = "timeout"
 
-    label = "CLI run " + str(i + 1) + ": "
+    # The program's own PASS line is what proves the fixture really got a thread
+    # parked in Accept() rather than dying on its first syscall -- without it a
+    # clean result would be meaningless.
+    ran = reader.saw(b"PASS", RUN_BUDGET)
     check(label + "program reached the parked-accept state", ran,
-          out.decode("utf-8", "replace")[-300:])
+          "no PASS within " + str(RUN_BUDGET) + "s; output so far: "
+          + repr(reader.text()[-300:]))
+
+    # obd is now back at its prompt with the run's image and heap released.
+    woke = wake_parked_thread() if ran else False
     check(label + "client woke the parked thread", woke,
           "nothing was listening on " + str(PORT))
-    check(label + "obd exited cleanly after the wake", rc == 0,
-          "exit " + describe(rc))
+
+    # The crash was on the wake, so this is the assertion. obd should either be
+    # sitting at its prompt (None) or have exited cleanly -- never dead of a
+    # signal or an access violation.
+    time.sleep(SETTLE)
+    rc = proc.poll()
+    check(label + "obd survived the wake", not crashed(rc),
+          "obd died abnormally: " + describe(rc) + "; output: "
+          + repr(reader.text()[-300:]))
+
+    # Deliberately kill rather than send `q`: see the module docstring.
+    try:
+        proc.kill()
+        proc.wait(timeout=10)
+    except Exception:
+        pass
 
 
 # ============================================================
@@ -190,7 +298,7 @@ class DapSession:
         self.lock = threading.Lock()
         self.seq = 1
         threading.Thread(target=self._reader, daemon=True).start()
-        self.request("initialize", {"adapterID": "objeck"})
+        self.request("initialize", {"adapterID": "objeck"}, timeout=DAP_REQUEST_BUDGET)
 
     def _read_msg(self):
         header = b""
@@ -204,7 +312,10 @@ class DapSession:
 
     def _reader(self):
         while True:
-            msg = self._read_msg()
+            try:
+                msg = self._read_msg()
+            except Exception:
+                return
             if msg is None:
                 return
             with self.lock:
@@ -222,7 +333,7 @@ class DapSession:
         except OSError:
             pass
 
-    def wait_for(self, predicate, timeout=90.0):
+    def wait_for(self, predicate, timeout):
         deadline = time.time() + timeout
         while time.time() < deadline:
             with self.lock:
@@ -232,7 +343,7 @@ class DapSession:
             time.sleep(0.05)
         return None
 
-    def request(self, command, args=None, timeout=90.0):
+    def request(self, command, args=None, timeout=DAP_REQUEST_BUDGET):
         self.send(command, args)
         return self.wait_for(
             lambda m: m.get("command") == command and m.get("type") == "response", timeout)
@@ -243,29 +354,39 @@ class DapSession:
                            for m in self.events if m.get("event") == "output")
 
 
-for i in range(ITERATIONS):
+for i in range(DAP_ITERATIONS):
+    label = "DAP run " + str(i + 1) + ": "
+    if i > 0 and budget_spent():
+        skipped += DAP_ITERATIONS - i
+        print("  [SKIP] " + str(DAP_ITERATIONS - i)
+              + " further DAP run(s): global budget spent")
+        break
+
     session = DapSession()
-    session.request("launch", {"program": PROG, "sourceDir": SCRIPT_DIR})
-    session.request("configurationDone")
-    session.wait_for(lambda m: m.get("event") == "terminated", timeout=120.0)
+    session.request("launch", {"program": PROG, "sourceDir": SCRIPT_DIR},
+                    timeout=DAP_REQUEST_BUDGET)
+    session.request("configurationDone", timeout=DAP_REQUEST_BUDGET)
+    session.wait_for(lambda m: m.get("event") == "terminated", timeout=DAP_TERM_BUDGET)
     ran = "PASS" in session.program_output()
+    check(label + "program reached the parked-accept state", ran,
+          "no PASS within " + str(DAP_TERM_BUDGET) + "s; output: "
+          + repr(session.program_output()[-300:]))
 
     session.send("disconnect")
     session.wait_for(
         lambda m: m.get("command") == "disconnect" and m.get("type") == "response",
-        timeout=30.0)
+        timeout=DAP_DISCONNECT_BUDGET)
     try:
-        rc = session.proc.wait(timeout=60)
+        rc = session.proc.wait(timeout=DAP_EXIT_BUDGET)
     except subprocess.TimeoutExpired:
         session.proc.kill()
-        rc = "timeout"
-
-    label = "DAP run " + str(i + 1) + ": "
-    check(label + "program reached the parked-accept state", ran,
-          session.program_output()[-300:])
-    check(label + "obd exited cleanly on disconnect", rc == 0,
-          "exit " + describe(rc))
+        rc = None       # never exited; not a crash, so not this test's failure
+    check(label + "obd exited cleanly on disconnect", not crashed(rc),
+          "obd died abnormally: " + describe(rc))
 
 
-print("\n  obd_teardown_test: " + str(passed) + " passed, " + str(failed) + " failed")
+summary = "  obd_teardown_test: " + str(passed) + " passed, " + str(failed) + " failed"
+if skipped:
+    summary += ", " + str(skipped) + " iteration(s) skipped on time"
+print("\n" + summary + " (%.0fs)" % (time.time() - started_at))
 sys.exit(1 if failed else 0)

--- a/programs/regression/run_dap_tests.py
+++ b/programs/regression/run_dap_tests.py
@@ -285,7 +285,10 @@ def run_standalone_tests(bin_dir):
     obc = os.path.join(bin_dir, "obc" + exe)
     for src_name, libs in (("debugger_test.obs", None),
                            ("dap_drilldown_test.obs", "gen_collect"),
-                           ("dap_databreak_test.obs", None)):
+                           ("dap_databreak_test.obs", None),
+                           # obd_teardown_test.py debugs the VM-side #681
+                           # reproducer rather than a fixture of its own.
+                           ("thread_accept_exit_test.obs", None)):
         src = os.path.join(REG_DIR, src_name)
         if not os.path.exists(src):
             continue
@@ -298,7 +301,8 @@ def run_standalone_tests(bin_dir):
     # shell runner -- add it back once that is fixed.
     for name in ("dap_print_test.py", "dap_stepin_test.py",
                  "dap_stepout_types_test.py", "dap_drilldown_test.py",
-                 "dap_protocol_test.py", "dap_databreak_test.py"):
+                 "dap_protocol_test.py", "dap_databreak_test.py",
+                 "obd_teardown_test.py"):
         path = os.path.join(REG_DIR, name)
         if not os.path.exists(path):
             continue
@@ -353,7 +357,7 @@ def main():
     print("\nException breakpoints:")
     run_exception_breakpoint(obd, exc_obe, REG_DIR, bin_dir)
     print("")
-    print("Standalone suites (drill-down, protocol, data breakpoints):")
+    print("Standalone suites (drill-down, protocol, data breakpoints, teardown):")
     run_standalone_tests(bin_dir)
 
     for f in (core_obe, exc_obe):

--- a/programs/regression/run_dap_tests.sh
+++ b/programs/regression/run_dap_tests.sh
@@ -96,6 +96,22 @@ cd "$REGRESSION_DIR"
 echo "  Compiled successfully."
 echo ""
 
+# Teardown fixture: parks a thread in accept() and returns from Main, the shape
+# obd_teardown_test.py debugs. Shared with the VM-side #681 regression test.
+TEARDOWN_SRC="thread_accept_exit_test.obs"
+TEARDOWN_BIN="${REGRESSION_DIR}/thread_accept_exit_test.obe"
+
+echo "Compiling obd teardown test program..."
+cd "${DEPLOY_DIR}/bin"
+"$ABS_COMPILER" -src "${REGRESSION_DIR}/${TEARDOWN_SRC}" -dest "$TEARDOWN_BIN" -debug 2>&1 | tee "${REGRESSION_DIR}/${RESULTS_DIR}/obd_teardown_compile.log" > /dev/null
+if [ ${PIPESTATUS[0]} -ne 0 ]; then
+    echo "  [FAIL] Compilation error"
+    exit 1
+fi
+cd "$REGRESSION_DIR"
+echo "  Compiled successfully."
+echo ""
+
 # ============================================
 # Helper: send a DAP message to stdin
 # ============================================
@@ -272,7 +288,7 @@ if [ -n "$PYTHON_BIN" ]; then
     # NOTE: dap_instance_var_test.py is deliberately not listed -- its
     # breakpoint inside Counter::Increment() verifies but never fires, which
     # predates the drill-down work. Add it back once that is fixed.
-    for py_test in dap_print_test.py dap_stepin_test.py dap_stepout_types_test.py dap_drilldown_test.py dap_protocol_test.py dap_databreak_test.py; do
+    for py_test in dap_print_test.py dap_stepin_test.py dap_stepout_types_test.py dap_drilldown_test.py dap_protocol_test.py dap_databreak_test.py obd_teardown_test.py; do
         if [ -f "$REGRESSION_DIR/$py_test" ]; then
             echo -n "Running: ${py_test%.py}..."
             if "$PYTHON_BIN" "$REGRESSION_DIR/$py_test" > "${RESULTS_DIR}/${py_test%.py}.log" 2>&1; then


### PR DESCRIPTION
Follow-on to #683. The same lifetime defect was already sitting in obd, which hosts the debuggee's VM in-process — and there it is **not** Windows-only.

## What obd was doing

`Debugger::ClearProgram` runs after every single run (via `ClearReload`) and:

- deletes the `Loader`, freeing the bytecode buffer and the `StackProgram`;
- calls `MemoryManager::Clear()`, which frees the young region and every old-generation object **and deletes the critical sections the VM takes on the way in** — so a woken thread hits freed heap and destroyed locks, not merely a dangling program;
- called neither `HaltAllExcept` nor `WaitForThreadsToDrain`. Those strings did not appear anywhere under `core/debugger/`. obd was strictly worse off than pre-#683 `vm.cpp`, which at least halted and waited.

And the drain would have lied if it had been called: `WaitForThreadsToDrain` returns true at `intpr_threads.size() <= 1`, i.e. it assumes the caller's own interpreter is registered. `obr` registers its (`vm.cpp:77`); obd never did, so one parked debuggee thread would have read as *"nothing left running"*.

## Reproduced, in two shapes

| Shape | What wakes the parked thread | Windows | Linux |
|---|---|---|---|
| CLI: run, then a client connects to the parked port | an ordinary TCP connection | **6/6** `0xC0000005` | **2/2** SIGSEGV |
| DAP: run to completion, then disconnect | `WSACleanup` at exit | **8/8** `0xC0000005` | 0/2, clean |
| Control: same program, thread exits before `Main` does | — | 0/8 | — |

The program printed its own `PASS` every time — it ran to completion under the debugger and obd died on the way out.

**That split is the headline.** #681 was filed Windows-only because `WSACleanup` was the only thing that ever woke the thread and Linux has no equivalent. obd outlives the run — it goes back to its prompt — so an ordinary client connect wakes the thread just as well, with no `WSACleanup` anywhere near it.

## The fix

- **`debugger.cpp`** — halt and drain in `ClearProgram`; on timeout, `loader->Abandon()` *and* skip `MemoryManager::Clear()`, leaking both rather than pulling them out from under a live thread. Register/deregister the run's interpreter so the drain's own predicate is true (and `RemoveThread` before the delete: obd builds a fresh interpreter per run, so the old pointer would otherwise be handed to the next `HaltAllExcept`).
- **`debugger.cpp`** — no `WSACleanup` on the way out, on any of the three paths. **This is defense-in-depth, not the fix**, and the ablation is why I can say so: with the drain in place, restoring `WSACleanup` does *not* crash (8/8 clean), and the CLI shape proves removing it alone would not have been enough. It buys nothing — Windows reclaims Winsock at exit regardless. The CLI one was unreachable anyway (`Debug()` is a `while(true)` with no break; quit exits through `exit(0)`), and the usage-error one had no matching `WSAStartup` at all.
- **`loader.h`** — `Abandon`'s comment said "used at process exit". obd calls it per run, where the leak is bounded by the debug session.

No iteration-counted sleep timeouts to fix here — there are no sleeps in `core/debugger` at all. The only one on this path was `WaitForThreadsToDrain`'s, already fixed in #683; obd now actually *calls* it, which is what makes that fix matter here. Measured: 2.1s of real drain at exit, not the ~30s it would have been.

## A second, unrelated defect this surfaced

**obd could not debug any multithreaded program.** Compile one with `-debug` — which is how you compile a program you intend to debug — and obd segfaulted on the first instruction the spawned thread executed. `StackInterpreter::debugger` was set by exactly one constructor; spawned VM threads use the default one, which left it indeterminate, and `Execute`'s hot loop calls through it unconditionally in a `_DEBUGGER` build.

It looked like a `-debug` problem rather than a threading one because `ProcessInstruction` reads nothing off `this` until `GetLineNumber() > -1`; without symbols every line is `-1`, so the call returned before dereferencing the garbage. A 2×2 matrix — threads × `-debug` — isolated it in one run, on stock obd.

`_DEBUGGER` is defined only for obd, so `obr`/`obi` never saw this and the VM regression suite could not have caught it. Their preprocessed source is unchanged by this PR. Spawned threads now run with `debugger == nullptr`, i.e. they *run* — breakpoints and stepping still do not reach inside them, which wants the `Debugger` propagated to `AsyncMethodCall`'s interpreter and is a feature, not this fix.

It is a separate commit, and it comes first so history stays bisectable-green: without it the new test's fixture cannot even reach the teardown path under the harness's standard `-debug` compile.

## Test

`programs/regression/obd_teardown_test.py` covers both shapes and reuses `thread_accept_exit_test.obs` rather than adding a near-duplicate fixture — same defect, same program, different host. It asserts the program actually reached the parked-accept state, so a fixture that died on its first syscall cannot produce a green no-op.

It has teeth: against a build with only the teardown commit reverted it reports **5 failures on Windows and 2 on Linux**. Wired into both DAP runners — the `.py` one CI uses and the `.sh` one it does not.

## Verification

- **Windows x64**: DAP 21/21, debugger 25/25, regression 203 passed / 3 skipped / 0 failed.
- **Linux (WSL2, gcc 13.3)**: DAP 21/21.

## Note for the v2026.8.4 release

v2026.8.4 is still a draft and #684 is staging its notes. Those notes cover the VM teardown crash but not these two obd fixes — worth a line each in `CHANGELOG.md` and `readme.json.in` if this lands before the tag. I have not touched #684's files to avoid conflicting with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
