### PR TITLE
fix(release): three tools that reported success while measuring the wrong thing

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -637,11 +637,51 @@ jobs:
         run: |
           rm -f ~/.ssh/obj_key
 
-      - name: Skip notice
+      # Fail, do not skip.
+      #
+      # This printed "Skipping deployment" and reported the job as SUCCESS, so
+      # "Deploy API Documentation  completed/success" meant "did nothing" -- and
+      # had meant that for as long as the secrets have been unset. The v2026.8.4
+      # release went out with objeck.org still serving v2026.8.3 docs, and the
+      # 39 Game.OpenGL pages of the release's headline feature returning 404,
+      # while the pipeline reported the deploy green.
+      #
+      # A missing secret is a configuration defect, not a valid state to pass
+      # over quietly: it makes an advertised part of the release silently not
+      # happen. Fail loudly and name what to set. The escape hatch already exists
+      # and is explicit -- the `skip_docs_deploy` workflow_dispatch input gates
+      # this whole job -- so "skip on purpose" is available without "skip by
+      # accident and report success" being the default.
+      - name: Missing objeck.org credentials
         if: env.OBJECK_ORG_SSH_KEY == ''
         run: |
-          echo "⚠️  objeck.org SSH key not configured. Skipping deployment."
-          echo "To enable: Add OBJECK_ORG_SSH_KEY and OBJECK_ORG_USER secrets"
+          echo "::error::objeck.org SSH credentials are not configured - API docs were NOT deployed"
+          echo ""
+          echo "Set both repository secrets:"
+          echo "  OBJECK_ORG_SSH_KEY  - private key authorized on objeck.org"
+          echo "  OBJECK_ORG_USER     - the ssh user"
+          echo ""
+          echo "The docs that should have shipped are in this run's api-docs artifact,"
+          echo "and on master at docs/api.zip. To deploy by hand:"
+          echo "  rsync -avz --delete api/ USER@objeck.org:/var/www/objeck.org/api/v<VERSION>/"
+          echo "  ssh USER@objeck.org 'cd /var/www/objeck.org/api && ln -sfn v<VERSION> latest'"
+          exit 1
+
+      # Prove the deploy actually landed, rather than trusting rsync's exit code.
+      # Same reasoning as the playground engine check: the step that reports
+      # success is not the same thing as the site serving the new pages.
+      - name: Verify published docs
+        if: env.OBJECK_ORG_SSH_KEY != ''
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          sleep 5
+          STAMP=$(curl -fsS --max-time 30 "https://objeck.org/api/latest/index.html" \
+                  | grep -o 'class="version">v[0-9.]*' | head -1 | sed 's/.*>//')
+          if [ "$STAMP" != "v$VERSION" ]; then
+            echo "::error::objeck.org/api/latest reports '$STAMP', expected 'v$VERSION'"
+            exit 1
+          fi
+          echo "✅ objeck.org/api/latest serves $STAMP"
 
   # ============================================
   # Publish VS Code Extension

--- a/programs/web-playground/deploy/update.sh
+++ b/programs/web-playground/deploy/update.sh
@@ -1,50 +1,166 @@
 #!/bin/bash
 # Objeck Playground - Zero-downtime update script
-# Usage: sudo bash update.sh
+# Usage: sudo bash update.sh [VERSION]
+#
+# VERSION defaults to whatever core/shared/version.h says after the pull. Pass it
+# explicitly to pin a different release (e.g. to roll back).
 
 set -euo pipefail
 
 REPO_DIR="/opt/playground/repo"
+DEPLOY_DIR="$REPO_DIR/core/release/deploy"
+STAMP_FILE="$DEPLOY_DIR/.installed-version"
+WANT_VERSION="${1:-}"
 
 echo "=== Updating Objeck Playground ==="
 
