### PR TITLE
docs(net): say why the short drains failed, now that a longer one ships

### DIFF
--- a/docs/windows_loopback_sockets.md
+++ b/docs/windows_loopback_sockets.md
@@ -52,11 +52,13 @@ run-to-run variance. **None of them work.** Do not spend a day rediscovering it:
 |---|---|
 | `SO_LINGER` before `shutdown` | no effect |
 | `SO_LINGER` with no `shutdown` | blocks >1s per close — unusable |
-| drain to EOF, 100ms bound | no effect |
-| drain to EOF, 400ms bound | no effect |
+| drain to EOF, 100ms bound | no effect — see note below |
+| drain to EOF, 400ms bound | no effect — see note below |
 | asymmetric sender-only drain | no effect |
 | `closesocket` with no `shutdown` | worse |
 | `SIO_TCP_INFO` / `BytesInFlight` | no effect — reports 0 in flight, because the data *is* delivered; the RST is what loses it |
+
+**On the two drain rows.** These are not saying a drain cannot work — `CloseGracefully()` below is a drain, and it measures 0 losses in 180 transfers. They are saying these *bounds* are too short: at 100ms and 400ms the drain gives up while the peer is still reading, this side closes first, and you are back in the failing case. What matters is not draining as such but who closes last, so a bound only helps if it is long enough for the peer to finish and hang up. The 1000ms default was chosen on that basis.
 
 The only mechanical thing that works is elapsed time before teardown, and that
 is not a fix. A delay inside `IPSocket::Close` would tax every socket close, on


### PR DESCRIPTION
`docs/windows_loopback_sockets.md` contradicts itself as of v2026.9.0.

Its **"what does not fix it"** table states, unqualified:

| attempt | result |
|---|---|
| drain to EOF, 100ms bound | no effect |
| drain to EOF, 400ms bound | no effect |

…and a few lines below, the same document recommends `CloseGracefully()` — which is **a drain to EOF with a 1000ms bound**, measured at 0 losses in 180 transfers against 21 for `Close()`.

Both statements are true. The reason is the **bound**, not the technique: at 100ms and 400ms the drain gives up while the peer is still reading, this side closes first, and the failing case returns. What matters is who closes *last*.

A reader hitting the table first has no way to know that, and would reasonably conclude either that the recommendation below it is wrong, or that the table is stale. Given the whole point of that document is to stop someone spending a day rediscovering this, the ambiguity is worth two lines.

Adds a note under the table and points the two rows at it. **No measurement is changed** — they stand as recorded.

Found while reviewing #690.

🤖 Generated with [Claude Code](https://claude.com/claude-code)