### PR TITLE
fix(deploy): the playground deploy that ships a fix should run the fix

### DIFF
--- a/.claude/skills/deploy-playground/SKILL.md
+++ b/.claude/skills/deploy-playground/SKILL.md
@@ -60,12 +60,51 @@ ssh root@$PLAYGROUND_HOST 'cd /opt/playground/repo && \
 
 Then re-run step 1. If it still fails, report the SSH output verbatim and stop.
 
-### 3. Version sanity check
+### 3. Version sanity check -- BOTH of them
+
+`/api/health` is a **label**, not evidence. It reports a hand-maintained constant
+in `backend/app/config.py`, which `git pull` updates on its own -- so it flips to
+the new version whether or not a single binary changed. It read `v2026.8.4` over
+a June engine for months, and it read `v2026.9.0` over a `2026.8.4` engine within
+seconds of the v2026.9.0 deploy.
+
+Always run both, and treat only the second as the answer:
 
 ```bash
+# the label
 curl -fsS https://playground.objeck.org/api/health | jq -r '.version'
-# must equal v<VERSION>  (the health endpoint returns the 'v' prefix)
+
+# the engine -- what actually executes
+curl -fsS -X POST https://playground.objeck.org/api/run   -H 'Content-Type: application/json'   -d '{"code":"class M { function : Main(a:String[])~Nil { System.Runtime->GetVersion()->PrintLine(); } }"}'
 ```
+
+If they disagree, the deploy did not install a toolchain. Do not report success.
+
+### 3b. Two failure modes that look like success
+
+**`update.sh` updates itself.** It lives in the repo it pulls, so a run that
+pulls a *new* `update.sh` keeps executing the old one -- and exits 0. At
+v2026.9.0 the first deploy printed `=== Update complete ===`, moved the health
+label, and never touched the toolchain; the identical command run a second time
+downloaded and installed the tarball. Fixed by re-exec'ing after the pull, but if
+you are ever on a server whose script predates that fix, **run the deploy twice**
+and compare -- a second run that does real work means the first one did not.
+
+A tell: the current script ends `=== Update complete (Objeck <VERSION>) ===`.
+A bare `=== Update complete ===` means an older script ran.
+
+**Do not pipe the ssh deploy through `head`.** `head` closes the pipe and can
+SIGPIPE the ssh mid-`docker build`, leaving a half-built image behind an
+apparently normal exit. Redirect to a file and read that, or use `tail` on the
+saved output:
+
+```bash
+ssh root@$PLAYGROUND_HOST 'bash /opt/playground/.../update.sh <VERSION>' 2>&1 | tee /tmp/deploy.log
+```
+
+The old single-shot health check (`sleep 3` then one curl) also cried wolf on
+every deploy, because uvicorn's workers need longer than 3s to bind. It polls for
+20s now; a failure there is real.
 
 > **If the version is stale after a successful deploy**, the reported string comes
 > from `programs/web-playground/backend/app/config.py` (`objeck_version`), a
@@ -94,6 +133,14 @@ If `playground.objeck.org` is unreachable, try the host directly:
   chat — a private key in a transcript is a leaked root credential.
 - Prefer a **dedicated** deploy key with a forced `command=` over your personal
   key, so a compromise can only run the deploy.
+
+## Sourceforge is not part of this
+
+Sourceforge mirrors the GitHub release through a **GitHub webhook** and updates
+itself when a release is published. It is not an SSH deploy, it is not this
+skill's job, and it needs no manual upload -- earlier notes calling it a manual
+post-release step are stale. Nothing to run; confirm the files appeared if you
+want, but do not wait on it.
 
 ## Note
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -481,7 +481,7 @@ Exit 0 only when all six gates pass. Read-only unless you pass the flags.
 | 3 signatures | real `Get-AuthenticodeSignature` on the **published** files | v2026.4.0-v2026.8.2 all shipped unsigned while the notes claimed otherwise |
 | 4 `SHA256SUMS` | manifest matches the published bytes; regenerates + re-proves if signing invalidated it | signing rewrites the MSIs, so v2026.8.3's manifest described pre-signing bytes and every user's verification would have FAILED |
 | 5 body | every advertised filename is a real asset; no `$VARS`, no `compare/v...`, no `[x]()` | the published body named `objeck-lsp-X.zip` (hyphen) when the asset is `objeck-lsp_X.zip`, and linked `compare/v...vX` |