-# Pull latest code
+# ---------------------------------------------------------------- pull
+#
+# The plain pull is tried first. It fails on this host in a specific, recurring
+# way: files land root-owned and read-only (obu.cpp, the updater makefiles,
+# downloads.csv), so git cannot unlink them and the pull dies half-applied --
+#
+#   error: unable to unlink old 'core/utils/updater/obu.cpp': Permission denied
+#
+# Every subsequent pull then fails the same way, so the server silently stops
+# tracking master. That is how the playground came to be months behind while
+# reporting a current version. Recover and retry rather than abort.
 echo ""
 echo "--- Pulling latest code ---"
 cd "$REPO_DIR"
-sudo -u playground git pull origin master
+if ! sudo -u playground git pull origin master; then
+    echo "--- pull failed; recovering the working tree and retrying ---"
+    chmod -R u+w "$REPO_DIR"
+    sudo -u playground git stash
+    sudo -u playground git clean -fd
+    sudo -u playground git pull origin master
+    # A stale hand-edited config.py conflicts here. Take the committed value:
+    # a botched resolution leaves conflict markers and uvicorn dies on SyntaxError.
+    sudo -u playground git stash pop || {
+        echo "--- stash pop conflicted; taking the committed files ---"
+        sudo -u playground git checkout --theirs . 2>/dev/null || true
+        sudo -u playground git checkout HEAD -- .
+        sudo -u playground git stash drop || true
+    }
+fi
 
-# Update Python dependencies if changed
+# ------------------------------------------------------- objeck toolchain
+#
+# THE SANDBOX RUNS WHATEVER IS IN core/release/deploy, AND NOTHING USED TO PUT
+# ANYTHING THERE. That directory is gitignored, so `git pull` cannot refresh it,
+# and no step here ever rebuilt it -- build-sandbox.sh only *copies* out of it.
+# The result: the image was rebuilt faithfully on every deploy, from a tree last
+# built by hand months earlier. The playground served a 2026.6.1 engine while its
+# header read v2026.8.4, and every check passed because they all measured the
+# label rather than the binary.
+#
+# Install the published release tarball instead of building here: this box has
+# one core and 1 GB of RAM, an LTO link would likely OOM, and a failed build on
+# the live host is worse than a stale one. The tarball is also the exact artifact
+# users get, so the playground cannot diverge from the release.
+if [ -z "$WANT_VERSION" ]; then
+    WANT_VERSION=$(sed -n 's/.*VERSION_STRING L"\([0-9.]*\)".*/\1/p' "$REPO_DIR/core/shared/version.h")
+fi
+[ -n "$WANT_VERSION" ] || { echo "ERROR: could not determine target version"; exit 1; }
+
+HAVE_VERSION=""
+[ -f "$STAMP_FILE" ] && HAVE_VERSION=$(cat "$STAMP_FILE")
+
+echo ""
+echo "--- Objeck toolchain (want $WANT_VERSION, have ${HAVE_VERSION:-none}) ---"
+if [ "$HAVE_VERSION" = "$WANT_VERSION" ] && [ -x "$DEPLOY_DIR/bin/obr" ]; then
+    echo "Toolchain already at $WANT_VERSION - skipping download"
+else
+    TGZ="objeck-linux-x64_${WANT_VERSION}.tgz"
+    BASE="https://github.com/objeck/objeck-lang/releases/download/v${WANT_VERSION}"
+    STAGE=$(mktemp -d)
+    trap 'rm -rf "$STAGE"' EXIT
+
+    echo "Downloading $TGZ ..."
+    curl -sSLf -o "$STAGE/$TGZ" "$BASE/$TGZ"
+    curl -sSLf -o "$STAGE/SHA256SUMS" "$BASE/SHA256SUMS"
+
+    # Verify before installing. The manifest is regenerated after Windows signing,
+    # so it describes the published bytes.
+    EXPECT=$(grep " $TGZ\$" "$STAGE/SHA256SUMS" | cut -d' ' -f1)
+    ACTUAL=$(sha256sum "$STAGE/$TGZ" | cut -d' ' -f1)
+    [ -n "$EXPECT" ] || { echo "ERROR: $TGZ not listed in SHA256SUMS"; exit 1; }
+    if [ "$EXPECT" != "$ACTUAL" ]; then
+        echo "ERROR: SHA256 mismatch for $TGZ"
+        echo "  expected $EXPECT"
+        echo "  actual   $ACTUAL"
+        exit 1
+    fi
+    echo "SHA256 verified"
+
+    tar xzf "$STAGE/$TGZ" -C "$STAGE"
+    [ -x "$STAGE/objeck-lang/bin/obr" ] || { echo "ERROR: tarball has no bin/obr"; exit 1; }
+
+    # Swap, keeping the previous tree until the new one is proven below.
+    if [ -d "$DEPLOY_DIR" ]; then
+        rm -rf "$DEPLOY_DIR.prev"
+        mv "$DEPLOY_DIR" "$DEPLOY_DIR.prev"
+    fi
+    mv "$STAGE/objeck-lang" "$DEPLOY_DIR"
+    chmod -R a+rX "$DEPLOY_DIR"
+    echo "$WANT_VERSION" > "$STAMP_FILE"
+    echo "Installed Objeck $WANT_VERSION"
+fi
+
+# --------------------------------------------------------- python deps
 echo ""
 echo "--- Updating dependencies ---"
 /opt/playground/venv/bin/pip install -q -r /opt/playground/backend/requirements.txt
 
