### PR TITLE
fix(examples): the lantern's mouse axes want opposite signs

### DIFF
--- a/programs/examples/gl_lantern.obs
+++ b/programs/examples/gl_lantern.obs
@@ -783,12 +783,16 @@ class Lantern {
 			@window->BeginFrame();
 			delta := @window->GetDelta();
 
-			# No sign flip on either axis. Both carried a * -1.0, which meant
-			# moving the mouse right turned left and pushing it forward looked
-			# down -- inverted on both axes at once, which reads as the controls
-			# being broken rather than as a preference.
+			# The two axes want OPPOSITE signs, which is why flipping both
+			# together was wrong in each direction it was tried. Turn takes the
+			# raw delta -- mouse right turns right. Look takes it negated, so
+			# pushing the mouse forward raises the view.
+			#
+			# Both carried a * -1.0 originally, which inverted the horizontal as
+			# well and made a dark maze genuinely hard to navigate; removing both
+			# then inverted the vertical the other way. One sign each.
 			@camera->Turn(@window->GetMouseDeltaX() * @sensitivity);
-			@camera->Look(@window->GetMouseDeltaY() * @sensitivity);
+			@camera->Look(@window->GetMouseDeltaY() * @sensitivity * -1.0);
 
 			Update(delta);
 			Draw();


### PR DESCRIPTION
`Turn` takes the raw delta so mouse-right turns right; `Look` takes it negated so pushing the mouse forward raises the view.

Both axes originally carried a `* -1.0`, which inverted the **horizontal** as well and made a dark maze genuinely hard to navigate. Removing both then inverted the **vertical** the other way. Neither uniform choice could be right — the two axes want opposite signs, one each.

## The run that settled it exercised the whole game for the first time

```
The dark closed over you.
Again. Four relics, and the lamp is full.
Relic taken -- 3 still out there.
Relic taken -- 2 still out there.
Relic taken -- 1 still out there.
Relic taken -- 0 still out there.
```

Death, restart on `R`, and a full collection — every path in the demo, in one session. Eleven sessions ago not a single relic had ever been picked up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)