### PR TITLE
docs: index the new docs; JSON Encode/ToString doc comments state the escaping contract

### DIFF
--- a/core/compiler/lib_src/json.obs
+++ b/core/compiler/lib_src/json.obs
@@ -1522,9 +1522,13 @@ obj->ToString()->PrintLine();
 		}
 
 		#~
-		General encoding for JSON strings
+		Escapes a string for inclusion in JSON text (quotes, backslashes, control
+		characters, non-ASCII as u-escapes). Serialization does this for you: ToString()
+		and Format() escape every string value and object key on the way out, so a
+		value handed to Insert() must be RAW text -- encoding it first would escape
+		it twice. Call this only when building JSON text by hand.
 		@param str decoded string
-		@return encoding string
+		@return encoded string
 		~#
 		function : native : Encode(str : String) ~ String {
 			buffer := String->New();
@@ -1651,6 +1655,9 @@ obj->ToString()->PrintLine();
 		
 		#~
 		Stringify the JSON element
+		String values and object keys are escaped as they are written, so text that
+		holds quotes, backslashes or newlines produces valid JSON; do not pre-encode
+		values before inserting them.
 		@return JSON string
 
 		```

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@
 | [AI.md](AI.md) | AI and ML developer guide |
 | [MODELS.md](MODELS.md) | Models the AI bindings expect |
 | [opengl.md](opengl.md) | `Game.OpenGL` |
+| [third_party_dependencies.md](third_party_dependencies.md) | Where each platform gets mbedTLS, nghttp2, SDL2, OpenCV, ONNX Runtime — and how to read the version a build used |
 
 ## Platform notes
 
@@ -37,11 +38,13 @@ Behaviour specific to one platform, usually discovered the hard way.
 | [CI_CD.md](CI_CD.md) | CI/CD architecture |
 | [CI_CD_QUICK_START.md](CI_CD_QUICK_START.md) | The short version |
 | [release_process.md](release_process.md) | Cutting a release |
+| [release_integrity.md](release_integrity.md) | What a release verifies today, and the signed manifest that would let `obu` detect a substituted `SHA256SUMS` |
 
 ## Designs and plans
 
 Written before the work, and kept afterwards as the record of why it looks the way it does.
 
+- [SYSTEM_TERMINAL_DESIGN.md](SYSTEM_TERMINAL_DESIGN.md) — `System.Terminal`: styled output, progress bars, interactive controls, and the five VM traps they need
 - [UPDATER_DESIGN.md](UPDATER_DESIGN.md) — auto-updater
 - [ONNX_CUDA_PLAN.md](ONNX_CUDA_PLAN.md) — CUDA execution provider for ONNX
 - [HTTP3_WINDOWS_PLAN.md](HTTP3_WINDOWS_PLAN.md) — enabling HTTP/3 on Windows

--- a/tools/lsp/clients/vscode/server/objk_apis.json
+++ b/tools/lsp/clients/vscode/server/objk_apis.json
@@ -3211,7 +3211,7 @@
 					"descriptions": ["**General decoding for Json strings**\n\n```function : native : Decode(str:String) ~ String```\n\n\n\nstr: String\n\nreturn: String"]
 				},
 				"Encode": {
-					"descriptions": ["**General encoding for JSON strings**\n\n```function : native : Encode(str:String) ~ String```\n\n\n\nstr: String\n\nreturn: String"]
+					"descriptions": ["**Escapes a string for inclusion in JSON text (quotes, backslashes, control characters, non-ASCII as u-escapes). Serialization does this for you: ToString() and Format() escape every string value and object key on the way out, so a value handed to Insert() must be RAW text -- encoding it first would escape it twice. Call this only when building JSON text by hand.**\n\n```function : native : Encode(str:String) ~ String```\n\n\n\nstr: String\n\nreturn: String"]
 				},
 				"FindElements": {
 					"descriptions": ["**Queries the object graph. Object attributes referenced by '\/' while array elements are referenced by '[index]'. Example \"cars\/[last]\/make\".**\n\n```method : public : FindElements(path:String) ~ JsonElement```\n\n\n\npath: String\n\nreturn: JsonElement\n\n```\njson := Data.JSON.JsonParser->TextToElement(\"{\\\"users\\\":[{\\\"name\\\":\\\"Alice\\\"},{\\\"name\\\":\\\"Bob\\\"}]}\");\r\nalice := json->FindElements(\"users\/[0]\/name\");\r\nalice->GetString()->PrintLine();  # Alice\n```"]
@@ -3265,7 +3265,7 @@
 					"descriptions": ["**Stringify and format the JSON element**\n\n```method : public : ToFormattedString() ~ String```\n\n\n\nreturn: String\n\n```\nobj := Data.JSON.JsonParser->TextToElement(\"{\\\"a\\\":1,\\\"b\\\":2}\");\r\nobj->ToFormattedString()->PrintLine();\n```"]
 				},
 				"ToString": {
-					"descriptions": ["**Stringify the JSON element**\n\n```method : public : ToString() ~ String```\n\n\n\nreturn: String\n\n```\nobj := Data.JSON.JsonElement->New(Data.JSON.JsonElement->JsonType->OBJECT);\r\nobj->Insert(\"ok\", true);\r\nobj->ToString()->PrintLine();  # {\"ok\":true}\n```"]
+					"descriptions": ["**Stringify the JSON element String values and object keys are escaped as they are written, so text that holds quotes, backslashes or newlines produces valid JSON; do not pre-encode values before inserting them.**\n\n```method : public : ToString() ~ String```\n\n\n\nreturn: String\n\n```\nobj := Data.JSON.JsonElement->New(Data.JSON.JsonElement->JsonType->OBJECT);\r\nobj->Insert(\"ok\", true);\r\nobj->ToString()->PrintLine();  # {\"ok\":true}\n```"]
 				}
 			}
 		},