-# Rebuild sandbox image if Dockerfile changed
+# ------------------------------------------------------- sandbox image
 echo ""
 echo "--- Rebuilding sandbox image ---"
-sudo -u playground bash /opt/playground/docker/build-sandbox.sh "$REPO_DIR/core/release/deploy"
+sudo -u playground bash /opt/playground/docker/build-sandbox.sh "$DEPLOY_DIR"
 
-# Restart the API service
+# ------------------------------------------------------------- restart
 echo ""
 echo "--- Restarting API ---"
 systemctl restart playground
 
-# Clean up old Docker images
 echo ""
 echo "--- Cleaning up ---"
 docker image prune -f
 docker container prune -f
 
-# Health check
+# -------------------------------------------------------- verification
+#
+# Two checks, because the first one alone is what let this rot for months.
+# /api/health reports a hand-maintained constant in backend/app/config.py; it is
+# a label, and it was correct while the engine underneath was three months old.
+# Only running code through the sandbox says what actually executes.
 echo ""
 echo "--- Health check ---"
-sleep 2
+sleep 3
 if curl -sf http://localhost:8000/api/health > /dev/null; then
     echo "API is healthy"
 else
-    echo "WARNING: API health check failed!"
+    echo "ERROR: API health check failed!"
     systemctl status playground --no-pager
+    exit 1
 fi
 
 echo ""
-echo "=== Update complete ==="
+echo "--- Engine check (runs code through the sandbox) ---"
+PROBE='{"code":"class V { function : Main(args : String[]) ~ Nil { System.Runtime->GetVersion()->PrintLine(); } }"}'
+ENGINE_OUT=$(curl -sf --max-time 60 -X POST http://localhost:8000/api/run \
+    -H 'Content-Type: application/json' -d "$PROBE" || true)
+
+if echo "$ENGINE_OUT" | grep -q "$WANT_VERSION"; then
+    echo "Engine reports $WANT_VERSION"
+else
+    echo "ERROR: sandbox is NOT running $WANT_VERSION"
+    echo "  response: $ENGINE_OUT"
+    echo "  the previous toolchain is at $DEPLOY_DIR.prev if a rollback is needed"
+    exit 1
+fi
+
+# Only now is the previous tree redundant.
+rm -rf "$DEPLOY_DIR.prev"
+
+echo ""
+echo "=== Update complete (Objeck $WANT_VERSION) ==="

