### PR TITLE
fix(macos): ship an uninstaller, and make the shell edit removable

### DIFF
--- a/core/release/create_macos_pkg.sh
+++ b/core/release/create_macos_pkg.sh
@@ -69,6 +69,12 @@ echo "Staging files..."
 mkdir -p "$STAGING_DIR$INSTALL_PREFIX"
 cp -R "$DEPLOY_DIR"/* "$STAGING_DIR$INSTALL_PREFIX/"
 
+# Ship the uninstaller inside the install tree. The .pkg previously shipped none,
+# so removing Objeck meant deleting /usr/local/objeck-lang by hand and leaving the
+# PATH entry, the LaunchDaemon and an export line in /etc/zshenv behind.
+cp "$(dirname "$0")/macos_uninstall.sh" "$STAGING_DIR$INSTALL_PREFIX/uninstall.sh"
+chmod 755 "$STAGING_DIR$INSTALL_PREFIX/uninstall.sh"
+
 # ============================================
 # Create postinstall script (PATH setup)
 # ============================================
@@ -104,19 +110,47 @@ cat > /Library/LaunchDaemons/org.objeck.env.plist << PLIST
 </plist>
 PLIST
 
-# Also set for current session via shell profile
-PROFILE_LINE='export OBJECK_LIB_PATH=/usr/local/objeck-lang/lib'
-SHELLS=("/etc/zshenv" "/etc/profile")
-for SHELL_RC in "${SHELLS[@]}"; do
-  if [ -f "$SHELL_RC" ]; then
-    if ! grep -q "OBJECK_LIB_PATH" "$SHELL_RC" 2>/dev/null; then
-      echo "$PROFILE_LINE" >> "$SHELL_RC"
-    fi
+# OBJECK_LIB_PATH for terminal sessions.
+#
+# This edit is load-bearing, not belt-and-braces: /etc/paths.d sets PATH only,
+# and without OBJECK_LIB_PATH the toolchain falls back to "../lib/" relative to
+# the CURRENT WORKING DIRECTORY (see GetLibraryPath in core/shared/sys.h), so
+# obc would work only when run from the install's own bin/.
+#
+# It previously appended only to files that already existed:
+#     SHELLS=("/etc/zshenv" "/etc/profile")
+#     if [ -f "$SHELL_RC" ]; then ... fi
+# Stock macOS ships /etc/zshrc and /etc/zprofile but NOT /etc/zshenv, and zsh --
+# the default shell since Catalina -- never reads /etc/profile. So on a default
+# install the variable was written where zsh does not look and nowhere it does.
+# Create the zsh file rather than skipping it.
+#
+# The block is delimited so the uninstaller can remove exactly what was added.
+# The old single appended line had no marker and nothing ever removed it, which
+# left a dangling export pointing at a deleted directory in a SYSTEM file.
+OBJECK_BEGIN='# >>> objeck >>>'
+OBJECK_END='# <<< objeck <<<'
+
+write_env_block() {
+  rc="$1"
+  [ -e "$rc" ] || : > "$rc"
+  if grep -qF "$OBJECK_BEGIN" "$rc" 2>/dev/null; then
+    return 0                      # already managed; upgrade leaves it alone
   fi
-done
+  {
+    echo "$OBJECK_BEGIN"
+    echo "# Added by the Objeck installer. Removed by $INSTALL_DIR/uninstall.sh"
+    echo "export OBJECK_LIB_PATH=$INSTALL_DIR/lib"
+    echo "$OBJECK_END"
+  } >> "$rc"
+}
+
+write_env_block /etc/zshenv       # zsh: read by every zsh, login or not
+write_env_block /etc/profile      # sh/bash
 
 echo "Objeck installed to $INSTALL_DIR"
 echo "Open a new terminal for PATH changes to take effect."
+echo "To remove Objeck: sudo $INSTALL_DIR/uninstall.sh"
 exit 0
 POSTINSTALL
 chmod +x "$SCRIPTS_DIR/postinstall"

--- a/core/release/macos_uninstall.sh
+++ b/core/release/macos_uninstall.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+#
+# Objeck uninstaller for macOS.
+#
+# The .pkg shipped no uninstaller at all, which mattered more than it sounds:
+# the installer writes to four places outside its own directory, and one of them
+# is an export line appended to SYSTEM shell files. Deleting
+# /usr/local/objeck-lang by hand -- the obvious thing to do -- left that line
+# behind pointing at a directory that no longer exists, in /etc/zshenv, for
+# every user on the machine.
+#
+# This removes exactly what the postinstall created:
+#   /usr/local/objeck-lang            the install itself
+#   /etc/paths.d/objeck               PATH entry
+#   /Library/LaunchDaemons/org.objeck.env.plist   OBJECK_LIB_PATH for GUI apps
+#   the '# >>> objeck >>>' block in /etc/zshenv and /etc/profile
+#
+# Usage: sudo ./uninstall.sh [--dry-run]
+
+set -u
+
+INSTALL_DIR="/usr/local/objeck-lang"
+PATHS_D="/etc/paths.d/objeck"
+PLIST="/Library/LaunchDaemons/org.objeck.env.plist"
+RC_FILES=("/etc/zshenv" "/etc/profile")
+BEGIN='# >>> objeck >>>'
+END='# <<< objeck <<<'
+
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+if [ "$DRY_RUN" -eq 0 ] && [ "$(id -u)" -ne 0 ]; then
+  echo "This uninstaller must run as root:  sudo $0" >&2
+  exit 1
+fi
+
+say() { if [ "$DRY_RUN" -eq 1 ]; then echo "would $*"; else echo "$*"; fi; }
+
+# ---- the launchd job, unloaded before its plist is removed ----
+if [ -f "$PLIST" ]; then
+  say "remove $PLIST"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    launchctl unload "$PLIST" 2>/dev/null || true
+    # The daemon ran `launchctl setenv`; unloading does not unset it, so the
+    # variable would survive in the GUI session until the next reboot.
+    launchctl unsetenv OBJECK_LIB_PATH 2>/dev/null || true
+    rm -f "$PLIST"
+  fi
+else
+  echo "not present: $PLIST"
+fi
+
+# ---- PATH entry ----
+if [ -f "$PATHS_D" ]; then
+  say "remove $PATHS_D"
+  [ "$DRY_RUN" -eq 0 ] && rm -f "$PATHS_D"
+else
+  echo "not present: $PATHS_D"
+fi
+
+# ---- the delimited block in system shell files ----
+#
+# Matched by marker, not by content: a grep for 'OBJECK_LIB_PATH' would also
+# match a line the user wrote themselves, and deleting that would be worse than
+# leaving ours behind. Installs from before the markers existed are reported
+# rather than guessed at.
+for rc in "${RC_FILES[@]}"; do
+  [ -f "$rc" ] || continue
+  if grep -qF "$BEGIN" "$rc" 2>/dev/null; then
+    say "remove the objeck block from $rc"
+    if [ "$DRY_RUN" -eq 0 ]; then
+      tmp="$(mktemp)"
+      if awk -v b="$BEGIN" -v e="$END" '
+        index($0, b) { skip = 1; next }
+        index($0, e) { skip = 0; next }
+        !skip        { print }
+      ' "$rc" > "$tmp"; then
+        # Gate on awk's exit status, NOT on whether the result is empty. An
+        # empty result is the COMMON case, not a failure: on stock macOS
+        # /etc/zshenv does not exist, the installer creates it, and it then
+        # holds nothing but our block -- so "refuse to empty the file" would
+        # leave the block behind precisely where it always needs removing.
+        # Written through cat so the file keeps its own mode and owner rather
+        # than inheriting mktemp's 0600 root.
+        cat "$tmp" > "$rc"
+      else
+        echo "  refused: could not rewrite $rc; leaving it untouched" >&2
+      fi
+      rm -f "$tmp"
+    fi
+  elif grep -q "OBJECK_LIB_PATH" "$rc" 2>/dev/null; then
+    echo "NOTE: $rc sets OBJECK_LIB_PATH but has no objeck marker block."
+    echo "      It predates this uninstaller (or was edited by hand)."
+    echo "      Remove the line yourself if you want it gone:"
+    grep -n "OBJECK_LIB_PATH" "$rc" | sed 's/^/        /'
+  fi
+done
+
+# ---- the install itself, last: everything above references it ----
+if [ -d "$INSTALL_DIR" ]; then
+  say "remove $INSTALL_DIR"
+  [ "$DRY_RUN" -eq 0 ] && rm -rf "$INSTALL_DIR"
+else
+  echo "not present: $INSTALL_DIR"
+fi
+
+# ---- forget the package receipt, so a reinstall is clean ----
+if [ "$DRY_RUN" -eq 0 ]; then
+  pkgutil --forget org.objeck.lang >/dev/null 2>&1 || true
+else
+  echo "would forget the org.objeck.lang receipt"
+fi
+
+echo
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "Dry run: nothing was changed."
+else
+  echo "Objeck removed. Open a new terminal for the PATH change to take effect."
+fi

--- a/core/utils/updater/obu.cpp
+++ b/core/utils/updater/obu.cpp
@@ -575,7 +575,10 @@ static int DoCheck(bool is_quiet, const std::string& channel)
 }
 
 /* ===================================================================
- * Update engine (POSIX). Windows is deferred to phase 3.
+ * Update engine. Windows included: OBU_UPDATE_SUPPORTED is 1 for _WIN32 and
+ * RunArgv has a CreateProcess path, so `obu update` runs on all three platforms.
+ * This said "POSIX. Windows is deferred to phase 3" long after that stopped
+ * being true, which reads as a supported platform being unsupported.
  * =================================================================== */
 
 /****************************


### PR DESCRIPTION
From the installer/updater usability review. The macOS `.pkg` wrote to four places and shipped no way to undo any of them.

## The problem

Deleting `/usr/local/objeck-lang` — the obvious way to remove Objeck — left behind `/etc/paths.d/objeck`, a LaunchDaemon, and an `export OBJECK_LIB_PATH` line in `/etc/zshenv` and `/etc/profile`. Those are **system** files affecting every user on the machine, and the export then pointed at a directory that no longer existed.

Nothing in the package could remove that line, because it carried no marker: a grep for `OBJECK_LIB_PATH` would equally match one the user wrote themselves.

## Changes

- **`macos_uninstall.sh` (new)**, staged into the install tree as `uninstall.sh`. Removes the install, the PATH entry, the LaunchDaemon (unloading it *and* `launchctl unsetenv`-ing the variable it set in the GUI session), and the delimited block. Matches by marker, never by content — a pre-marker install is **reported** with file and line rather than guessed at. `--dry-run` prints what it would do. Idempotent.
- **`postinstall`** now writes a `# >>> objeck >>>` delimited block.
- **`obu.cpp`** — the update engine was commented *"POSIX. Windows is deferred to phase 3"* long after `OBU_UPDATE_SUPPORTED` became `1` for `_WIN32` with a `CreateProcess` `RunArgv` path. It reads as a supported platform being unsupported.

## Why the shell edit couldn't just be deleted

`/etc/paths.d` sets `PATH` only. Without `OBJECK_LIB_PATH` the toolchain falls back to `../lib/` relative to the **working directory** (`GetLibraryPath`, `core/shared/sys.h`), so `obc` would work only when run from its own `bin/`. Making the edit removable was the available fix; making that fallback executable-relative is the better one, and is deliberately **not** attempted here.

## A functional bug fixed in passing

The block appended only to files that already existed:

```bash
SHELLS=("/etc/zshenv" "/etc/profile")
if [ -f "$SHELL_RC" ]; then ... fi
```

Stock macOS ships `/etc/zshrc` and `/etc/zprofile` but **not** `/etc/zshenv`, and zsh — the default shell since Catalina — never reads `/etc/profile`. So the variable was written where zsh does not look, and nowhere it does. It now creates the zsh file.

## Testing

Against a relocated fake install root:

| case | result |
|---|---|
| `--dry-run` | lists all five artifacts, changes nothing |
| live run | install, paths.d, plist and both blocks removed |
| file holding **only** our block | ends up empty |
| file with user content | `PS1`/comments kept, block gone |
| two stacked blocks | both removed, surrounding lines kept |
| re-run when clean | idempotent, reports "not present" |
| pre-marker line, no block | preserved and reported with line number |

The empty-file case is the **common** one — the installer creates `/etc/zshenv` on stock macOS — and an earlier draft of the guard refused to write an empty result, which would have left the block behind exactly where it always needs removing. It now gates on `awk`'s exit status.

Not covered: this was tested on Windows against a fake root, so `launchctl`, `pkgutil` and real `/etc` permissions are unexercised. Worth one run on a real Mac before it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)