--- a/tools/lsp/server/objk_apis.json
+++ b/tools/lsp/server/objk_apis.json
@@ -3211,7 +3211,7 @@
 					"descriptions": ["**General decoding for Json strings**\n\n```function : native : Decode(str:String) ~ String```\n\n\n\nstr: String\n\nreturn: String"]
 				},
 				"Encode": {
-					"descriptions": ["**General encoding for JSON strings**\n\n```function : native : Encode(str:String) ~ String```\n\n\n\nstr: String\n\nreturn: String"]
+					"descriptions": ["**Escapes a string for inclusion in JSON text (quotes, backslashes, control characters, non-ASCII as u-escapes). Serialization does this for you: ToString() and Format() escape every string value and object key on the way out, so a value handed to Insert() must be RAW text -- encoding it first would escape it twice. Call this only when building JSON text by hand.**\n\n```function : native : Encode(str:String) ~ String```\n\n\n\nstr: String\n\nreturn: String"]
 				},
 				"FindElements": {
 					"descriptions": ["**Queries the object graph. Object attributes referenced by '\/' while array elements are referenced by '[index]'. Example \"cars\/[last]\/make\".**\n\n```method : public : FindElements(path:String) ~ JsonElement```\n\n\n\npath: String\n\nreturn: JsonElement\n\n```\njson := Data.JSON.JsonParser->TextToElement(\"{\\\"users\\\":[{\\\"name\\\":\\\"Alice\\\"},{\\\"name\\\":\\\"Bob\\\"}]}\");\r\nalice := json->FindElements(\"users\/[0]\/name\");\r\nalice->GetString()->PrintLine();  # Alice\n```"]
@@ -3265,7 +3265,7 @@
 					"descriptions": ["**Stringify and format the JSON element**\n\n```method : public : ToFormattedString() ~ String```\n\n\n\nreturn: String\n\n```\nobj := Data.JSON.JsonParser->TextToElement(\"{\\\"a\\\":1,\\\"b\\\":2}\");\r\nobj->ToFormattedString()->PrintLine();\n```"]
 				},
 				"ToString": {
-					"descriptions": ["**Stringify the JSON element**\n\n```method : public : ToString() ~ String```\n\n\n\nreturn: String\n\n```\nobj := Data.JSON.JsonElement->New(Data.JSON.JsonElement->JsonType->OBJECT);\r\nobj->Insert(\"ok\", true);\r\nobj->ToString()->PrintLine();  # {\"ok\":true}\n```"]
+					"descriptions": ["**Stringify the JSON element String values and object keys are escaped as they are written, so text that holds quotes, backslashes or newlines produces valid JSON; do not pre-encode values before inserting them.**\n\n```method : public : ToString() ~ String```\n\n\n\nreturn: String\n\n```\nobj := Data.JSON.JsonElement->New(Data.JSON.JsonElement->JsonType->OBJECT);\r\nobj->Insert(\"ok\", true);\r\nobj->ToString()->PrintLine();  # {\"ok\":true}\n```"]
 				}
 			}
 		},


### PR DESCRIPTION
Follow-up to the "is the code documented and part of docgen" check.

- `docs/README.md` now lists `third_party_dependencies.md` (Reference), `release_integrity.md` (Process) and `SYSTEM_TERMINAL_DESIGN.md` (Designs) — they were reachable only by path.
- `JsonElement->Encode`'s doc comment still described a world where callers encode values themselves. Since #721 the serializer escapes string values and object keys on the way out, and a pre-encoded value is escaped twice; `Encode` and `ToString` state that contract now.
- `objk_apis.json` (both copies) regenerated so hover/completion carry the new text. `json.obl` is byte-identical — comment-only change — and is not touched.

`check_doc_lists.py` and `check_doc_fences.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)