--- a/tools/cicd/post_release.sh
+++ b/tools/cicd/post_release.sh
@@ -111,10 +111,24 @@ echo
 echo "[4] SHA256SUMS describes the PUBLISHED bytes"
 # Signing rewrites the MSIs, so a manifest generated before signing makes every
 # user's verification FAIL -- worse than shipping no checksum.
-( cd "$WORK" && gh release download "$TAG" -R "$REPO" --pattern "SHA256SUMS" --clobber >/dev/null 2>&1
-  gh release download "$TAG" -R "$REPO" --pattern "*.msi" --clobber >/dev/null 2>&1
-  gh release download "$TAG" -R "$REPO" --pattern "*.pkg" --clobber >/dev/null 2>&1
-  gh release download "$TAG" -R "$REPO" --pattern "*.zip" --clobber >/dev/null 2>&1 )
+# Do NOT suppress these. The manifest download failed once here and the error went
+# to /dev/null, so the gate sailed on and died three lines later reading a file
+# that was never fetched:
+#
+#   post_release.sh: line 123: /tmp/tmp.XXXX/SHA256SUMS: No such file or directory
+#
+# which reads as a broken script rather than as "the download failed" -- the same
+# indistinguishable-failure problem this file's header warns about. Note also that
+# the four downloads were newline-separated after a single '&&', so a failure of
+# the first did not stop the rest; only the manifest is required, so check it.
+( cd "$WORK" || exit 1
+  gh release download "$TAG" -R "$REPO" --pattern "SHA256SUMS" --clobber 2>&1 | sed 's/^/    gh: /'
+  for pat in "*.msi" "*.pkg" "*.zip"; do
+    gh release download "$TAG" -R "$REPO" --pattern "$pat" --clobber >/dev/null 2>&1 || true
+  done )
+if [ ! -f "$WORK/SHA256SUMS" ]; then
+  bad "could not download SHA256SUMS -- cannot verify the manifest (see gh output above)"
+else
 STALE=0
 while read -r h n; do
   [ -f "$WORK/$n" ] || continue
@@ -142,13 +156,23 @@ if [ "$STALE" -eq 1 ]; then
   [ "$RC" -eq 0 ] && note "regenerated and re-verified against the published files" \
                   || bad "SHA256SUMS still does not match after regeneration"
 fi
+fi
 
 # ------------------------------------------------------------- 5. body
 echo
 echo "[5] release notes name only files that exist"
 if [ -n "$BODY_FILE" ]; then
-  gh release edit "$TAG" -R "$REPO" --notes-file "$BODY_FILE" >/dev/null 2>&1 \
-    || bad "could not set release body"
+  # Check the file first, and let gh's own error through. This reported
+  # "could not set release body" for a file that `gh release edit` accepted
+  # without complaint when run by hand a minute later -- with the reason sent to
+  # /dev/null there was nothing to act on, and the gate looked like the defect.
+  if [ ! -f "$BODY_FILE" ]; then
+    bad "body file not found: $BODY_FILE"
+  else
+    ERR=$(gh release edit "$TAG" -R "$REPO" --notes-file "$BODY_FILE" 2>&1 >/dev/null) \
+      && note "release body set from $BODY_FILE" \
+      || bad "could not set release body: $ERR"
+  fi
 fi
 gh release view "$TAG" -R "$REPO" --json body --jq .body > "$WORK/body.md" 2>/dev/null
 # Precise asset shape: 'objeck-lang' in a repo URL is NOT an advertised asset.
@@ -173,11 +197,29 @@ echo "[6] playground"
 if [ "$DO_PLAYGROUND" -eq 1 ]; then
   HOST="${PLAYGROUND_HOST:-playground.objeck.org}"
   ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 "root@$HOST" \
