### PR TITLE
test(jit): probe issue #722 -- String->Equals in a virtual callback under the ARM64 JIT

### DIFF
--- a/programs/regression/http_persistence_test.obs
+++ b/programs/regression/http_persistence_test.obs
@@ -1,5 +1,4 @@
 # EXTRA_LIBS: net,net_server
-# JIT_DISABLE
 use Collection, System.IO.Net, Web.HTTP.Server;
 
 # Exercises the HTTP/1.x persistence contract with a raw client. Every response
@@ -10,12 +9,12 @@ class PersistenceHandler from HttpRequestHandler {
 	method : ProcessGet(request : Request, response : Response) ~ Bool {
 		path := request->GetPath();
 		# Virtual handler callbacks are JIT-compiled independently of the test's
-		# auto-JIT opt-out. Keep this callback to operations supported reliably by
-		# both JIT backends; ARM64 currently miscompiles String->Equals here.
-		if(path->Size() = 6) {
+		# auto-JIT opt-out. Routing by String->Equals is deliberate: issue #722
+		# reported the ARM64 JIT miscompiling it right here, and this is the check.
+		if(path->Equals("/empty")) {
 			response->SetCode(200);
 		}
-		else if(path->Size() = 4) {
+		else if(path->Equals("/err")) {
 			response->SetCode(404);
 		}
 		else {

--- a/programs/regression/https_persistence_test.obs
+++ b/programs/regression/https_persistence_test.obs
@@ -1,16 +1,16 @@
 # EXTRA_LIBS: net,net_server
-# JIT_DISABLE
 use Collection, System.IO.Filesystem, System.IO.Net, Web.HTTP.Server;
 class HttpsPersistenceHandler from HttpsRequestHandler {
 	New() { Parent(); }
 
 	method : ProcessGet(request : Request, response : Response) ~ Bool {
-		if(request->GetPath()->Size() = 7) {
+		if(request->GetPath()->Equals("/client")) {
 			"TLS stage: HttpsClient request reached handler"->ErrorLine();
 		};
 		# This virtual callback is JIT-compiled even when test auto-JIT is disabled;
-		# ARM64 currently miscompiles String->Equals in this context.
-		if(request->GetPath()->Size() = 6) {
+		# routing by String->Equals is deliberate (issue #722 reported the ARM64 JIT
+		# miscompiling it here) and this is the check.
+		if(request->GetPath()->Equals("/empty")) {
 			response->SetCode(200);
 		}
 		else {

--- a/programs/regression/jit_virtual_equals.obs
+++ b/programs/regression/jit_virtual_equals.obs
@@ -1,0 +1,90 @@
+# Issue #722: on ARM64 the JIT miscompiled String->Equals inside a virtual
+# request-handler callback (the compare of the returned Bool went wrong), which
+# two gating tests hid behind `# JIT_DISABLE` and a handler rewritten to avoid
+# Equals. This is the reduction the issue asks for: a base class with a virtual
+# method that compares a String parameter with Equals, overridden in a subclass,
+# called through the base reference from a native (always compiled) loop, with
+# the receiver coming from a getter and the operand a literal -- the shape of
+# `request->GetPath()->Equals("/x")`. The counts are asserted against values
+# the interpreter computes.
+class Request {
+  @path : String;
+  New(path : String) { @path := path; }
+  method : public : GetPath() ~ String { return @path; }
+}
+
+class Handler {
+  New() {}
+
+  method : virtual : public : Route(request : Request) ~ Int;
+
+  method : public : Classify(request : Request) ~ Int {
+    # the same comparisons, not virtual, for the cross-check
+    path := request->GetPath();
+    if(path->Equals("/index")) { return 200; };
+    if(path->Equals("/404")) { return 404; };
+    if(path->Equals("/") = false & path->Size() > 3) { return 301; };
+    return 500;
+  }
+}
+
+class RouteHandler from Handler {
+  New() { Parent(); }
+
+  method : public : Route(request : Request) ~ Int {
+    path := request->GetPath();
+    if(path->Equals("/index")) {
+      return 200;
+    }
+    else if(path->Equals("/404")) {
+      return 404;
+    }
+    else if(path->Equals("/") = false & path->Size() > 3) {
+      return 301;
+    };
+    return 500;
+  }
+}
+
+class VirtualEquals {
+  function : native : Drive(handler : Handler, requests : Request[], rounds : Int) ~ Int {
+    sum := 0;
+    for(r := 0; r < rounds; r += 1;) {
+      each(i : requests) {
+        sum += handler->Route(requests[i]);
+      };
+    };
+    return sum;
+  }
+
+  function : native : Check(handler : Handler, requests : Request[], rounds : Int) ~ Int {
+    sum := 0;
+    for(r := 0; r < rounds; r += 1;) {
+      each(i : requests) {
+        sum += handler->Classify(requests[i]);
+      };
+    };
+    return sum;
+  }
+
+  function : Main(args : String[]) ~ Nil {
+    "Testing String->Equals in a virtual callback under the JIT..."->PrintLine();
+    requests := Request->New[5];
+    requests[0] := Request->New("/index");
+    requests[1] := Request->New("/404");
+    requests[2] := Request->New("/");
+    requests[3] := Request->New("/other");
+    requests[4] := Request->New("/index");
+    handler := RouteHandler->New();
+    # per round: 200 + 404 + 500 + 301 + 200 = 1605
+    expected := 1605 * 400;
+    virt := Drive(handler, requests, 400);
+    flat := Check(handler, requests, 400);
+    "  virtual={$virt} direct={$flat} expected={$expected}"->PrintLine();
+    if(virt <> expected | flat <> expected) {
+      "FAIL: String->Equals in a virtual callback"->PrintLine();
+      Runtime->Exit(1);
+    };
+    "PASS: String->Equals in a virtual callback"->PrintLine();
+  }
+}


### PR DESCRIPTION
A probe for #722, run by CI: the reduction fixture `jit_virtual_equals.obs` (a virtual method comparing a String parameter with `Equals`, called through the base reference from a native loop) plus the two persistence tests routing by `Equals` again without their `# JIT_DISABLE` markers. If the three ARM64 legs pass, batch 4 fixed the miscompile and this can merge as the regression test; if they fail, the failure artifact carries the reduction. Both persistence tests and the fixture pass fully compiled on Windows x64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)