-| 6 playground | `/api/health` reports the tag | the version is a tracked constant the deploy does not auto-bump |
+| 6 playground | `/api/health` reports the tag -- **and `/api/run` reports it too**; health is a label `git pull` moves on its own, so it flipped to v2026.9.0 over a 2026.8.4 engine | the version is a tracked constant the deploy does not auto-bump |
 
 `--sign` needs the SafeNet eToken plugged in and prompts for its password (once per MSI
 unless single-logon is on). Signing cannot happen in CI -- the key is non-exportable and a

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -486,7 +486,8 @@ jobs:
         if: env.SOURCEFORGE_SSH_KEY == '' && contains(vars.RELEASE_MANUAL_STEPS, 'sourceforge')
         run: |
           echo "ℹ️  Sourceforge upload is declared manual via RELEASE_MANUAL_STEPS - skipping."
-          echo "   Upload the release assets to Sourceforge by hand."
+          echo "   Nothing to do: Sourceforge mirrors the GitHub release through a"
+          echo "   GitHub webhook and updates itself once the release is published."
 
       - name: Missing Sourceforge credentials
         if: env.SOURCEFORGE_SSH_KEY == '' && !contains(vars.RELEASE_MANUAL_STEPS, 'sourceforge')
@@ -708,8 +709,8 @@ jobs:
           echo ""
           echo "The docs that should have shipped are in this run's api-docs artifact,"
           echo "and on master at docs/api.zip. To deploy by hand:"
-          echo "  rsync -avz --delete api/ USER@objeck.org:/var/www/objeck.org/api/v<VERSION>/"
-          echo "  ssh USER@objeck.org 'cd /var/www/objeck.org/api && ln -sfn v<VERSION> latest'"
+          echo "  rsync -avz --delete api/ USER@objeck.org:/var/www/objeck.org/api/latest/"
+          echo "  (there are no versioned /api/v<VERSION>/ directories - 'latest' is the only served path)"
           echo ""
           echo "Or declare it manual:  gh variable set RELEASE_MANUAL_STEPS --body '<existing>,docs'"
           exit 1

--- a/programs/web-playground/deploy/update.sh
+++ b/programs/web-playground/deploy/update.sh
@@ -12,6 +12,17 @@ DEPLOY_DIR="$REPO_DIR/core/release/deploy"
 STAMP_FILE="$DEPLOY_DIR/.installed-version"
 WANT_VERSION="${1:-}"
 
+# This script lives in the repo it pulls, so a run that updates the script keeps
+# executing the OLD logic -- and reports success. That is not hypothetical: the
+# v2026.9.0 deploy printed "Update complete", flipped /api/health to v2026.9.0,
+# and left the engine on 2026.8.4, because the tarball-install step did not exist
+# in the copy bash was running. Re-running the identical command installed it.
+# Nothing in the first run's output distinguished it from a real deploy.
+#
+# So: hash ourselves before the pull, and re-exec if the pull changed us.
+SELF="$(readlink -f "$0")"
+SELF_HASH_BEFORE="$(sha256sum "$SELF" | cut -d' ' -f1)"
+
 echo "=== Updating Objeck Playground ==="
 
 # ---------------------------------------------------------------- pull
@@ -42,6 +53,22 @@ if ! sudo -u playground git pull origin master; then
         sudo -u playground git checkout HEAD -- .
         sudo -u playground git stash drop || true
     }
+fi
+
+# ---------------------------------------------------------------- re-exec
+#
+# The pull may have replaced this script. Hand over to the new one before any
+# real work happens, so the deploy that ships a fix to update.sh is the deploy
+# that benefits from it, not the one after. UPDATE_SH_REEXEC stops a loop if the
+# hash somehow keeps changing.
+if [ -z "${UPDATE_SH_REEXEC:-}" ]; then
+    SELF_HASH_AFTER="$(sha256sum "$SELF" | cut -d' ' -f1)"
+    if [ "$SELF_HASH_BEFORE" != "$SELF_HASH_AFTER" ]; then
+        echo ""
+        echo "--- update.sh changed in this pull; re-executing the new version ---"
+        export UPDATE_SH_REEXEC=1
+        exec bash "$SELF" "$@"
+    fi
 fi
 
 # ------------------------------------------------------- objeck toolchain
@@ -134,12 +161,22 @@ docker container prune -f
 # a label, and it was correct while the engine underneath was three months old.
 # Only running code through the sandbox says what actually executes.
 echo ""
+# Poll rather than sleeping a fixed 3s and asking once. uvicorn with --workers 2
+# needs longer than that to bind, so the single-shot check printed
+# "ERROR: API health check failed!" moments after a restart that was fine --
+# a false alarm on every deploy trains you to ignore the true one.
 echo "--- Health check ---"
-sleep 3
-if curl -sf http://localhost:8000/api/health > /dev/null; then
-    echo "API is healthy"
-else
-    echo "ERROR: API health check failed!"
+HEALTHY=""
+for i in $(seq 1 20); do
+    if curl -sf --max-time 5 http://localhost:8000/api/health > /dev/null; then
+        HEALTHY=1
+        echo "API is healthy (after ${i}s)"
+        break
+    fi
+    sleep 1
+done
+if [ -z "$HEALTHY" ]; then
+    echo "ERROR: API did not become healthy within 20s"
     systemctl status playground --no-pager
     exit 1
 fi

