### PR TITLE
perf(jit): inline a->Size(), arithmetic >> on AMD64, no zero-check on constant divisors, save XMM10-15 on Windows, OBJECK_JIT_REPORT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Objeck will be documented in this file.
 
+## [Unreleased]
+
+The first batch of the JIT code-generation work from `docs/JIT_CODEGEN_ASSESSMENT_2026_09.md`.
+
+### Bug Fixes
+- **AMD64 JIT: `>>` was a logical shift** — the interpreter shifts a signed `INT64` (arithmetic) and the ARM64 backend emits `asr`, so `-8 >> 1` was `-4` in three places and `9223372036854775804` in the fourth: every negative operand of `>>` in JIT'd x64 code has been wrong, in every release. All three emission sites (immediate, register and memory shift counts) use `SAR` now; the equivalence fixture's new shift probe diverges on the shipped `obr` and matches
+
+### Virtual Machine
+- **`a->Size()` is inlined by the JIT** (AMD64 and ARM64) — `LOAD_ARY_SIZE` went through the interpreter callback: push the array onto the VM operand stack, call C++, read the result back, ~35 instructions and a call per evaluation of `i < a->Size()`. It is a nil check and one load now. An array-summing loop went from 6.0 to 0.75 ns per element (8×); a float dot product 2.7×
+- **Constant divisors skip the divide-by-zero check**, and AMD64 saves `RAX`/`RDX` around `idiv` only when they hold something — they were saved and restored unconditionally. (The `idiv` itself is the next item: a magic-number multiply for constant divisors)
+- **Windows: JIT code saves `XMM10`–`XMM15`** — the allocator hands out those registers and the Windows x64 ABI makes them callee-saved; the JIT'd function is entered by a plain C++ call whose MSVC-compiled caller may keep values in them across the call, and nothing saved them. 96 bytes in the prologue, restored in the teardown; Linux and macOS have no callee-saved vector registers
+- **`OBJECK_JIT_REPORT=1`** names every method the JIT hands back to the interpreter and why (an unsupported opcode, or a compile that failed part-way, with the instruction index). One unsupported instruction returns the whole method to the interpreter and nothing said so — the equivalence fixture's own division probe turned out to be interpreted because a twelve-term expression exhausted the AMD64 allocator's four registers
+- The interpreter/JIT equivalence fixture gains probes for `Size()` in a loop condition and body, a multi-dimensional `Size()`, and constant divisors of every shape (small, negative, above 32 bits, composite)
+
 ## [v2026.9.1] - 2026-09-08
 
 Every string hash was wrong; JIT arithmetic now matches the interpreter; the

--- a/core/vm/arch/jit/README.md
+++ b/core/vm/arch/jit/README.md
@@ -84,3 +84,8 @@ The reload of `INSTANCE_MEM` after the callback is essential: a callback can tri
 
 ### Implementation
 C++ using the STL. Back-end sources: `amd64/jit_amd_lp64.{h,cpp}`, `arm64/jit_arm_a64.{h,cpp}`; shared driver and tunables in `jit_common.{h,cpp}`. Canonical benchmark numbers live in [`docs/performance.md`](../../../../docs/performance.md).
+
+## Diagnostics
+
+- `OBJECK_JIT_REPORT=1` — stderr line per method the JIT hands back to the interpreter (unsupported opcode, or the instruction where compilation failed). Both backends. Use it on a real program before deciding which fallback to fix next.
+- `CL=/D_DEBUG_JIT` (MSVC) / `-D_DEBUG_JIT` — build an `obr` that prints every emitted instruction; it also prints per call at runtime, so keep iteration counts small.