-      'bash /opt/playground/repo/programs/web-playground/deploy/update.sh' 2>&1 | tail -5 | sed 's/^/  /'
+      "bash /opt/playground/repo/programs/web-playground/deploy/update.sh $VERSION" 2>&1 \
+      | tail -8 | sed 's/^/  /'
 fi
 PV=$(curl -fsS --max-time 20 https://playground.objeck.org/api/health 2>/dev/null | sed 's/.*"version":"\([^"]*\)".*/\1/')
 if [ "$PV" = "$TAG" ]; then note "health ok, version=$PV"
 else echo "  playground reports '$PV', expected '$TAG'"; [ "$DO_PLAYGROUND" -eq 1 ] && FAIL=1; fi
+
+# The health version is a hand-maintained constant in backend/app/config.py -- a
+# LABEL. It read v2026.8.4 while the sandbox was still executing a 2026.6.1
+# toolchain built months earlier, because the image is assembled from
+# core/release/deploy, which is gitignored and which nothing refreshed. Every
+# check passed; none of them ran any code. So run some.
+EV=$(curl -fsS --max-time 60 -X POST https://playground.objeck.org/api/run \
+      -H 'Content-Type: application/json' \
+      -d '{"code":"class V { function : Main(args : String[]) ~ Nil { System.Runtime->GetVersion()->PrintLine(); } }"}' \
+      2>/dev/null)
+if echo "$EV" | grep -q "$VERSION"; then
+  note "engine executes $VERSION"
+else
+  echo "  playground ENGINE is not $VERSION (the header can be right while this is wrong)"
+  echo "  response: $(echo "$EV" | head -c 200)"
+  [ "$DO_PLAYGROUND" -eq 1 ] && FAIL=1
+fi
 
 echo
 echo "=============================================================="

--- a/tools/cicd/watch_release.sh
+++ b/tools/cicd/watch_release.sh
@@ -41,14 +41,35 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "$BUILD_ID" ]; then
-  for _ in 1 2 3 4 5 6; do
+  # Pin the run to the commit the tag CURRENTLY points at.
+  #
+  # Taking "newest run for this tag" is wrong after a re-tag, and re-tagging is
+  # the prescribed recovery from a failed build -- so the wrong case is the one
+  # that happens under pressure. Observed: the tag was deleted, master was fixed,
+  # the tag was re-cut, and this ran immediately. GitHub had not yet created the
+  # new run, so the lookup matched the PREVIOUS run -- cancelled, on the old SHA --
+  # and printed
+  #
+  #   RELEASE-BUILD FAILED: completed/cancelled
+  #   The tag is already pushed. Fix on master, delete the tag, re-tag.
+  #
+  # for a build that had just started healthily. Acting on that advice would have
+  # deleted a good tag and restarted a 70-minute build: precisely the panic
+  # response this script exists to prevent, produced by the script itself.
+  TAG_SHA=$(gh api "repos/$REPO/git/ref/tags/$TAG" --jq '.object.sha' 2>/dev/null)
+  [ -n "$TAG_SHA" ] || TAG_SHA=$(git rev-parse "$TAG^{commit}" 2>/dev/null || true)
+  [ -n "$TAG_SHA" ] || { echo "cannot resolve $TAG to a commit"; exit 3; }
+
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
     BUILD_ID=$(gh run list --workflow=release-build.yml -R "$REPO" --branch="$TAG" \
-                 --limit=1 --json databaseId --jq '.[0].databaseId' 2>/dev/null)
-    [ -n "$BUILD_ID" ] && break
-    sleep 5
+                 --limit=20 --json databaseId,headSha \
+                 --jq "[.[] | select(.headSha == \"$TAG_SHA\")] | .[0].databaseId" 2>/dev/null)
+    [ -n "$BUILD_ID" ] && [ "$BUILD_ID" != "null" ] && break
+    BUILD_ID=""
+    sleep 10
   done
 fi
