### PR TITLE
perf(compiler): stop copying the library maps on every name lookup

### DIFF
--- a/core/compiler/linker.cpp
+++ b/core/compiler/linker.cpp
@@ -219,7 +219,20 @@ void Linker::ResolveExternalMethodCalls()
   }
 }
 
-std::unordered_map<std::wstring, LibraryAlias*> Linker::GetAllAliasesMap()
+// The three GetAll*Map getters return by REFERENCE. They used to return by
+// value, and the lazy cache below only avoids rebuilding the map -- not copying
+// it, which happened on every single call: every node, and every wstring key.
+//
+// Search{Alias,Class,Enum}Libraries then copied the whole map to perform ONE
+// lookup, and took `uses` by value on top of that. context.cpp calls them from
+// 75 sites, so a large share of name resolution was spent duplicating the
+// library class map. A sampling profile of a 4,087-line application put
+// hash<wstring, LibraryAlias*> at 20.4% of total compile time, with
+// RtlAllocateHeap/RtlFreeHeap/memcpy adding ~30% more.
+//
+// Returning a reference is safe because each map is built once, on first use,
+// and never mutated afterwards -- the only writes are the builders below.
+const std::unordered_map<std::wstring, LibraryAlias*>& Linker::GetAllAliasesMap()
 {
   if(all_aliases_map.empty()) {
     std::vector<LibraryAlias*> aliases = GetAllAliases();
@@ -270,7 +283,7 @@ std::vector<LibraryAlias*> Linker::GetAllAliases()
   return all_aliases;
 }
 
-std::unordered_map<std::wstring, LibraryClass*> Linker::GetAllClassesMap()
+const std::unordered_map<std::wstring, LibraryClass*>& Linker::GetAllClassesMap()
 {
   if(all_classes_map.empty()) {
     std::vector<LibraryClass*> klasses = GetAllClasses();
@@ -298,7 +311,7 @@ std::vector<LibraryClass*> Linker::GetAllClasses()
   return all_classes;
 }
 
-std::unordered_map<std::wstring, LibraryEnum*> Linker::GetAllEnumsMap()
+const std::unordered_map<std::wstring, LibraryEnum*>& Linker::GetAllEnumsMap()
 {
   if(all_enums_map.empty()) {
     std::vector<LibraryEnum*> enums = GetAllEnums();
@@ -326,16 +339,18 @@ std::vector<LibraryEnum*> Linker::GetAllEnums()
   return all_enums;
 }
 
-LibraryAlias* Linker::SearchAliasLibraries(const std::wstring& name, std::vector<std::wstring> uses)
+LibraryAlias* Linker::SearchAliasLibraries(const std::wstring& name, const std::vector<std::wstring>& uses)
 {
-  std::unordered_map<std::wstring, LibraryAlias*> alias_map = GetAllAliasesMap();
-  LibraryAlias* alias = alias_map[name];
+  const std::unordered_map<std::wstring, LibraryAlias*>& alias_map = GetAllAliasesMap();
+  std::unordered_map<std::wstring, LibraryAlias*>::const_iterator hit = alias_map.find(name);
+  LibraryAlias* alias = hit != alias_map.end() ? hit->second : nullptr;
   if(alias) {
     return alias;
   }
 
   for(size_t i = 0; i < uses.size(); ++i) {
-    alias = alias_map[uses[i] + L"." + name];
+    hit = alias_map.find(uses[i] + L"." + name);
+    alias = hit != alias_map.end() ? hit->second : nullptr;
     if(alias) {
       return alias;
     }
@@ -344,16 +359,18 @@ LibraryAlias* Linker::SearchAliasLibraries(const std::wstring& name, std::vector
   return nullptr;
 }
 
-LibraryClass* Linker::SearchClassLibraries(const std::wstring& name, std::vector<std::wstring> uses)
+LibraryClass* Linker::SearchClassLibraries(const std::wstring& name, const std::vector<std::wstring>& uses)
 {
-  std::unordered_map<std::wstring, LibraryClass*> klass_map = GetAllClassesMap();
-  LibraryClass* klass = klass_map[name];
+  const std::unordered_map<std::wstring, LibraryClass*>& klass_map = GetAllClassesMap();
+  std::unordered_map<std::wstring, LibraryClass*>::const_iterator hit = klass_map.find(name);
+  LibraryClass* klass = hit != klass_map.end() ? hit->second : nullptr;
   if(klass) {
     return klass;
   }
 
   for(size_t i = 0; i < uses.size(); ++i) {
-    klass = klass_map[uses[i] + L"." + name];
+    hit = klass_map.find(uses[i] + L"." + name);
+    klass = hit != klass_map.end() ? hit->second : nullptr;
     if(klass) {
       return klass;
     }
@@ -374,16 +391,18 @@ bool Linker::HasBundleName(const std::wstring& name)
   return false;
 }
 
-LibraryEnum* Linker::SearchEnumLibraries(const std::wstring& name, std::vector<std::wstring> uses)
+LibraryEnum* Linker::SearchEnumLibraries(const std::wstring& name, const std::vector<std::wstring>& uses)
 {
-  std::unordered_map<std::wstring, LibraryEnum*> enum_map = GetAllEnumsMap();
-  LibraryEnum* eenum = enum_map[name];
+  const std::unordered_map<std::wstring, LibraryEnum*>& enum_map = GetAllEnumsMap();
+  std::unordered_map<std::wstring, LibraryEnum*>::const_iterator hit = enum_map.find(name);
+  LibraryEnum* eenum = hit != enum_map.end() ? hit->second : nullptr;
   if(eenum) {
     return eenum;
   }
 
   for(size_t i = 0; i < uses.size(); ++i) {
-    eenum = enum_map[uses[i] + L"." + name];
+    hit = enum_map.find(uses[i] + L"." + name);
+    eenum = hit != enum_map.end() ? hit->second : nullptr;
     if(eenum) {
       return eenum;
     }

--- a/core/compiler/linker.h
+++ b/core/compiler/linker.h
@@ -1113,19 +1113,19 @@ public:
   std::vector<Library*> GetAllUsedLibraries();
 
   // returns all aliases including duplicates
-  std::unordered_map<std::wstring, LibraryAlias*> GetAllAliasesMap();
+  const std::unordered_map<std::wstring, LibraryAlias*>& GetAllAliasesMap();
 
   // returns all aliases including duplicates
   std::vector<LibraryAlias*> GetAllAliases();
 
   // returns all classes including duplicates
-  std::unordered_map<std::wstring, LibraryClass*> GetAllClassesMap();
+  const std::unordered_map<std::wstring, LibraryClass*>& GetAllClassesMap();
 
   // returns all classes including duplicates
   std::vector<LibraryClass*> GetAllClasses();
 
   // returns all enums including duplicates
-  std::unordered_map<std::wstring, LibraryEnum*> GetAllEnumsMap();
+  const std::unordered_map<std::wstring, LibraryEnum*>& GetAllEnumsMap();
 
   // returns all enums including duplicates
   std::vector<LibraryEnum*> GetAllEnums();
@@ -1139,13 +1139,13 @@ public:
   bool HasBundleName(const std::wstring &name);
 
   // finds the first alias match; note multiple matches may exist
-  LibraryAlias* SearchAliasLibraries(const std::wstring& name, std::vector<std::wstring> uses);
+  LibraryAlias* SearchAliasLibraries(const std::wstring& name, const std::vector<std::wstring>& uses);
 
   // finds the first class match; note multiple matches may exist
-  LibraryClass* SearchClassLibraries(const std::wstring& name, std::vector<std::wstring> uses);
+  LibraryClass* SearchClassLibraries(const std::wstring& name, const std::vector<std::wstring>& uses);
 
   // finds the first enum match; note multiple matches may exist
-  LibraryEnum* SearchEnumLibraries(const std::wstring& name, std::vector<std::wstring> uses);
+  LibraryEnum* SearchEnumLibraries(const std::wstring& name, const std::vector<std::wstring>& uses);
 
   void Load(bool is_lib);
 };


### PR DESCRIPTION
**−36% on a real application compile.** Found with a sampling profile, after two rounds of hand-inspection missed it.

## The defect

`Linker::GetAllAliasesMap()` — and its `Classes` and `Enums` twins — returned the whole `unordered_map` **by value**. The lazy cache avoided *rebuilding* it but not *copying* it: every call deep-copied every node and every `wstring` key.

The three callers made it worse, copying the map to perform **one** lookup, and taking `uses` by value too:

```cpp
LibraryAlias* Linker::SearchAliasLibraries(const std::wstring& name, std::vector<std::wstring> uses) {
  std::unordered_map<std::wstring, LibraryAlias*> alias_map = GetAllAliasesMap();  // full copy
  LibraryAlias* alias = alias_map[name];                                            // one lookup
```

`context.cpp` calls these from **75 sites**, so a large share of name resolution was spent duplicating the library class map.

## The profile

In-process sampler on a 4,087-line application (`wpr`/`xperf` need elevation; this doesn't):

```
20.41%  hash<wstring, LibraryAlias*>
14.36%  Scanner::CheckIdentifier
13.54%  RtlAllocateHeap
 9.54%  deflateReset          (zlib -- the write phase)
 8.82%  RtlFreeHeap
 7.38%  memcpy_repmovs
```

Heap traffic totals ~24.5%.

## The fix

Return `const&`, take `uses` by `const&`, and `find()` instead of `operator[]` — which additionally inserted a null entry on every miss, invisibly, into the copy about to be discarded.

| workload | before | after | change |
|---|---|---|---|
| real app + 3 libs | 1.819s | 1.164s | **−36.0%** |
| call-heavy 800 | 0.928s | 0.531s | **−42.7%** |
| 400 classes × 4 | 1.873s | 1.697s | −9.4% |
| jit_game_bot | 0.814s | 0.758s | −6.9% |

## Correctness

Not just "tests are green":

- **34 regression programs compiled with both compilers produce byte-identical `.obe`** — 0 differing, 0 exit-code mismatches
- **4 error paths** (undefined class, unknown bundle, unknown alias, unknown method) — identical messages *and* exit codes. Checked separately because `find()` changes the **miss** path, which is exactly where `operator[]` used to insert.
- regression **205 passed / 0 failed**
- LSP **45 passed / 0 failed**

Returning a reference is safe because each map is built once on first use and never mutated afterwards — the only writes are in the builders.

## Note for reviewers

`linker.h` is compiled into `libobjk_diags.dll` too, so rebuild `diag.sln` alongside the compiler. A stale DLL fails the LSP tests in a way that reads as an unrelated regression.

This supersedes nothing in #699 (`AddMethod`), which is independent and still worth taking, though its real-world effect is ~0% where this one is −36%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)