--- a/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
+++ b/core/vm/arch/jit/amd64/jit_amd_lp64.cpp
@@ -75,6 +75,18 @@ void JitAmd64::Prolog() {
     // SafePoint call (one push would otherwise leave it misaligned).
     0x49, 0x54,                  // push r12
     0x48, 0x83, 0xec, 0x08,      // sub  rsp, 8   (alignment filler)
+    // XMM6-XMM15 are callee-saved in the Windows x64 ABI and the allocator
+    // hands out XMM10-XMM15. This code is entered by a plain C++ call
+    // (jit_fun), whose MSVC-compiled caller may keep values in those
+    // registers across the call; nothing saved them. 96 bytes keeps RSP
+    // 16-byte aligned. Linux/macOS: every XMM is caller-saved, nothing to do.
+    0x48, 0x83, 0xec, 0x60,      // sub  rsp, 96
+    0xf3, 0x44, 0x0f, 0x7f, 0x54, 0x24, 0x00,   // movdqu [rsp+0],  xmm10
+    0xf3, 0x44, 0x0f, 0x7f, 0x5c, 0x24, 0x10,   // movdqu [rsp+16], xmm11
+    0xf3, 0x44, 0x0f, 0x7f, 0x64, 0x24, 0x20,   // movdqu [rsp+32], xmm12
+    0xf3, 0x44, 0x0f, 0x7f, 0x6c, 0x24, 0x30,   // movdqu [rsp+48], xmm13
+    0xf3, 0x44, 0x0f, 0x7f, 0x74, 0x24, 0x40,   // movdqu [rsp+64], xmm14
+    0xf3, 0x44, 0x0f, 0x7f, 0x7c, 0x24, 0x50,   // movdqu [rsp+80], xmm15
 #else
     0x49, 0x50,                  // push r8
     0x49, 0x51,                  // push r9
@@ -164,6 +176,13 @@ void JitAmd64::Epilog()
   unsigned char teardown_code[] = {
     // restore registers
 #ifdef _WIN64
+    0xf3, 0x44, 0x0f, 0x6f, 0x54, 0x24, 0x00,   // movdqu xmm10, [rsp+0]
+    0xf3, 0x44, 0x0f, 0x6f, 0x5c, 0x24, 0x10,   // movdqu xmm11, [rsp+16]
+    0xf3, 0x44, 0x0f, 0x6f, 0x64, 0x24, 0x20,   // movdqu xmm12, [rsp+32]
+    0xf3, 0x44, 0x0f, 0x6f, 0x6c, 0x24, 0x30,   // movdqu xmm13, [rsp+48]
+    0xf3, 0x44, 0x0f, 0x6f, 0x74, 0x24, 0x40,   // movdqu xmm14, [rsp+64]
+    0xf3, 0x44, 0x0f, 0x6f, 0x7c, 0x24, 0x50,   // movdqu xmm15, [rsp+80]
+    0x48, 0x83, 0xc4, 0x60,  // add  rsp, 96  (XMM save area)
     0x48, 0x83, 0xc4, 0x08,  // add  rsp, 8   (undo alignment filler)
     0x49, 0x5c,       // pop r12
 #else
@@ -988,8 +1007,38 @@ void JitAmd64::ProcessInstructions() {
 #ifdef _DEBUG_JIT
       std::wcout << L"LOAD_ARY_SIZE: regs=" << aval_regs.size() << L"," << aux_regs.size() << std::endl;
 #endif
-      ProcessStackCallback(LOAD_ARY_SIZE, instr, instr_index, 1);
-      ProcessReturnParameters(INT_TYPE);
+      // Inline. The size is one word in the array header (index 2, the first
+      // dimension: what StackInterpreter::LoadArySize pushes). This used to go
+      // through ProcessStackCallback -- push the array onto the VM operand
+      // stack, call C++, read the result back: ~35 instructions and a call per
+      // evaluation of `i < a->Size()`, which made an array loop ten times
+      // slower than the same loop with the size hoisted.
+      RegInstr* left = working_stack.front();
+      working_stack.pop_front();
+      RegisterHolder* holder = nullptr;
+      switch(left->GetType()) {
+      case REG_INT:
+        holder = left->GetRegister();
+        break;
+
+      case MEM_INT:
+        holder = GetRegister();
+        move_mem_reg((long)left->GetOperand(), RBP, holder->GetRegister());
+        break;
+
+      default:
+        // an immediate is never an array reference
+        compile_success = false;
+        break;
+      }
+      delete left;
+      left = nullptr;
+      if(!holder) {
+        break;
+      }
+      CheckNilDereference(holder->GetRegister());
+      move_mem_reg(2 * sizeof(size_t), holder->GetRegister(), holder->GetRegister());
+      working_stack.push_front(new RegInstr(holder));
     }
       break;
       
@@ -3613,7 +3662,7 @@ void JitAmd64::math_imm_reg(int64_t imm, Register reg, InstructionType type)
     break;
     
   case SHR_INT:
-    shr_imm_reg(imm, reg);
+    sar_imm_reg(imm, reg);
     break;
 
   case BIT_AND_INT:
@@ -3652,7 +3701,7 @@ void JitAmd64::math_reg_reg(Register src, Register dest, InstructionType type) {
     break;
     
   case SHR_INT:
-    shr_reg_reg(src, dest);
+    sar_reg_reg(src, dest);
     break;
   case AND_INT:
     and_reg_reg(src, dest);
@@ -3718,7 +3767,7 @@ void JitAmd64::math_mem_reg(long offset, Register reg, InstructionType type) {
     break;
 
   case SHR_INT:
-    shr_mem_reg(offset, RBP, reg);
+    sar_mem_reg(offset, RBP, reg);
     break;
     
   case AND_INT:
@@ -4626,7 +4675,7 @@ void JitAmd64::div_imm_reg(int64_t imm, Register reg, bool is_mod) {
 
   RegisterHolder* imm_holder = GetRegister();
   move_imm_reg(imm, imm_holder->GetRegister());
-  div_reg_reg(imm_holder->GetRegister(), reg, is_mod);
+  div_reg_reg(imm_holder->GetRegister(), reg, is_mod, imm != 0);
   ReleaseRegister(imm_holder);
 }
 
@@ -4692,22 +4741,26 @@ void JitAmd64::div_mem_reg(long offset, Register src, Register dest, bool is_mod
   }
 }
 
-void JitAmd64::div_reg_reg(Register src, Register dest, bool is_mod) {
-  CheckDivideByZero(src);
-
-  if(is_mod) {
-    if(dest != RDX) {
-      move_reg_mem(RDX, TMP_REG_1, RBP);
-    }
-    move_reg_mem(RAX, TMP_REG_0, RBP);
+void JitAmd64::div_reg_reg(Register src, Register dest, bool is_mod, bool src_nonzero) {
+  // A divisor the compiler already knows is non-zero (an immediate) needs no
+  // runtime check; every constant `/` and `%` used to pay a test+branch.
+  if(!src_nonzero) {
+    CheckDivideByZero(src);
   }
-  else {
-    if(dest != RAX) {
-      move_reg_mem(RAX, TMP_REG_0, RBP);
-    }
+
+  // idiv clobbers RAX and RDX. They were saved to the spill slots and restored
+  // unconditionally -- four memory operations per division whether or not
+  // either held anything. Save a register only if it is allocated (a value on
+  // the working stack, a cached local) or if it IS the divisor, which the
+  // memory-operand form below reads back from its slot.
+  const bool save_rax = (src == RAX) || (dest != RAX && !IsRegisterFree(RAX));
+  const bool save_rdx = (src == RDX) || (dest != RDX && !IsRegisterFree(RDX));
+  if(save_rdx) {
     move_reg_mem(RDX, TMP_REG_1, RBP);
   }
-  
+  if(save_rax) {
+    move_reg_mem(RAX, TMP_REG_0, RBP);
+  }
   // ============
   move_reg_reg(dest, RAX);
   AddMachineCode(0x48); // cdq
@@ -4758,26 +4811,21 @@ void JitAmd64::div_reg_reg(Register src, Register dest, bool is_mod) {
 #endif
   }
   // ============
-  
   if(is_mod) {
     if(dest != RDX) {
       move_reg_reg(RDX, dest);
-      move_mem_reg(TMP_REG_1, RBP, RDX);
-    }
-
-    if(dest != RAX) {
-      move_mem_reg(TMP_REG_0, RBP, RAX);
     }
   }
   else {
     if(dest != RAX) {
       move_reg_reg(RAX, dest);
-      move_mem_reg(TMP_REG_0, RBP, RAX);
     }
-     
-    if(dest != RDX) {
-      move_mem_reg(TMP_REG_1, RBP, RDX);
-    }
+  }
+  if(save_rax && dest != RAX) {
+    move_mem_reg(TMP_REG_0, RBP, RAX);
+  }
+  if(save_rdx && dest != RDX) {
+    move_mem_reg(TMP_REG_1, RBP, RDX);
   }
 }
 
@@ -4974,6 +5022,58 @@ void JitAmd64::shr_mem_reg(long offset, Register src, Register dest)
   RegisterHolder* mem_holder = GetRegister();
   move_mem_reg(offset, src, mem_holder->GetRegister());
   shr_reg_reg(mem_holder->GetRegister(), dest);
+  ReleaseRegister(mem_holder);
+}
+
+// Arithmetic right shift -- what Objeck's `>>` means: the interpreter shifts a
+// signed INT64 and the ARM64 backend emits asr. This backend emitted the LOGICAL
+// shr for SHR_INT, so every negative operand of `>>` in JIT'd x64 code came out
+// as a huge positive number. The shr_* encoders stay: the power-of-two division
+// trick in div_imm_reg needs a logical shift of the sign mask.
+void JitAmd64::sar_reg_reg(Register src, Register dest)
+{
+  Register old_dest;
+  RegisterHolder* reg_holder = nullptr;
+  if(dest == RCX) {
+    reg_holder = GetRegister();
+    old_dest = dest;
+    dest = reg_holder->GetRegister();
+    move_reg_reg(old_dest, dest);
+  }
+  
+  if(src != RCX) {
+    move_reg_mem(RCX, TMP_REG_0, RBP);
+    move_reg_reg(src, RCX);
+  }
+    
+  // encode
+  AddMachineCode(B(dest));
+  AddMachineCode(0xd3);
+  unsigned char code = 0xc0;
+  // write value
+  RegisterEncode3(code, 2, RDI);   // /7: SAR, not /5 SHR
+  RegisterEncode3(code, 5, dest);
+  AddMachineCode(code);
+#ifdef _DEBUG_JIT
+  std::wcout << L"  " << (++instr_count) << L": [sarq %" << GetRegisterName(RCX) 
+        << L", %" << GetRegisterName(dest) << L"]" << std::endl;
+#endif
+  
+  if(src != RCX) {
+    move_mem_reg(TMP_REG_0, RBP, RCX);
+  }
+  
+  if(reg_holder) {
+    move_reg_reg(dest, old_dest);
+    ReleaseRegister(reg_holder);
+  }
+}
+
+void JitAmd64::sar_mem_reg(long offset, Register src, Register dest) 
+{
+  RegisterHolder* mem_holder = GetRegister();
+  move_mem_reg(offset, src, mem_holder->GetRegister());
+  sar_reg_reg(mem_holder->GetRegister(), dest);
   ReleaseRegister(mem_holder);
 }
 
@@ -6344,6 +6444,19 @@ static bool CanJitInstruction(InstructionType type) {
   }
 }
 
+
+// OBJECK_JIT_REPORT=1 names every method the JIT hands back to the interpreter,
+// and why. One unsupported opcode returns the WHOLE method to the interpreter
+// and nothing said so; the opcode number maps to `obc -asm`'s listing.
+static bool JitReportEnabled() {
+#ifdef _WIN32
+  static const bool enabled = []() { size_t len = 0; getenv_s(&len, nullptr, 0, "OBJECK_JIT_REPORT"); return len > 0; }();
+#else
+  static const bool enabled = getenv("OBJECK_JIT_REPORT") != nullptr;
+#endif
+  return enabled;
+}
+
 bool JitAmd64::Compile(StackMethod* cm)
 {
   compile_success = true;
@@ -6365,6 +6478,10 @@ bool JitAmd64::Compile(StackMethod* cm)
     for(long i = 0; i < method->GetInstructionCount(); ++i) {
       StackInstr* scan_instr = method->GetInstruction(i);
       if(!CanJitInstruction(scan_instr->GetType())) {
+        if(JitReportEnabled()) {
+          std::wcerr << L"[jit] " << method->GetName() << L": not compiled -- unsupported opcode "
+                     << scan_instr->GetType() << L" at instruction " << i << std::endl;
+        }
         return false;
       }
       // DYN_MTHD_CALL return marshalling (ProcessReturnParameters) is driven by
@@ -6516,6 +6633,9 @@ bool JitAmd64::Compile(StackMethod* cm)
     // translate program
     ProcessInstructions();
     if(!compile_success) {
+      if(JitReportEnabled()) {
+        std::wcerr << L"[jit] " << method->GetName() << L": compile failed at instruction " << instr_index << std::endl;
+      }
 #ifdef _WIN64
       VirtualFree(float_consts, 0, MEM_RELEASE);
 #else

--- a/core/vm/arch/jit/amd64/jit_amd_lp64.h
+++ b/core/vm/arch/jit/amd64/jit_amd_lp64.h
@@ -783,6 +783,17 @@ namespace Runtime {
     }
 
     // Returns a register to the pool
+    // True when the register is in the free pool: not on the working stack,
+    // not caching a local, not held by any RegInstr. Anything else may be live.
+    bool IsRegisterFree(Register reg) {
+      for(size_t i = 0; i < aval_regs.size(); ++i) {
+        if(aval_regs[i]->GetRegister() == reg) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     void ReleaseRegister(RegisterHolder* h) {
 #ifdef _VERBOSE
       std::wcout << L"\t * releasing " << GetRegisterName(h->GetRegister())
@@ -991,7 +1002,7 @@ namespace Runtime {
     void div_xreg_xreg(Register src, Register dest);
     void div_mem_xreg(long offset, Register src, Register dest);
     void div_imm_reg(int64_t imm, Register reg, bool is_mod = false);
-    void div_reg_reg(Register src, Register dest, bool is_mod = false);
+    void div_reg_reg(Register src, Register dest, bool is_mod = false, bool src_nonzero = false);
     void div_mem_reg(long offset, Register src, Register dest, bool is_mod = false);
 
     // compare instructions
@@ -1018,6 +1029,8 @@ namespace Runtime {
     void shr_mem_reg(long offset, Register src, Register dest);
     void shr_imm_reg(int64_t value, Register dest);
     void sar_imm_reg(int64_t value, Register dest);
+    void sar_reg_reg(Register src, Register dest);
+    void sar_mem_reg(long offset, Register src, Register dest);
 
     // push/pop instructions
     void push_imm(long value);

--- a/core/vm/arch/jit/arm64/jit_arm_a64.cpp
+++ b/core/vm/arch/jit/arm64/jit_arm_a64.cpp
@@ -938,11 +938,37 @@ void JitArm64::ProcessInstructions() {
       break;
 
     case LOAD_ARY_SIZE: {
-#ifdef _DEBUG_JIT_JIT
-      std::wcout << L"LOAD_ARY_SIZE: regs=" << aval_regs.size() << endl;
+#ifdef _DEBUG_JIT
+      std::wcout << L"LOAD_ARY_SIZE: regs=" << aval_regs.size() << std::endl;
 #endif
-      ProcessStackCallback(LOAD_ARY_SIZE, instr, instr_index, 1);
-      ProcessReturnParameters(INT_TYPE);
+      // Inline: the size is header word 2 (the first dimension), which is what
+      // StackInterpreter::LoadArySize pushes. Mirror of the AMD64 change; this
+      // was an interpreter callback per evaluation of `i < a->Size()`.
+      RegInstr* left = working_stack.front();
+      working_stack.pop_front();
+      RegisterHolder* holder = nullptr;
+      switch(left->GetType()) {
+      case REG_INT:
+        holder = left->GetRegister();
+        break;
+
+      case MEM_INT:
+        holder = GetRegister();
+        move_mem_reg((long)left->GetOperand(), SP, holder->GetRegister());
+        break;
+
+      default:
+        compile_success = false;
+        break;
+      }
+      delete left;
+      left = nullptr;
+      if(!holder) {
+        break;
+      }
+      CheckNilDereference(holder->GetRegister());
+      move_mem_reg(2 * sizeof(size_t), holder->GetRegister(), holder->GetRegister());
+      working_stack.push_front(new RegInstr(holder));
     }
       break;
       
@@ -2948,7 +2974,7 @@ void JitArm64::mul_reg_reg(Register src, Register dest) {
 void JitArm64::div_imm_reg(int64_t imm, Register reg, bool is_mod) {
   RegisterHolder* src_holder = GetRegister();
   move_imm_reg(imm, src_holder->GetRegister());
-  div_reg_reg(src_holder->GetRegister(), reg, is_mod);
+  div_reg_reg(src_holder->GetRegister(), reg, is_mod, imm != 0);
   ReleaseRegister(src_holder);
 }
 
@@ -2959,12 +2985,15 @@ void JitArm64::div_mem_reg(long offset, Register src, Register dest, bool is_mod
   ReleaseRegister(src_holder);
 }
 
-void JitArm64::div_reg_reg(Register src, Register dest, bool is_mod) {
+void JitArm64::div_reg_reg(Register src, Register dest, bool is_mod, bool src_nonzero) {
 #ifdef _DEBUG_JIT_JIT
   std::wcout << L"  " << (++instr_count) << L": [sdiv " << GetRegisterName(dest) << L", " << GetRegisterName(src) << L", " << GetRegisterName(dest) << L"]" << std::endl;
 #endif
   
-  CheckIntDivideByZero(src);
+  // an immediate divisor is known non-zero at compile time; no runtime check
+  if(!src_nonzero) {
+    CheckIntDivideByZero(src);
+  }
   
   uint32_t op_code = 0x9AC00C00;
   
@@ -5032,6 +5061,19 @@ static bool CanJitInstruction(InstructionType type) {
 //
 // translate bytecode to machine code
 //
+
+// OBJECK_JIT_REPORT=1 names every method the JIT hands back to the interpreter,
+// and why. One unsupported opcode returns the WHOLE method to the interpreter
+// and nothing said so; the opcode number maps to `obc -asm`'s listing.
+static bool JitReportEnabled() {
+#ifdef _WIN32
+  static const bool enabled = []() { size_t len = 0; getenv_s(&len, nullptr, 0, "OBJECK_JIT_REPORT"); return len > 0; }();
+#else
+  static const bool enabled = getenv("OBJECK_JIT_REPORT") != nullptr;
+#endif
+  return enabled;
+}
+
 bool JitArm64::Compile(StackMethod* cm)
 {
   compile_success = true;
@@ -5056,6 +5098,10 @@ bool JitArm64::Compile(StackMethod* cm)
     for(long i = 0; i < method->GetInstructionCount(); ++i) {
       StackInstr* scan_instr = method->GetInstruction(i);
       if(!CanJitInstruction(scan_instr->GetType())) {
+        if(JitReportEnabled()) {
+          std::wcerr << L"[jit] " << method->GetName() << L": not compiled -- unsupported opcode "
+                     << scan_instr->GetType() << L" at instruction " << i << std::endl;
+        }
         return false;
       }
       // DYN_MTHD_CALL return marshalling is driven by operand2 (the func-ref's
@@ -5166,6 +5212,9 @@ bool JitArm64::Compile(StackMethod* cm)
     ProcessInstructions();
     
     if(!compile_success) {
+      if(JitReportEnabled()) {
+        std::wcerr << L"[jit] " << method->GetName() << L": compile failed at instruction " << instr_index << std::endl;
+      }
       free(code);
       code = nullptr;
 

--- a/core/vm/arch/jit/arm64/jit_arm_a64.h
+++ b/core/vm/arch/jit/arm64/jit_arm_a64.h
@@ -744,7 +744,7 @@ namespace Runtime {
     // div instructions
     void div_freg_freg(Register src, Register dest);
     void div_imm_reg(int64_t imm, Register reg, bool is_mod = false);
-    void div_reg_reg(Register src, Register dest, bool is_mod = false);
+    void div_reg_reg(Register src, Register dest, bool is_mod = false, bool src_nonzero = false);
     void div_mem_reg(long offset, Register src, Register dest, bool is_mod = false);
     
     // operations

--- a/docs/cli_options.md
+++ b/docs/cli_options.md
@@ -68,6 +68,7 @@ See [optimization_pipeline.md](optimization_pipeline.md) for what each `-opt` le
 |--------|-------------|-------------|
 | `--gc-threshold=<n>(k\|m\|g)` | `--GC_THRESHOLD=` | Initial garbage-collection threshold, e.g. `512k`, `2m`, `1g` |
 | `--jit=off` / `--jit=<calls>` | env `OBJECK_JIT_DISABLE=1` / `OBJECK_JIT_THRESHOLD=N` | `off` runs the interpreter only; a positive number is how many calls a method makes before it is compiled (default `10`) |
+| — | env `OBJECK_JIT_REPORT=1` | Print, to stderr, every method the JIT hands back to the interpreter and why: an unsupported opcode (number per `obc -asm`), or the instruction at which compilation failed. Diagnostic; no effect on execution |
 | `--lib-path=<dir>` | env `OBJECK_LIB_PATH` | The Objeck `lib` root. `obc` reads the `.obl` files from it; `obr` loads the native libraries from `<dir>/native/` (`libobjk_*.dll|.so|.dylib`), reads `<dir>/cacert.pem` for TLS, and reports it as the `lib_dir` runtime property. On Windows the third-party runtime DLLs those libraries import (SDL2, onnxruntime, opencv, lame, the VC runtime) are resolved from `obr.exe`'s own directory, so `bin/` keeps them wherever `lib/` is |
 | `--objeck-stdio=binary\|utf16\|utf8` | `--OBJECK_STDIO=` | Console I/O mode. Acted on by **Windows**; accepted and ignored elsewhere so one script works on every platform |
 

--- a/programs/regression/vm_jit_equiv.obs
+++ b/programs/regression/vm_jit_equiv.obs
@@ -54,6 +54,42 @@ class Arith {
     return n * 4294967311 + n * 3000000000 - n * 2147483648;
   }
 
+  # constant divisors of every shape the JIT special-cases: small, negative,
+  # above INT32, composite; the interpreter result is the reference
+  function : ConstDiv(n : Int) ~ Int {
+    # one division per statement: a single twelve-term expression exhausts the
+    # AMD64 allocator's four registers, and the method silently falls back to
+    # the interpreter (OBJECK_JIT_REPORT=1 says so) -- which would make this
+    # probe compare the interpreter with itself
+    acc := n / 3;
+    acc += n % 3;
+    acc += n / (0 - 7);
+    acc -= n % (0 - 7);
+    acc += n / 1000003;
+    acc += n % 1000003;
+    acc += n / 10;
+    acc -= n % 10;
+    acc += n / 2147483649;
+    acc += n % 2147483649;
+    acc += n / 6;
+    acc += n % 6;
+    return acc;
+  }
+
+  # `>>` on negative values: arithmetic in the interpreter and on ARM64; the
+  # AMD64 JIT emitted a logical shift until 2026-09-09
+  function : Shr(n : Int, k : Int) ~ Int {
+    return (n >> k) + (n >> 3) + (n >> 63) + (n >> 1);
+  }
+
+  function : SizeLoop(a : Int[]) ~ Int {
+    acc := 0;
+    for(i := 0; i < a->Size(); i += 1;) {
+      acc += a[i] * (a->Size() - i);
+    };
+    return acc;
+  }
+
   function : Digest(values : Int[]) ~ Int {
     total := 0;
     each(i : values) {
@@ -114,6 +150,30 @@ class VmJitEquiv {
       bm += Arith->BigMul(i) % 1000003;
     };
     "bigmul={$bm}"->PrintLine();
+
+    # a->Size() in a loop condition and in the body (inlined by the JIT now)
+    ary := Int->New[37];
+    for(i := 0; i < ary->Size(); i += 1;) {
+      ary[i] := i * 3 - 7;
+    };
+    asz := Arith->SizeLoop(ary);
+    "arysize={$asz}"->PrintLine();
+    # a multi-dimensional array: Size() is the first dimension (header word 2)
+    grid := Int->New[3, 5];
+    gsz := grid->Size();
+    "dim2="->Print();
+    gsz->PrintLine();
+    cd := 0;
+    for(i := -25; i < 25; i += 1;) {
+      cd += Arith->ConstDiv(i * 104729 - 3);
+    };
+    "constdiv={$cd}"->PrintLine();
+
+    sh := 0;
+    for(i := -20; i < 20; i += 1;) {
+      sh += Arith->Shr(i * 1000000007 - 5, i and 15);
+    };
+    "shr={$sh}"->PrintLine();
 
     "done"->PrintLine();
   }


### PR DESCRIPTION
Batch 1 of [`docs/JIT_CODEGEN_ASSESSMENT_2026_09.md`](docs/JIT_CODEGEN_ASSESSMENT_2026_09.md) — the afternoon-sized items — on both backends, plus a miscompile found on the way.

**The AMD64 JIT emitted a *logical* right shift for `>>`.** The interpreter shifts a signed `INT64` (arithmetic) and the ARM64 backend emits `asr`, so `-8 >> 1` was `-4` in three places and `9223372036854775804` in the fourth: every negative operand of `>>` in JIT'd x64 code has been wrong, in every release. All three emission sites (immediate, register and memory shift counts) now use `SAR`; the logical `shr_*` encoders stay for the power-of-two division trick that needs them. The equivalence fixture's new shift probe diverges on the shipped `obr` and matches now.

| finding | change | measured (Windows x64, `--jit=1`, `programs/tests/jit_probe.obs`) |
|---|---|---|
| **F1** `a->Size()` went through the interpreter callback (~35 instructions + a C++ call per `i < a->Size()`) | `LOAD_ARY_SIZE` is a nil check + one load of header word 2 (what `LoadArySize` pushes), AMD64 and ARM64 | **ArraySum 0.120 s → 0.015 s (8×)**, 6.0 → 0.75 ns/element; FloatDot 0.126 → 0.047 s; ArraySum's method 111 → 86 instructions |
| **F2a** dead divide-by-zero check on immediate divisors; RAX/RDX saved/restored unconditionally around `idiv` | immediates skip the check (both); AMD64 saves RAX/RDX only when allocated or when one is the divisor | IntLoop's method 74 → 64 instructions; time unchanged — `idiv` itself is F2b |
| **F10** (new) Windows x64: the allocator uses XMM10–XMM15, callee-saved in the ABI, and JIT code is entered by a plain C++ call; nothing saved them | prologue stores the six registers (96 bytes, alignment kept), teardown restores | latent ABI violation; suites green before and after |
| **F9** whole-method fallback was silent | `OBJECK_JIT_REPORT=1` names each method handed back and why (opcode number per `obc -asm`, or the failing instruction index); documented in `cli_options.md` and the JIT README | caught the fixture's own division probe being interpreted (twelve-term expression exhausted the 4-register pool) |

**Equivalence fixture** gains `Size()` in a loop condition and body, a multi-dimensional `Size()`, and constant divisors of every shape (small, negative, above 32 bits, composite) — one division per statement so the method actually compiles. `run_vm_flag_tests.py` compares interpreter and JIT output on every leg, which is how the ARM64 half is verified.

Verified here: flag tests 22/22, full regression green, timings above. Next batch: magic-number division (F2b), the AMD64 register pool (F4), array addressing (F5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
