### PR TITLE
test(obd): give each teardown iteration its own port, and stop probing for one

### DIFF
--- a/programs/regression/obd_teardown_test.py
+++ b/programs/regression/obd_teardown_test.py
@@ -89,7 +89,27 @@ LIB_PATH = os.path.join(DEPLOY_DIR, "lib")
 # The fixture is the VM-side #681 reproducer, reused rather than duplicated: the
 # defect and the program shape are the same, only the host differs.
 PROG = os.path.join(SCRIPT_DIR, "thread_accept_exit_test.obe")
-PORT = 19993          # the port ParkedAcceptServer listens on
+BASE_PORT = 19993     # the fixture's default; each iteration gets its own
+
+# Every iteration runs on its own port. Sharing one is not safe on Windows:
+# SO_REUSEADDR there permits binding a port that already has a LIVE listener --
+# unlike POSIX, where it only relaxes TIME_WAIT -- so an obd left over from an
+# earlier iteration and the new one both bind successfully, and the client can be
+# handed the stale listener. It connects, nothing echoes, and the iteration fails
+# for a reason that has nothing to do with the defect. Reproduced 4 times in 10
+# cycles while chasing exactly that, with the fixture printing "ok: client
+# connected" immediately followed by "FAIL: server echoed the request".
+#
+# Probing the port first cannot substitute for this. A connect probe only answers
+# "is anyone accepting"; a bind probe succeeds against a live listener for the
+# very reason above. Both were tried, and the bind probe made it worse.
+_next_port = [BASE_PORT]
+
+
+def take_port():
+    port = _next_port[0]
+    _next_port[0] += 1
+    return port
 
 # The crash races teardown, so a single iteration can miss it -- against a build
 # with the fix reverted these report between one and three failures, and not
@@ -262,34 +282,12 @@ class CliDriver:
                 pass
 
 
-def wait_port_free(timeout=20.0):
-    """Wait until nothing is listening on PORT.
-
-    The fixture binds one fixed port, and each iteration starts a fresh obd while
-    the previous one's listener may not be fully gone. If it is not, the
-    program's Listen() fails, it never reaches the parked-accept state, and the
-    iteration burns RUN_BUDGET before reporting a failure that is about the port
-    rather than about the defect -- which is exactly what one 65s run showed
-    against a *fixed* build. A false failure is worse than a missed detection, so
-    wait for the port instead of racing it.
-    """
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        try:
-            probe = socket.create_connection(("127.0.0.1", PORT), timeout=0.5)
-            probe.close()
-        except OSError:
-            return True         # refused: nothing is listening
-        time.sleep(0.3)
-    return False
-
-
-def wake_parked_thread():
+def wake_parked_thread(port):
     """Connect to the port the debuggee's thread is parked on, unblocking its
     accept(). Returns True if the connection was made."""
     for _ in range(4):
         try:
-            sock = socket.create_connection(("127.0.0.1", PORT), timeout=2.0)
+            sock = socket.create_connection(("127.0.0.1", port), timeout=2.0)
             try:
                 sock.sendall(b"ping\r\n")
                 sock.settimeout(1.0)
@@ -319,13 +317,9 @@ for i in range(CLI_ITERATIONS):
               + " further CLI run(s): global budget spent")
         break
 
-    if not wait_port_free():
-        skipped += 1
-        print("  [SKIP] " + label.rstrip(": ")
-              + ": port " + str(PORT) + " never freed by the previous run")
-        continue
-
-    cli = CliDriver([OBD, "-bin", PROG, "-src", SCRIPT_DIR], child_env())
+    port = take_port()
+    cli = CliDriver([OBD, "-bin", PROG, "-src", SCRIPT_DIR,
+                     "-args", str(port)], child_env())
 
     # Wait until obd has finished loading before sending, so the command cannot
     # land before the command loop is reading. Deliberately NOT the "> " prompt:
@@ -345,9 +339,9 @@ for i in range(CLI_ITERATIONS):
           + repr(cli.text()[-300:]))
 
     # obd is now back at its prompt with the run's image and heap released.
-    woke = wake_parked_thread() if ran else False
+    woke = wake_parked_thread(port) if ran else False
     check(label + "client woke the parked thread", woke,
-          "nothing was listening on " + str(PORT))
+          "nothing was listening on " + str(port))
 
     # The crash was on the wake, so this is the assertion. obd should either be
     # sitting at its prompt (None) or have exited cleanly -- never dead of a
@@ -440,14 +434,10 @@ for i in range(DAP_ITERATIONS):
               + " further DAP run(s): global budget spent")
         break
 