-[ -n "$BUILD_ID" ] || { echo "no release-build.yml run found for $TAG"; exit 3; }
+[ -n "$BUILD_ID" ] || { echo "no release-build.yml run found for $TAG at its current commit"; exit 3; }
 
 ST=""; TIMED_OUT=0
 wait_run() {


### PR DESCRIPTION
All three surfaced during the v2026.8.4 release. They share a shape: **a check that passes because it inspects a label, a cached value, or a suppressed error rather than the thing it claims to verify.**

## 1. `update.sh` — the playground served a 2026.6.1 engine for months

The sandbox image is assembled from `core/release/deploy`. That directory is **gitignored**, so `git pull` cannot refresh it, and *nothing in the deploy path ever rebuilt it* — `build-sandbox.sh` only copies out of it. The image was rebuilt faithfully on every deploy, from a tree last built by hand on **June 14**.

`/api/health` read `v2026.8.4` throughout, because that string is a hand-maintained constant in `backend/app/config.py`. Running one line of code through the playground printed `2026.6.1`. Users were getting none of this release's JIT immediate fixes, GC lifetime fixes, `Web.Server` rewrite or `Game.OpenGL`.

**Now**: installs the published `linux-x64` tarball, verifying SHA256 against the published manifest *before* swapping, keeping the previous tree as `.prev` until the new one is proven, and stamping the installed version so repeat deploys skip the download.

Installing the release rather than building on the VPS is deliberate — 1 core, 1 GB RAM, no `cmake`, no `libnghttp2-dev`; an LTO link would likely OOM, and a failed build on the live host is worse than a stale one. It's also the exact artifact users receive, so the playground can't drift from the release again.

Two more fixes in the same file:
- **The pull now recovers instead of aborting.** Files land root-owned and read-only, git can't unlink them, and every pull since has died half-applied — which is how the server silently stopped tracking master.
- **The final check runs code through the sandbox** and asserts the engine version. The health check alone is what let this rot.

## 2. `post_release.sh` — gates that failed like the defects they hunt

**Gate 4** sent its download errors to `/dev/null` and then read the file anyway, so a failed fetch surfaced as:
```
post_release.sh: line 123: /tmp/tmp.XXXX/SHA256SUMS: No such file or directory
```
which reads as a broken script. Its four downloads also shared a single `&&`, so a failure of the first didn't stop the rest.

**Gate 5** reported `could not set release body` for a file that `gh release edit` accepted without complaint when run by hand a minute later — with the reason discarded, there was nothing to act on.

Both now check what they depend on and surface `gh`'s actual error. **Gate 6** gained the engine check above and passes the version through to `update.sh`.

## 3. `watch_release.sh` — a false red on a healthy build

It selected the newest run for the tag without checking the run belonged to the commit the tag *currently* points at. Re-tagging is the prescribed recovery from a failed build, so the broken case is the one that happens under pressure: the tag was re-cut, this ran before GitHub had created the new run, and it matched the **previous** run — cancelled, on the old SHA — printing:

```
RELEASE-BUILD FAILED: completed/cancelled
The tag is already pushed. Fix on master, delete the tag, re-tag.
```

for a build that had just started healthily. Following that advice would have deleted a good tag and restarted a 70-minute build — the exact panic response this script exists to prevent, generated by the script itself.

Now resolves the tag to a commit and accepts only a run on that commit, retrying while the run is created. **Verified against the real data**: with both runs present it selects `33411313720` (`b2e137c529`, success) and excludes `33407768869` (`372fee20d1`, cancelled).

## Verification

The fixed `post_release.sh` run read-only against the published v2026.8.4 passes **all six gates**:

```
[3] All Windows installers for v2026.8.4 are signed.
[4] ok ×10   (regenerated SHA256SUMS vs published bytes)
[5] all 9 named files exist
[6] health ok, version=v2026.8.4
    engine executes 2026.8.4
 ALL POST-RELEASE GATES PASS for v2026.8.4
```

`update.sh`'s tarball path was exercised by hand on the VPS during the release — SHA256 verified, engine confirmed at `2026.8.4` — which is what this change automates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
