### PR TITLE
fix(release): signing is not finished until the manifest matches

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -444,6 +444,17 @@ Expected: build ~45-70 min (the arm64 leg dominates; vcpkg rebuilds
 `chore: update api.zip for v<VERSION> [skip ci]`, so any push you make during or after
 the build is rejected as non-fast-forward. Rebase onto it; the tag is unaffected.
 
+**Do not match the publish run by the tag's commit SHA.** That same api.zip commit is
+what `release-publish.yml` carries as its `headSha`, because it is triggered by
+`workflow_run` and not by the tag. A watcher looking for a publish run whose headSha
+equals the tag's commit finds nothing and reports "build green but publish never
+started" while the publish is running normally -- which is what happened at v2026.9.0.
+Match the publish run by **workflow + recency**, or follow it by run ID:
+
+```bash
+gh run list --workflow=release-publish.yml --limit=1 --json databaseId,status,conclusion
+```
+
 ### 9. Write the release body
 
 `release-publish.yml` sets a generic body with no changelog. Replace it. Combine the
@@ -463,6 +474,32 @@ verified" on the strength of the MSI existing is exactly how three consecutive r
 reports were wrong.
 
 ### 10-11b. Post-publish: ONE command
+
+**Signing is initiated by you, not requested by the user.** The moment
+`release-publish.yml` is green and the assets are on the release, send a
+`PushNotification` telling them to plug the eToken in, then RUN the signing.
+Do not report "ready to sign" and wait to be asked -- at v2026.9.0 the user had
+to say "you'll need to kick off the process of signing the binaries" after
+being told twice that it was ready. Reporting readiness is not the deliverable;
+a signed release is. The user's only part is typing the token password into
+SafeNet's own dialog, which appears on their desktop when `signtool` runs.
+
+The sequence, without pausing between:
+
+1. Publish goes green -> verify the assets exist (query the RELEASE, not the job
+   colours) and that both MSIs are present.
+2. `PushNotification`: token needed now.
+3. Run the signing (below). Warn in-band that the SafeNet dialog is about to
+   appear, once per MSI unless single-logon is on.
+4. Verify signatures on the **published** files and re-prove `SHA256SUMS`.
+
+**Use `post_release.sh --sign`, not `sign_release.cmd` directly.** The .cmd signs,
+verifies and re-uploads the MSIs, but it does NOT touch `SHA256SUMS` -- and signing
+rewrites the MSIs, so the published manifest is left describing pre-signing bytes and
+every user's `sha256sum -c` FAILS on exactly the two files whose integrity matters most.
+Gate 4 of `post_release.sh` regenerates and re-proves it; the bare .cmd leaves you to
+remember, which is how v2026.8.3 shipped a broken manifest. If the .cmd is run on its
+own, regenerating the manifest is not optional cleanup -- it is part of signing.
 
 Everything after `release-publish.yml` goes green is a single pipeline, and it runs as
 one script. It used to be four prose sections here, which meant the commands were

--- a/tools/cicd/sign_release.cmd
+++ b/tools/cicd/sign_release.cmd
@@ -100,6 +100,23 @@ for %%f in (%STAGING%\*.msi) do (
     echo Uploaded: %%~nxf
 )
 
+REM Regenerate SHA256SUMS -- signing REWROTE the MSIs, so the manifest published
+REM alongside them now describes bytes that no longer exist. Without this, every
+REM user running `sha256sum -c SHA256SUMS` sees both Windows installers FAIL --
+REM which is what v2026.8.3 shipped, because this step lived only in a human's
+REM memory and in post_release.sh's gate 4. Signing is not finished until the
+REM manifest describes the signed bytes.
+echo.
+echo Regenerating SHA256SUMS for the signed installers...
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0update_sha256sums.ps1" %VERSION%
+if errorlevel 1 (
+    echo.
+    echo ERROR: SHA256SUMS was NOT updated - the release now advertises hashes
+    echo        that do not match the signed MSIs. Fix before announcing:
+    echo          powershell -File tools\cicd\update_sha256sums.ps1 %VERSION%
+    exit /b 1
+)
+
 REM Cleanup
 rmdir /s /q %STAGING%
 

--- a/tools/cicd/update_sha256sums.ps1
+++ b/tools/cicd/update_sha256sums.ps1
@@ -1,0 +1,94 @@
+# Regenerate a release's SHA256SUMS from the PUBLISHED assets.
+#
+# Signing rewrites the MSIs, so a manifest generated before signing describes
+# bytes nobody can download. v2026.8.3 shipped exactly that: every user running
+# `sha256sum -c SHA256SUMS` would have seen both Windows installers FAIL, on the
+# two files whose integrity matters most. sign_release.cmd re-uploads the signed
+# MSIs but has never touched the manifest, so this ran by hand or not at all.
+#
+# Hashes the assets as downloaded from the release -- not local staging copies --
+# because the manifest describes what users get, and "the file I just signed" and
+# "the file the release serves" are only the same thing if the upload worked.
+#
+# Usage: update_sha256sums.ps1 <version>          e.g. 2026.9.0
+
+param([Parameter(Mandatory = $true)][string]$Version)
+
+$ErrorActionPreference = "Stop"
+$tag = "v$Version"
+$gh = "C:\Program Files\GitHub CLI\gh.exe"
+if (-not (Test-Path $gh)) { $gh = "gh" }
+
+$work = Join-Path $env:TEMP "sha256sums-$Version"
+if (Test-Path $work) { Remove-Item $work -Recurse -Force }
+New-Item -ItemType Directory -Path $work | Out-Null
+
+Write-Output "Downloading published assets for $tag ..."
+& $gh release download $tag --dir $work
+if ($LASTEXITCODE -ne 0) { throw "failed to download assets for $tag" }
+
+$manifest = Join-Path $work "SHA256SUMS"
+if (-not (Test-Path $manifest)) { throw "no SHA256SUMS asset on $tag" }
+
+# Rebuild every line from the bytes on disk, preserving the manifest's order and
+# file list. Recomputing all of them (not just the MSIs) means the result is a
+# statement about the release as it stands, not a patch applied on trust.
+$lines = Get-Content $manifest | Where-Object { $_.Trim() -ne "" }
+$out = @()
+$changed = @()
+foreach ($line in $lines) {
+    $parts = $line -split '\s+', 2
+    $oldHash = $parts[0]
+    $name = $parts[1].Trim().TrimStart('*')
+    $path = Join-Path $work $name
+    if (-not (Test-Path $path)) { throw "manifest names '$name' but it is not an asset of $tag" }
+    $newHash = (Get-FileHash $path -Algorithm SHA256).Hash.ToLower()
+    if ($newHash -ne $oldHash.ToLower()) { $changed += $name }
+    $out += "$newHash  $name"
+}
+
+if ($changed.Count -eq 0) {
+    Write-Output "SHA256SUMS already matches all $($out.Count) published assets - nothing to do."
+    exit 0
+}
+
+Write-Output ""
+Write-Output "Stale entries ($($changed.Count) of $($out.Count)):"
+$changed | ForEach-Object { Write-Output "  $_" }
+
+# Write LF-terminated: sha256sum(1) on Linux/macOS is the consumer, and CRLF
+# makes it report every line as improperly formatted.
+$text = ($out -join "`n") + "`n"
+[System.IO.File]::WriteAllText($manifest, $text, (New-Object System.Text.UTF8Encoding $false))
+
+Write-Output ""
+Write-Output "Uploading corrected SHA256SUMS ..."
+& $gh release upload $tag $manifest --clobber
+if ($LASTEXITCODE -ne 0) { throw "failed to upload SHA256SUMS" }
+
+# Prove it against the release, not against what we just wrote locally.
+$verify = Join-Path $env:TEMP "sha256sums-verify-$Version"
+if (Test-Path $verify) { Remove-Item $verify -Recurse -Force }
+New-Item -ItemType Directory -Path $verify | Out-Null
+& $gh release download $tag --pattern "SHA256SUMS" --dir $verify | Out-Null
+$published = Get-Content (Join-Path $verify "SHA256SUMS") | Where-Object { $_.Trim() -ne "" }
+
+$bad = @()
+foreach ($line in $published) {
+    $parts = $line -split '\s+', 2
+    $name = $parts[1].Trim().TrimStart('*')
+    $actual = (Get-FileHash (Join-Path $work $name) -Algorithm SHA256).Hash.ToLower()
+    if ($actual -ne $parts[0].ToLower()) { $bad += $name }
+}
+
+Remove-Item $work -Recurse -Force
+Remove-Item $verify -Recurse -Force
+
+if ($bad.Count -gt 0) {
+    Write-Output ""
+    Write-Output "VERIFICATION FAILED for: $($bad -join ', ')"
+    exit 1
+}
+
+Write-Output ""
+Write-Output "SHA256SUMS verified against all $($published.Count) published assets."


### PR DESCRIPTION
Follow-up to the v2026.9.0 release, which is signed and published. Three gaps, all found by doing the release rather than by reading about it.

## 1. `sign_release.cmd` left `SHA256SUMS` stale

Signing rewrites the MSIs, so the manifest published beside them describes bytes that no longer exist. Any user running `sha256sum -c SHA256SUMS` sees **both Windows installers FAIL** — the two files whose integrity matters most. v2026.8.3 shipped exactly that.

The `.cmd` re-uploads the signed MSIs and has never touched the manifest. The repair lived in `post_release.sh`'s gate 4 and in whoever remembered to run it; this release it was done by hand, afterwards, from memory. A step that runs only when someone recalls it is not part of the process.

**New `tools/cicd/update_sha256sums.ps1`**, called by `sign_release.cmd` before cleanup:

- hashes the **published** assets, not local staging copies — "the file I signed" and "the file the release serves" coincide only if the upload worked
- recomputes every line rather than patching the two MSI ones, so the result is a statement about the release rather than a patch applied on trust
- writes LF (`sha256sum(1)` rejects CRLF as improperly formatted)
- re-downloads the uploaded manifest and verifies it against the release
- no-op when already correct; the `.cmd` fails loudly if it cannot run

## 2. Signing waited to be asked

The skill said signing was a required human step but never said *who starts it*. The user was told twice the release was ready to sign and had to reply "you'll need to kick off the process of signing the binaries." Reporting readiness is not the deliverable — a signed release is.

The skill now spells out the sequence: publish green → verify the assets on the release → `PushNotification` that the token is needed → **run the signing**. The user's only part is typing the password into SafeNet's own dialog.

It also now says to prefer `post_release.sh --sign` over the bare `.cmd`, since gate 4 covers the manifest.

## 3. The publish watcher looked up the wrong SHA

`release-publish.yml` is `workflow_run`-triggered, so its `headSha` is the `chore: update api.zip` commit CI pushes — **not** the tag's commit. A watcher matching on the tag SHA reported *"build green but publish never started"* while the publish was running normally. Documented with the correct lookup.

## Verification

```
$ powershell -File tools/cicd/update_sha256sums.ps1 2026.9.0
Downloading published assets for v2026.9.0 ...
SHA256SUMS already matches all 10 published assets - nothing to do.
exit=0
```

Run against the live release, which was repaired by hand first — so this confirms the idempotent path. The rewrite path is what produced the currently-published manifest, verified with `sha256sum -c` against all ten freshly downloaded assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)