### PR TITLE
fix(release): a manual declaration nothing reads is not a declaration

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -682,8 +682,23 @@ jobs:
       # and is explicit -- the `skip_docs_deploy` workflow_dispatch input gates
       # this whole job -- so "skip on purpose" is available without "skip by
       # accident and report success" being the default.
+      # Declared-manual escape hatch, mirroring sourceforge and playground.
+      # Without this pair the `docs` token in RELEASE_MANUAL_STEPS was inert:
+      # check_release_config.sh reported "manual  OBJECK_ORG_* (declared in
+      # RELEASE_MANUAL_STEPS)" and passed pre-flight, then this job failed the
+      # v2026.9.0 publish anyway, because nothing here read the variable. The
+      # gate asserted a property the workflow did not implement.
+      - name: objeck.org docs are handled manually
+        if: env.OBJECK_ORG_SSH_KEY == '' && contains(vars.RELEASE_MANUAL_STEPS, 'docs')
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          echo "ℹ️  objeck.org API docs deploy is declared manual via RELEASE_MANUAL_STEPS - skipping."
+          echo "   Deploy by hand from this run's api-docs artifact (or master's docs/api.zip):"
+          echo "     rsync -avz --delete api/ USER@objeck.org:/var/www/objeck.org/api/v${VERSION}/"
+          echo "     ssh USER@objeck.org 'cd /var/www/objeck.org/api && ln -sfn v${VERSION} latest'"
+
       - name: Missing objeck.org credentials
-        if: env.OBJECK_ORG_SSH_KEY == ''
+        if: env.OBJECK_ORG_SSH_KEY == '' && !contains(vars.RELEASE_MANUAL_STEPS, 'docs')
         run: |
           echo "::error::objeck.org SSH credentials are not configured - API docs were NOT deployed"
           echo ""
@@ -695,6 +710,8 @@ jobs:
           echo "and on master at docs/api.zip. To deploy by hand:"
           echo "  rsync -avz --delete api/ USER@objeck.org:/var/www/objeck.org/api/v<VERSION>/"
           echo "  ssh USER@objeck.org 'cd /var/www/objeck.org/api && ln -sfn v<VERSION> latest'"
+          echo ""
+          echo "Or declare it manual:  gh variable set RELEASE_MANUAL_STEPS --body '<existing>,docs'"
           exit 1
 
       # Prove the deploy actually landed, rather than trusting rsync's exit code.

--- a/tools/cicd/check_release_config.sh
+++ b/tools/cicd/check_release_config.sh
@@ -78,7 +78,19 @@ for s in $REFERENCED; do
   if printf '%s\n' "$CONFIGURED" | grep -qx "$s"; then
     note "set        $s  ($desc)"
   elif [ -n "$token" ] && printf '%s' "$MANUAL" | grep -q "$token"; then
-    note "manual     $s  ($desc -- declared in RELEASE_MANUAL_STEPS)"
+    # Declaring a step manual only helps if a workflow actually READS the
+    # declaration. It did not for 'docs': this gate printed "manual ... declared
+    # in RELEASE_MANUAL_STEPS" and exited 0, and the v2026.9.0 publish then failed
+    # in Deploy API Documentation, because that job had a hard-fail on the missing
+    # secret and no contains(vars.RELEASE_MANUAL_STEPS, 'docs') branch beside it.
+    # A declaration nothing honours is worse than none: it reads as handled.
+    if grep -rq "contains(vars.RELEASE_MANUAL_STEPS, '$token')" "$WF_DIR"; then
+      note "manual     $s  ($desc -- declared in RELEASE_MANUAL_STEPS)"
+    else
+      bad "INERT  $s  ($desc -- '$token' is declared but NO workflow honours it)"
+      echo "         the step will still fail; add a guarded skip beside its"
+      echo "         hard-fail:  if: <secret> == '' && contains(vars.RELEASE_MANUAL_STEPS, '$token')"
+    fi
   else
     bad "UNSET  $s  ($desc)"
     if [ -n "$token" ]; then
@@ -102,7 +114,7 @@ if [ -n "$MANUAL" ]; then
       playground)  note "playground   -> ssh <host> 'bash /opt/playground/repo/programs/web-playground/deploy/update.sh <VERSION>'" ;;
       docs)        note "docs         -> rsync api/ to /var/www/objeck.org/api/v<VERSION>/ and repoint 'latest'" ;;
       "")          ;;
-      *)           note "$t (unrecognised token -- no workflow honours it)" ;;
+      *)           bad "$t (unrecognised token -- no workflow honours it)" ;;
     esac
   done
 fi


### PR DESCRIPTION
## What happened

The v2026.9.0 publish failed in **Deploy API Documentation**, even though `docs` was listed in `RELEASE_MANUAL_STEPS` and `check_release_config.sh` had passed pre-flight with *"release configuration OK — every advertised step can run or is declared manual"*.

The release itself is fine — it published, all 11 assets uploaded, both MSIs present. Only the docs job went red, and that deploy was going to be done by hand anyway.

## Why

Sourceforge and playground each have **two** steps: a guarded skip when the secret is absent *and* the step is declared manual, and a hard-fail when it is absent and *not* declared. The docs job only ever got the hard-fail half:

```yaml
- name: Missing objeck.org credentials
  if: env.OBJECK_ORG_SSH_KEY == ''      # no manual branch anywhere
```

So the `docs` token was inert. The escape hatch existed in the variable, and in the gate's output, but not in the code path that decides whether the job fails.

`check_release_config.sh` hid this instead of catching it. It confirmed the token was in the variable and printed `manual  OBJECK_ORG_SSH_KEY (declared in RELEASE_MANUAL_STEPS)` — a statement about the **variable**, not about whether any workflow honours it. Same shape as every defect in this series: a check that passes while measuring the adjacent thing.

## Fix

- `release-publish.yml` — the docs job gets the missing manual branch, and its hard-fail now offers the declaration the way sourceforge's does.
- `check_release_config.sh` — a declared token is only accepted if a workflow actually contains a branch reading it; otherwise it reports **INERT** and exits 1.

## Verification

Removed the new branch from the workflow and re-ran the gate:

```
exit=1
  GAP: INERT  OBJECK_ORG_SSH_KEY  ('docs' is declared but NO workflow honours it)
         hard-fail:  if: <secret> == '' && contains(vars.RELEASE_MANUAL_STEPS, 'docs')
  GAP: INERT  OBJECK_ORG_USER     ('docs' is declared but NO workflow honours it)
 *** CONFIGURATION GAPS -- fix or declare before tagging ***
```

Restored → exit 0. The check fails on the broken state and passes on the fixed one, so it is not passing for the wrong reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)