--- a/tools/cicd/check_release_config.sh
+++ b/tools/cicd/check_release_config.sh
@@ -109,10 +109,17 @@ if [ -n "$MANUAL" ]; then
   IFS=',' read -ra STEPS <<< "$MANUAL"
   for t in "${STEPS[@]}"; do
     case "$(echo "$t" | tr -d ' ')" in
-      sourceforge) note "sourceforge  -> upload the release assets to Sourceforge by hand" ;;
+      # Sourceforge mirrors the GitHub release via a GitHub WEBHOOK -- it updates
+      # itself when the release is published. The token stays declared so the job
+      # does not hard-fail on the unset secrets, but there is nothing to do by hand.
+      sourceforge) note "sourceforge  -> nothing to do: a GitHub webhook mirrors the release" ;;
       vscode)      note "vscode       -> publish the .vsix from the build run's artifacts" ;;
       playground)  note "playground   -> ssh <host> 'bash /opt/playground/repo/programs/web-playground/deploy/update.sh <VERSION>'" ;;
-      docs)        note "docs         -> rsync api/ to /var/www/objeck.org/api/v<VERSION>/ and repoint 'latest'" ;;
+      # objeck.org has NO versioned doc directories -- /api/v2026.8.4/, v2026.8.3,
+      # v2026.8.2 and v2026.6.1 all 404. `latest` is the only served path, so
+      # rsync straight into it; the symlink dance in the old hint described a
+      # layout that has never existed and would send you hunting for a 404.
+      docs)        note "docs         -> rsync api/ into /var/www/objeck.org/api/latest/ (no versioned dirs exist)" ;;
       "")          ;;
       *)           bad "$t (unrecognised token -- no workflow honours it)" ;;
     esac


### PR DESCRIPTION
Learnings from the v2026.9.0 playground deploy. Every one of them presented as success.

## 1. `update.sh` updates itself, then runs the old logic

It lives in the repo it pulls, so a run that pulls a *new* `update.sh` keeps executing the old one — and exits 0.

The first v2026.9.0 deploy printed `=== Update complete ===`, moved `/api/health` to `v2026.9.0`, and left the engine on `2026.8.4`. The tarball-install step simply wasn't in the copy bash was running. The **identical command, run a second time**, downloaded and installed it:

```
--- Objeck toolchain (want 2026.9.0, have none) ---
Downloading objeck-linux-x64_2026.9.0.tgz ...
SHA256 verified
Installed Objeck 2026.9.0
```

Nothing in the first run's output distinguished it from a real deploy.

**Fix:** hash the script before the pull, `exec` the new one if the pull changed it, guarded by `UPDATE_SH_REEXEC` against loops.

## 2. The health check cried wolf on every deploy

`sleep 3` then one `curl`. uvicorn with `--workers 2` needs longer than that to bind, so it printed `ERROR: API health check failed!` seconds after a restart that was fine. A check that fails every time is how a real failure gets waved through — I nearly did exactly that.

**Fix:** poll for 20s, report which second it came up.

## 3. `/api/health` is a label, not evidence

It reports a hand-maintained constant in `config.py` that `git pull` updates on its own — so it moves to the new version whether or not a single binary changed. It read `v2026.8.4` over a June engine for months, and `v2026.9.0` over a `2026.8.4` engine within seconds of this deploy.

The skill now puts the `/api/run` probe beside it and says only the second one answers the question. Also documented: **don't pipe the ssh deploy through `head`** — it can SIGPIPE the ssh mid-`docker build` and leave a half-built image behind a normal-looking exit.

## 4. Sourceforge is a webhook, not a chore

It mirrors the GitHub release when the release is published. The token stays in `RELEASE_MANUAL_STEPS` so the job doesn't hard-fail on unset secrets, but the gate and workflow now say *nothing to do* instead of sending you to upload files by hand.

## 5. objeck.org has no versioned doc directories

```
/api/v2026.8.4/   404
/api/v2026.8.3/   404
/api/v2026.8.2/   404
/api/v2026.6.1/   404
```

`latest` is the only served path. Both the gate hint and the workflow's failure message told you to rsync into `/api/v<VERSION>/` and repoint a symlink — a layout that has never existed.

## Verification

`bash -n` on both scripts, YAML parses, and the pre-flight gate runs clean with the corrected to-do text. The re-exec path gets its live test on the next deploy: the server is still running the pre-fix script, so the pull that lands this commit is exactly the case it's built for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)