### PR TITLE
fix(release): steps that cannot run must not report success, and a pre-flight that catches it

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -96,7 +96,28 @@ Release target:
 
 ### 1. Pre-flight gates (all must pass)
 
-Run the following and **abort** on the first failure:
+**First, the configuration gate — one command:**
+
+```bash
+tools/cicd/check_release_config.sh
+```
+
+Every other gate below checks the repository. This one checks whether the pipeline
+can actually *do* what it advertises, which nothing checked until v2026.8.4 shipped
+with four publish steps reporting `completed/success` having done nothing: no
+Sourceforge upload, no Marketplace publish, no playground deploy, no API-docs
+deploy. None of those secrets had ever been set. The playground was left on a
+three-month-old engine and objeck.org a release behind, both repaired by hand
+afterwards.
+
+Those jobs now fail rather than skip, but a failure *during* a release is still the
+expensive place to learn it. Exit 0 means every advertised step can run or is
+declared manual in the `RELEASE_MANUAL_STEPS` repository variable; exit 1 lists each
+gap with the command to fix or declare it. Steps declared manual are printed as a
+to-do list — declaring one is a reminder, not a free pass: **you still have to do
+it after publishing.**
+
+Then run the following and **abort** on the first failure:
 
 ```bash
 # Clean working tree
@@ -168,19 +189,29 @@ Note the cloud build *does* pass the release version to `code_doc` and commits t
 result back as `chore: update api.zip for v<VERSION> [skip ci]` -- so a wrong stamp in
 the committed file is not simply "CI never refreshes it".
 
-**Unresolved, with the evidence recorded so it is not rediscovered.** Three consecutive
-CI commits each committed a zip stamped **v2026.8.0**:
+**SOLVED (2026-09-02, commit `b2e137c529`).** This section previously recorded three
+consecutive CI commits each committing a zip stamped **v2026.8.0** as an open
+question. The cause was neither of the two theories here:
 
-```
-a757830453  "chore: update api.zip for v2026.8.2"  -> zip stamps v2026.8.0
-930dd19836  "chore: update api.zip for v2026.8.1"  -> zip stamps v2026.8.0
-7dba61d324  "chore: update api.zip for v2026.8.1"  -> zip stamps v2026.8.0
-```
+`doc_html.obs` addresses every output as a hardcoded **`../html/`** — relative to
+`obr`'s working directory, which the job sets to `core/release/deploy/bin`, so
+`core/release/deploy/html`. It opens those paths with `FileWriter`, and **FileWriter
+fails silently when the directory does not exist.** The job created `docs/api`
+instead and never created `../html`, so every page write was a no-op: `code_doc`
+printed "Writing API files...", spun through every class, exited 0, and wrote
+nothing. The old gate then counted entries inside the *tracked* `docs/api.zip`,
+which the checkout always supplies, so it counted the stale ones and passed.
 
-So either the version handed to `code_doc` was wrong on those runs, or the commit step
-(which stashes the built zip to `/tmp` and copies it back around a git operation)
-restored a stale file. Not diagnosed. Until it is, **verify the stamp every release**
-rather than assuming the cloud produced a correct one.
+`windows-x64` was the one platform whose shipped docs were correct because
+`code_doc64.cmd` is the only caller that does the `mkdir ..\html` + `xcopy` this
+needs — and it is the only platform that regenerates its own docs. The POSIX job now
+mirrors it. Evidence: CI's next committed `api.zip` went from 472 stale pages to
+**482** stamped v2026.8.4, including the `game.opengl-*` pages that had never
+appeared in any release.
+
+Keep verifying the stamp anyway — it is cheap, and it is what finally caught this.
+But note the stamp alone cannot distinguish the 472-page and 482-page archives:
+**both are stamped v2026.8.4.** Count pages when it matters.
 
 ### 1b. Derive the release summary
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -474,11 +474,28 @@ jobs:
         run: |
           rm -f ~/.ssh/sf_key
 
-      - name: Skip notice
-        if: env.SOURCEFORGE_SSH_KEY == ''
+      # A missing secret must not silently stand in for a decision. The
+      # `skip_sourceforge` input only exists on workflow_dispatch, so on the normal
+      # workflow_run path there was no way to say "manual on purpose" -- and the
+      # absent secret said it instead, reporting success. v2026.8.4 recorded
+      # "Upload to Sourceforge  completed/success" having uploaded nothing.
+      #
+      # RELEASE_MANUAL_STEPS is a repository VARIABLE (not a secret), so it applies
+      # on every trigger. List the steps handled by hand, e.g. "sourceforge,vscode".
+      - name: Sourceforge is handled manually
+        if: env.SOURCEFORGE_SSH_KEY == '' && contains(vars.RELEASE_MANUAL_STEPS, 'sourceforge')
         run: |
-          echo "⚠️  Sourceforge SSH key not configured. Skipping upload."
-          echo "To enable: Add SOURCEFORGE_SSH_KEY and SOURCEFORGE_USERNAME secrets"
+          echo "ℹ️  Sourceforge upload is declared manual via RELEASE_MANUAL_STEPS - skipping."
+          echo "   Upload the release assets to Sourceforge by hand."
+
+      - name: Missing Sourceforge credentials
+        if: env.SOURCEFORGE_SSH_KEY == '' && !contains(vars.RELEASE_MANUAL_STEPS, 'sourceforge')
+        run: |
+          echo "::error::Sourceforge credentials are not configured - nothing was uploaded"
+          echo ""
+          echo "Either add the secrets SOURCEFORGE_SSH_KEY and SOURCEFORGE_USERNAME,"
+          echo "or declare it manual:  gh variable set RELEASE_MANUAL_STEPS --body 'sourceforge'"
+          exit 1
 
   # ============================================
   # Deploy the web playground
@@ -565,13 +582,26 @@ jobs:
         run: |
           rm -f ~/.ssh/playground_key
 
-      - name: Skip notice
-        if: env.PLAYGROUND_SSH_KEY == '' || env.PLAYGROUND_HOST == ''
+      - name: Playground is handled manually
+        if: (env.PLAYGROUND_SSH_KEY == '' || env.PLAYGROUND_HOST == '') && contains(vars.RELEASE_MANUAL_STEPS, 'playground')
         run: |
-          echo "⚠️  Playground deploy not configured. Skipping."
-          echo "To enable: add PLAYGROUND_HOST and PLAYGROUND_SSH_KEY secrets."
+          echo "ℹ️  Playground deploy is declared manual via RELEASE_MANUAL_STEPS - skipping."
+          echo "   Run: ssh root@<host> 'bash /opt/playground/repo/programs/web-playground/deploy/update.sh <VERSION>'"
+
+      # This reported success while deploying nothing, so v2026.8.4 went out with the
+      # playground still serving a 2026.6.1 engine -- and the deploy had to be done by
+      # hand afterwards. A deploy that does not happen must not be green.
+      - name: Missing playground credentials
+        if: (env.PLAYGROUND_SSH_KEY == '' || env.PLAYGROUND_HOST == '') && !contains(vars.RELEASE_MANUAL_STEPS, 'playground')
+        run: |
+          echo "::error::Playground credentials are not configured - the playground was NOT deployed"
+          echo ""
+          echo "Add secrets PLAYGROUND_HOST and PLAYGROUND_SSH_KEY, or declare it manual:"
+          echo "  gh variable set RELEASE_MANUAL_STEPS --body 'playground'"
+          echo ""
           echo "The key should be a deploy key restricted on the VPS to:"
           echo "  command=\"bash /opt/playground/repo/programs/web-playground/deploy/update.sh\",no-pty,no-port-forwarding"
+          exit 1
 
   # ============================================
   # Deploy API Documentation
@@ -724,11 +754,23 @@ jobs:
           vsce publish --packagePath "$VSIX"
           echo "✅ VS Code extension published to marketplace"
 
-      - name: Skip notice
-        if: env.VSCE_PAT == ''
+      - name: VS Code publish is handled manually
+        if: env.VSCE_PAT == '' && contains(vars.RELEASE_MANUAL_STEPS, 'vscode')
         run: |
-          echo "⚠️  VSCE_PAT secret not configured — skipping VS Code Marketplace publish."
-          echo "To enable: add a VSCE_PAT secret (Personal Access Token for VS Code Marketplace)"
+          echo "ℹ️  VS Code Marketplace publish is declared manual via RELEASE_MANUAL_STEPS - skipping."
+          echo "   Publish the .vsix from this run's artifacts by hand."
+
+      # The release notes advertise the extension, so a skipped publish means the
+      # notes describe something that did not ship. v2026.8.4 reported
+      # "Publish VS Code Extension  completed/success" having published nothing.
+      - name: Missing VS Code Marketplace token
+        if: env.VSCE_PAT == '' && !contains(vars.RELEASE_MANUAL_STEPS, 'vscode')
+        run: |
+          echo "::error::VSCE_PAT is not configured - the extension was NOT published"
+          echo ""
+          echo "Add a VSCE_PAT secret (Marketplace Personal Access Token), or declare it manual:"
+          echo "  gh variable set RELEASE_MANUAL_STEPS --body 'vscode'"
+          exit 1
 
   # ============================================
   # Release Summary

--- a/tools/cicd/check_release_config.sh
+++ b/tools/cicd/check_release_config.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# check_release_config.sh
+#
+# Pre-flight: is the release pipeline actually CONFIGURED to do what it claims?
+#
+# WHY THIS EXISTS
+# ---------------
+# Every other pre-flight gate checks the repository -- version consistency, tag
+# state, docs, api.zip. None of them checked whether the pipeline could perform
+# the steps it advertises. It could not, and had not for many releases.
+#
+# v2026.8.4 published with all of these reporting completed/success:
+#
+#     Upload to Sourceforge        -> uploaded nothing   (no SOURCEFORGE_SSH_KEY)
+#     Publish VS Code Extension    -> published nothing  (no VSCE_PAT)
+#     Deploy playground            -> deployed nothing   (no PLAYGROUND_SSH_KEY)
+#     Deploy API Documentation     -> deployed nothing   (no OBJECK_ORG_SSH_KEY)
+#
+# The playground was left serving a three-month-old engine and objeck.org a
+# release-old set of API docs; both were repaired by hand after the fact. The
+# jobs now fail instead of skipping, but a failure DURING a release is still the
+# expensive place to learn this. Learn it before the tag.
+#
+# Run it before tagging. Exit 0 = every advertised step can run, or is declared
+# manual. Exit 1 = a gap that would silently or noisily cost you a release step.
+set -uo pipefail
+
+REPO="${REPO:-objeck/objeck-lang}"
+WF_DIR=".github/workflows"
+FAIL=0
+note() { echo "  $*"; }
+bad()  { echo "  GAP: $*"; FAIL=1; }
+
+echo "=============================================================="
+echo " release configuration pre-flight ($REPO)"
+echo "=============================================================="
+
+# Which secrets do the release workflows actually reference?
+# [A-Z0-9_]+, not [A-Z_]+: without the digits this truncates APPLE_CERTIFICATE_BASE64
+# to APPLE_CERTIFICATE_BASE and reports a set secret as a gap -- a checker that
+# fails like the defect it hunts, which is the whole family of bug this file is
+# here to end.
+REFERENCED=$(grep -ohE 'secrets\.[A-Z0-9_]+' \
+  "$WF_DIR/release-build.yml" "$WF_DIR/release-publish.yml" 2>/dev/null \
+  | sed 's/secrets\.//' | sort -u | grep -v '^GITHUB_TOKEN$')
+
+# Which are set? (names only; values are never readable, by design)
+CONFIGURED=$(gh secret list -R "$REPO" --json name --jq '.[].name' 2>/dev/null | sort -u)
+if [ -z "$CONFIGURED" ]; then
+  echo "  cannot read the secret list for $REPO (auth/permissions?) -- aborting"
+  exit 1
+fi
+
+# Steps declared manual, via the repository VARIABLE the workflows honour.
+MANUAL=$(gh variable list -R "$REPO" --json name,value \
+           --jq '.[] | select(.name=="RELEASE_MANUAL_STEPS") | .value' 2>/dev/null)
+echo
+echo "RELEASE_MANUAL_STEPS = '${MANUAL:-<unset>}'"
+
+# secret -> the release step it powers, and the RELEASE_MANUAL_STEPS token that
+# legitimately excuses its absence.
+step_for() {
+  case "$1" in
+    SOURCEFORGE_*)  echo "Sourceforge upload|sourceforge" ;;
+    PLAYGROUND_*)   echo "playground deploy|playground" ;;
+    OBJECK_ORG_*)   echo "objeck.org API docs deploy|docs" ;;
+    VSCE_PAT)       echo "VS Code Marketplace publish|vscode" ;;
+    APPLE_*|CODESIGN_*|KEYCHAIN_*) echo "macOS signing/notarization|" ;;
+    *)              echo "unknown step|" ;;
+  esac
+}
+
+echo
+echo "[secrets referenced by the release workflows]"
+for s in $REFERENCED; do
+  info=$(step_for "$s"); desc="${info%%|*}"; token="${info##*|}"
+  if printf '%s\n' "$CONFIGURED" | grep -qx "$s"; then
+    note "set        $s  ($desc)"
+  elif [ -n "$token" ] && printf '%s' "$MANUAL" | grep -q "$token"; then
+    note "manual     $s  ($desc -- declared in RELEASE_MANUAL_STEPS)"
+  else
+    bad "UNSET  $s  ($desc)"
+    if [ -n "$token" ]; then
+      echo "         fix:  gh secret set $s < <keyfile>"
+      echo "         or:   gh variable set RELEASE_MANUAL_STEPS --body '<existing>,$token'"
+    else
+      echo "         fix:  gh secret set $s"
+    fi
+  fi
+done
+
+# A step declared manual is a REMINDER, not a free pass: it still has to happen.
+if [ -n "$MANUAL" ]; then
+  echo
+  echo "[manual steps -- CI will not do these, you must]"
+  IFS=',' read -ra STEPS <<< "$MANUAL"
+  for t in "${STEPS[@]}"; do
+    case "$(echo "$t" | tr -d ' ')" in
+      sourceforge) note "sourceforge  -> upload the release assets to Sourceforge by hand" ;;
+      vscode)      note "vscode       -> publish the .vsix from the build run's artifacts" ;;
+      playground)  note "playground   -> ssh <host> 'bash /opt/playground/repo/programs/web-playground/deploy/update.sh <VERSION>'" ;;
+      docs)        note "docs         -> rsync api/ to /var/www/objeck.org/api/v<VERSION>/ and repoint 'latest'" ;;
+      "")          ;;
+      *)           note "$t (unrecognised token -- no workflow honours it)" ;;
+    esac
+  done
+fi
+
+echo
+echo "=============================================================="
+if [ "$FAIL" -eq 0 ]; then
+  echo " release configuration OK -- every advertised step can run or is declared manual"
+else
+  echo " *** CONFIGURATION GAPS -- fix or declare before tagging ***"
+fi
+echo "=============================================================="
+exit "$FAIL"


### PR DESCRIPTION
Completes the work started in #687. Two commits.

## 1. Three more steps that skipped and passed

v2026.8.4 published with **four** publish jobs reporting `completed/success` having done nothing:

| Job | Reported | Actually |
|---|---|---|
| Upload to Sourceforge | ✅ | uploaded nothing — no `SOURCEFORGE_SSH_KEY` |
| Publish VS Code Extension | ✅ | published nothing — no `VSCE_PAT` |
| Deploy playground | ✅ | deployed nothing — no `PLAYGROUND_SSH_KEY` |
| Deploy API Documentation | ✅ | deployed nothing — no `OBJECK_ORG_SSH_KEY` |

None of those secrets has ever been set, so these steps have likely **never run in CI** while every release reported them green. The playground was left serving a 2026.6.1 engine and objeck.org a release-old set of API docs; both were repaired by hand after publishing.

#687 fixed the docs job. This does the other three.

**A missing secret is not a decision.** The `skip_sourceforge` / `skip_playground` inputs exist only on `workflow_dispatch`, so on the normal `workflow_run` path there was no way to say *"manual on purpose"* — and the absent secret said it instead, silently, as success.

`RELEASE_MANUAL_STEPS` is a repository **variable**, not a secret, so it applies on every trigger:

```
gh variable set RELEASE_MANUAL_STEPS --body 'sourceforge,vscode'
```

A step named there skips and says so. A step *not* named there, whose credentials are missing, now fails with the secret names and the command to declare it manual. Either way the release report matches what happened. (Already set to `sourceforge,vscode` on this repo.)

## 2. A pre-flight gate for pipeline configuration

Every existing pre-flight gate checks the *repository*. None checked whether the pipeline could **do what it advertises** — which is why the above went unnoticed for many releases. The jobs now fail rather than skip, but a failure *during* a release is still the expensive place to learn it: the tag is already pushed.

`tools/cicd/check_release_config.sh` cross-references every `secrets.*` the release workflows reference against what is set and against `RELEASE_MANUAL_STEPS`. Exit 0 = every advertised step can run or is declared manual. Exit 1 = each gap, with the command to fix or declare it.

It also prints declared-manual steps as a **to-do list**, because declaring one is a reminder, not a dispensation — Sourceforge and the Marketplace still have to be done by hand after publishing.

Live output on this repo:

```
RELEASE_MANUAL_STEPS = 'sourceforge,vscode'
  set        APPLE_CERTIFICATE_BASE64  (macOS signing/notarization)      [+7 more]
  GAP: UNSET  OBJECK_ORG_SSH_KEY  (objeck.org API docs deploy)
  GAP: UNSET  PLAYGROUND_HOST     (playground deploy)                    [+2 more]
  manual     SOURCEFORGE_SSH_KEY  (declared in RELEASE_MANUAL_STEPS)
  manual     VSCE_PAT             (declared in RELEASE_MANUAL_STEPS)
```

**One bug found by running it**, worth recording because it is the exact family this change is about: the first version matched `secrets\.[A-Z_]+`, which stops at the digits in `APPLE_CERTIFICATE_BASE64` and reported a *set* secret as a gap. A checker that fails like the defect it hunts is worse than no checker. Fixed and re-verified.

## 3. Release skill

- Adds the gate to step 1.
- Replaces the **"Unresolved"** `api.zip` section with the actual diagnosis: `code_doc` writes to a hardcoded `../html` the POSIX job never created, `FileWriter` fails silently, and the old gate counted the tracked zip. Also notes the 472- and 482-page archives are stamped **identically**, so the stamp cannot distinguish them — count pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
