### PR TITLE
feat(release): an open issue must be fixed or explained before a tag

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -117,6 +117,34 @@ gap with the command to fix or declare it. Steps declared manual are printed as 
 to-do list — declaring one is a reminder, not a free pass: **you still have to do
 it after publishing.**
 
+**Second, the open-issue gate:**
+
+```bash
+tools/cicd/check_open_issues.sh "$VERSION"
+```
+
+Releases were cut without ever looking at the issue list. Nothing forced the
+question, so an issue could sit open across several releases having never been
+considered -- and from the outside that is indistinguishable from one deliberately
+deferred. The difference is the whole point: "this can wait, because X" is a
+decision; "nobody looked" is not.
+
+This does **not** require issues to be fixed before a release. It requires each
+open one to be either fixed or explained, in a place that outlives the conversation
+where it was decided. To defer:
+
+```bash
+gh issue comment <N> --body "Deferred from v$VERSION: <why it waits>"
+```
+
+The note names the version, and a note from an **older** release does not carry
+forward -- every release re-asks the question, so one deferral cannot silence an
+issue permanently. Exit 1 lists each unexplained issue with the command to record it.
+
+Read what the gate prints, and pull anything that should ship into this release
+before tagging. Deferring the whole list to clear the gate is the failure this is
+meant to prevent.
+
 Then run the following and **abort** on the first failure:
 
 ```bash

--- a/tools/cicd/check_open_issues.sh
+++ b/tools/cicd/check_open_issues.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Release gate: every open issue is either fixed in this release, or carries a
+# written reason it is not.
+#
+# Releases were cut without ever looking at the issue list. Nothing forced the
+# question, so an issue could sit open across several releases having never been
+# considered -- indistinguishable, from the outside, from one deliberately
+# deferred. The difference matters: "we decided this can wait, because X" is a
+# decision, and "nobody looked" is not.
+#
+# This does not require issues to be FIXED before a release. It requires the
+# deferral to be a recorded decision. Fix it, or say why not, in a place that
+# outlives the conversation where it was decided.
+#
+# To defer an issue, comment on it (the first line is parsed as the reason):
+#
+#   gh issue comment <N> --body "Deferred from v2026.9.0: needs a reproducer on
+#   real hardware; the loopback-only shape is not what users hit."
+#
+# Usage: check_open_issues.sh <version>        e.g. 2026.9.0
+# Exit 0 = every open issue is accounted for. Exit 1 = at least one is not.
+
+set -uo pipefail
+
+VERSION="${1:-}"
+[ -n "$VERSION" ] || { echo "usage: check_open_issues.sh <version>"; exit 1; }
+REPO="${REPO:-objeck/objeck-lang}"
+MARKER="Deferred from v$VERSION"
+
+echo "=============================================================="
+echo " open-issue triage for v$VERSION"
+echo "=============================================================="
+
+# Test hooks. A gate whose failing path has never run is not a gate -- with an
+# empty issue list every path below "nothing to triage" is dead code, and this
+# would pass identically if the parsing were broken. These exercise both paths
+# without opening throwaway issues on the real repo.
+#   ISSUES_FILE=<file>  tab-separated "<number>	<title>" lines, one per issue
+#   REASONS_DIR=<dir>   <dir>/<number> holds that issue's comment body
+if [ -n "${ISSUES_FILE:-}" ]; then
+  ISSUES=$(cat "$ISSUES_FILE")
+else
+  ISSUES=$(gh issue list --repo "$REPO" --state open --limit 200 \
+             --json number,title --jq '.[] | (.number|tostring) + "\t" + .title' 2>/dev/null)
+  if [ $? -ne 0 ]; then
+    echo "  cannot read the issue list for $REPO (auth/permissions?) -- aborting"
+    exit 1
+  fi
+fi
+
+if [ -z "$ISSUES" ]; then
+  echo
+  echo " no open issues -- nothing to triage"
+  exit 0
+fi
+
+FAIL=0
+DEFERRED=0
+
+while IFS=$'\t' read -r num title; do
+  [ -n "$num" ] || continue
+  # Look for a deferral note naming THIS version. A note from an older release
+  # does not carry forward: each release re-asks the question, which is the
+  # whole point -- otherwise one deferral silences an issue permanently.
+  if [ -n "${REASONS_DIR:-}" ]; then
+    REASON=""
+    if [ -f "$REASONS_DIR/$num" ] && grep -q "^$MARKER" "$REASONS_DIR/$num"; then
+      REASON=$(cat "$REASONS_DIR/$num")
+    fi
+  else
+    REASON=$(gh issue view "$num" --repo "$REPO" --json comments \
+               --jq '[.comments[].body | select(startswith("'"$MARKER"'"))] | last // ""' 2>/dev/null)
+  fi
+  if [ -n "$REASON" ]; then
+    # first line after the marker, trimmed
+    TEXT=$(printf '%s' "$REASON" | sed "s/^$MARKER:*[[:space:]]*//" | head -3 | tr '\n' ' ')
+    echo
+    echo "  DEFERRED  #$num  $title"
+    echo "            reason: $TEXT"
+    DEFERRED=$((DEFERRED + 1))
+  else
+    echo
+    echo "  UNTRIAGED #$num  $title"
+    echo "            fix it before tagging, or record why it waits:"
+    echo "            gh issue comment $num --body \"$MARKER: <reason>\""
+    FAIL=$((FAIL + 1))
+  fi
+done <<< "$ISSUES"
+
+echo
+echo "=============================================================="
+if [ "$FAIL" -eq 0 ]; then
+  echo " all open issues accounted for ($DEFERRED deferred with a reason)"
+  echo "=============================================================="
+  exit 0
+fi
+echo " *** $FAIL open issue(s) neither fixed nor explained ***"
+echo " Deferring is fine. Deferring silently is not."
+echo "=============================================================="
+exit 1


### PR DESCRIPTION
Releases were cut without ever consulting the issue list. Nothing in the process asked, so an issue could sit open across several releases having never been considered — and from the outside, *"we decided this can wait, because X"* and *"nobody looked"* are indistinguishable. Only one of them is a decision.

## What the gate does

`tools/cicd/check_open_issues.sh <version>` — run as the second pre-flight gate, beside `check_release_config.sh`.

It does **not** require issues to be fixed before a release. It requires each open one to be either fixed or explained, somewhere that outlives the conversation where it was decided:

```bash
gh issue comment <N> --body "Deferred from v2026.9.1: <why it waits>"
```

The gate prints each reason, so the reasoning lands in the release log rather than in someone's memory. A note naming an **older** version does not carry forward — every release re-asks the question, so one deferral can't silence an issue permanently.

The skill also says plainly that deferring the whole list to clear the gate is the failure this is meant to prevent.

## Testing

The live repo has **no open issues** right now (#669 and #659 both closed in v2026.9.0), so a live run only ever exercises `no open issues -- nothing to triage`. Every branch past that line is dead code under that condition, and the gate would pass identically if the parsing were broken — the exact "check that passes while measuring nothing" shape the last several PRs have been unpicking.

So it ships with `ISSUES_FILE` / `REASONS_DIR` test hooks (house style, cf. `OBU_TEST_HOOKS`) and was driven through all four paths:

| case | result |
|---|---|
| 3 open, none explained | exit 1, all three named with the command to record them |
| 1 explained, 2 not | exit 1; #901 printed with its reason, others flagged |
| all 3 explained | exit 0, "3 deferred with a reason" |
| v2026.9.1 notes, checked at v2026.9.2 | exit 1 — correctly refuses to carry forward |

Plus a clean live run against the real repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)