-    if not wait_port_free():
-        skipped += 1
-        print("  [SKIP] " + label.rstrip(": ")
-              + ": port " + str(PORT) + " never freed by the previous run")
-        continue
-
+    port = take_port()
     session = DapSession()
-    session.request("launch", {"program": PROG, "sourceDir": SCRIPT_DIR},
+    session.request("launch", {"program": PROG, "sourceDir": SCRIPT_DIR,
+                              "args": str(port)},
                     timeout=DAP_REQUEST_BUDGET)
     session.request("configurationDone", timeout=DAP_REQUEST_BUDGET)
     session.wait_for(lambda m: m.get("event") == "terminated", timeout=DAP_TERM_BUDGET)

--- a/programs/regression/thread_accept_exit_test.obs
+++ b/programs/regression/thread_accept_exit_test.obs
@@ -66,8 +66,21 @@ class ThreadAcceptExitTest {
 	@failures : Int;
 
 	function : Main(args : String[]) ~ Nil {
+		# The port is a parameter so that a harness running several of these back
+		# to back can give each run its own. Sharing one port is not safe on
+		# Windows: SO_REUSEADDR there permits binding a port that already has a
+		# LIVE listener, unlike POSIX where it only relaxes TIME_WAIT, so a
+		# leftover server from a previous run and this one both bind, and the
+		# client can be handed the stale one -- it connects, and nothing echoes.
+		# Defaults to 19993 so the regression runner keeps invoking it with no
+		# arguments.
+		port := 19993;
+		if(args->Size() > 0) {
+			port := args[0]->ToInt();
+		};
+
 		test := ThreadAcceptExitTest->New();
-		test->Run();
+		test->Run(port);
 	}
 
 	New() {
@@ -84,9 +97,7 @@ class ThreadAcceptExitTest {
 		};
 	}
 
-	method : Run() ~ Nil {
-		port := 19993;
-
+	method : Run(port : Int) ~ Nil {
 		server := ParkedAcceptServer->New(port);
 		server->Execute(Nil);
 		Thread->Sleep(700);


### PR DESCRIPTION
Follow-up to #685. **Test-only — no production code changes.** `obd_teardown_test` could fail against a *fixed* build.

## What it was

It showed up once in twelve runs just after #685 landed, and I could not attribute it at the time: the suite reports `20 passed, 1 failed` and names nothing. A 5-cycle harness — three deliberately-crashing runs, then the full suite — reproduced it, and the diagnostics added in #685 named the check:

```
[FAIL] DAP run 1: program reached the parked-accept state: no PASS within 30s
       output: '  ok: client connected to parked-accept server
                  FAIL: server echoed the request (thread reached Accept)'
```

A client that connects and gets **no echo** has reached a *leftover listener* from an earlier obd.

The part that matters: the failing iteration was `CLI run 2` and `DAP run 2` as often as `run 1` — leftovers from earlier iterations of the **same suite run**. The test manufactured the condition itself, so CI was exposed. My first read, that this was an artifact of running crashing builds back-to-back (which CI doesn't do), was wrong.

## Why

A Windows/POSIX divergence I'd assumed away: **`SO_REUSEADDR` on Windows permits binding a port that already has a LIVE listener**, where POSIX only relaxes `TIME_WAIT`. `core/vm/arch/win32/win32.h:535` sets it on every server socket. So a leftover obd and a fresh one both bind the same port successfully, and the connection can be handed to the stale one.

That also settles why **no probe can work here**, which cost two attempts to learn:

- a **connect** probe only answers "is anyone accepting";
- a **bind** probe succeeds against a live listener, for the very reason above.

The bind probe was my first fix and it made things measurably worse — 3 failures in 5 cycles, against 1 in 5 with the connect probe. Both are gone.

## The fix

Remove the shared resource rather than try to detect contention. `thread_accept_exit_test.obs` takes the port as an optional argument, defaulting to 19993 so the regression runner keeps invoking it with none; `obd_teardown_test` hands each of its five iterations a port of its own, via `-args` on the CLI and `launch.args` on DAP.

## Verification

| Harness (5 cycles: 3 crashing runs → full suite) | Result |
|---|---|
| Original connect probe | 1 / 5 failed |
| Bind probe (first attempt) | **3 / 5 failed** |
| **Per-iteration ports** | **0 / 5 failed** |

- **Teeth unchanged**: all 15 burst runs against a reverted build still report 2–4 failures each.
- Linux full DAP suite **21/21 ×3**; Windows **21/21**.
- **VM regression 203 passed / 3 skipped / 0 failed** with the modified fixture.
- The fixture exits 0 both with an explicit port and with none — it is also the VM-side #681 regression test, so the no-argument path had to keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
