### PR TITLE
examples: shipped examples for System.AI and the classic System.ML surface

### DIFF
--- a/programs/deploy/ai_search_25.obs
+++ b/programs/deploy/ai_search_25.obs
@@ -1,0 +1,104 @@
+#~
+System.AI search: shortest paths across a small weighted road map.
+
+The same directed, weighted graph is searched four ways. Dijkstra and A* both
+minimize total edge weight and find the same least-cost route; A* reaches it
+while expanding fewer nodes, because its heuristic steers the search toward the
+goal. Breadth-first and depth-first ignore the weights -- BFS finds the
+fewest-hops route and DFS the first route it stumbles onto -- so their reported
+"cost" is a hop count, not a distance, and their route need not be the
+weighted-optimal one.
+
+Edge weights and the A* heuristic are both computed from node coordinates, so
+the heuristic is admissible (never over-estimates the true remaining cost) by
+construction -- the condition A* needs to stay optimal.
+
+  compile: obc -src ai_search_25.obs -lib ai
+  run:     obr ai_search_25.obe
+~#
+
+use System.AI;
+
+class RoadMap {
+  # eight places, laid out on a grid; 0 = "Harbor" (start), 7 = "Summit" (goal)
+  @names : static : String[];
+  @xs : static : Float[];
+  @ys : static : Float[];
+
+  function : Main(args : String[]) ~ Nil {
+    @names := ["Harbor", "Market", "Mill", "Chapel", "Forge", "Bridge", "Orchard", "Summit"];
+    @xs := [0.0, 2.0, 4.0, 1.0, 3.0, 5.0, 2.0, 5.0];
+    @ys := [0.0, 1.0, 0.0, 3.0, 3.0, 2.0, 5.0, 5.0];
+
+    n := @names->Size();
+    graph := Graph->New(n);
+
+    # undirected roads, added both ways; weight = straight-line distance
+    Road(graph, 0, 1); Road(graph, 0, 3);
+    Road(graph, 1, 2); Road(graph, 1, 4);
+    Road(graph, 2, 5);
+    Road(graph, 3, 4); Road(graph, 3, 6);
+    Road(graph, 4, 5); Road(graph, 4, 6);
+    Road(graph, 5, 7);
+    Road(graph, 6, 7);
+
+    start := 0;
+    goal := 7;
+    goal_name := @names[goal];
+
+    "Road map: {$n} places, goal is {$goal_name}"->PrintLine();
+    "=========================================="->PrintLine();
+
+    dj := Dijkstra->FindPath(graph, start, goal);
+    Report("Dijkstra", dj);
+
+    # A* needs a lower-bound estimate from every node to the goal
+    heuristic := Float->New[n];
+    each(i : n) {
+      heuristic[i] := Distance(i, goal);
+    };
+    astar := AStar->FindPath(graph, start, goal, heuristic);
+    Report("A*", astar);
+
+    bfs := BreadthFirst->FindPath(graph, start, goal);
+    Report("Breadth-first", bfs);
+
+    dfs := DepthFirst->FindPath(graph, start, goal);
+    Report("Depth-first", dfs);
+  }
+
+  # add an undirected road: distance-weighted edges in both directions
+  function : Road(graph : Graph, a : Int, b : Int) ~ Nil {
+    w := Distance(a, b);
+    graph->AddEdge(a, b, w);
+    graph->AddEdge(b, a, w);
+  }
+
+  function : Distance(a : Int, b : Int) ~ Float {
+    dx := @xs[a] - @xs[b];
+    dy := @ys[a] - @ys[b];
+    sum := dx * dx + dy * dy;
+    return sum->Sqrt();
+  }
+
+  function : Report(title : String, result : SearchResult) ~ Nil {
+    "{$title}:"->PrintLine();
+    if(result->Found()) {
+      path := result->GetPath();
+      line := "  path: ";
+      each(i : path) {
+        line += @names[path[i]];
+        if(i < path->Size() - 1) {
+          line += " -> ";
+        };
+      };
+      line->PrintLine();
+      cost := result->GetCost();
+      expanded := result->GetExpanded();
+      "  cost: {$cost}, nodes expanded: {$expanded}"->PrintLine();
+    }
+    else {
+      "  no path"->PrintLine();
+    };
+  }
+}

--- a/programs/deploy/ml_regression_26.obs
+++ b/programs/deploy/ml_regression_26.obs
@@ -1,0 +1,68 @@
+#~
+System.ML supervised learning: fit a linear model and read it back.
+
+Twelve samples are generated from a known rule, y = 3*x1 - 2*x2 + 5, and
+LinearRegression is asked to recover it. Fit is called with fit_intercept
+true, so the model has a constant term to find; because the data is exactly
+linear it recovers the intercept 5 and coefficients [3, -2], its R-squared is
+1.0, and it predicts unseen points exactly. That is a clean way to see what
+Fit / GetCoefficients / GetRSquared / GetRMSE / Predict each return before
+turning the same calls on real, noisier data -- where R-squared drops below 1
+and the fit is an approximation.
+
+GetCoefficients returns the intercept first, then one coefficient per feature.
+
+  compile: obc -src ml_regression_26.obs -lib csv,ml
+  run:     obr ml_regression_26.obe
+~#
+
+use System.ML;
+
+class LinearDemo {
+  function : Main(args : String[]) ~ Nil {
+    n := 12;
+
+    # feature matrix X (rows = samples, cols = features) and target column y,
+    # generated from the rule below so the model has something exact to recover
+    X := Float->New[n, 2];
+    y := Float->New[n, 1];
+    each(i : n) {
+      x1 := (i % 7)->As(Float);
+      x2 := (i % 5)->As(Float);
+      X[i, 0] := x1;
+      X[i, 1] := x2;
+      y[i, 0] := 3.0 * x1 - 2.0 * x2 + 5.0;
+    };
+
+    model := LinearRegression->New();
+    ok := model->Fit(X, y, true);   # true: fit an intercept term
+    if(<>ok) {
+      "Fit failed"->PrintLine();
+      return;
+    };
+
+    "Linear regression on y = 3*x1 - 2*x2 + 5"->PrintLine();
+    "========================================"->PrintLine();
+
+    # coefficients come back as [intercept, b1, b2]
+    coeffs := model->GetCoefficients();
+    intercept := coeffs[0];
+    b1 := coeffs[1];
+    b2 := coeffs[2];
+    "  recovered: y = {$b1}*x1 + {$b2}*x2 + {$intercept}"->PrintLine();
+
+    r2 := model->GetRSquared();
+    rmse := model->GetRMSE();
+    "  R-squared: {$r2}, RMSE: {$rmse}"->PrintLine();
+
+    # predict two unseen points and compare with the true rule
+    probe := Float->New[2, 2];
+    probe[0, 0] := 10.0; probe[0, 1] := 1.0;   # true y = 33
+    probe[1, 0] := 0.0;  probe[1, 1] := 0.0;   # true y = 5
+    preds := model->Predict(probe);
+    p0 := preds[0, 0];
+    p1 := preds[1, 0];
+    "  predict (10, 1) -> {$p0}   (true 33)"->PrintLine();
+    "  predict (0, 0)  -> {$p1}   (true 5)"->PrintLine();
+  }
+}


### PR DESCRIPTION
The two library-example gaps found while checking release readiness. `programs/deploy` is what a release packages (see the release-ships-deploy note), so both land there.

- **System.AI** shipped with no example anywhere. [ai_search_25.obs](programs/deploy/ai_search_25.obs) searches a small weighted road map four ways -- Dijkstra, A* with a coordinate-derived admissible heuristic, BFS, DFS -- showing A* reaching the optimal route while expanding fewer nodes, and the unweighted searches minimizing hops.
- **System.ML** shipped only the neural-network example though the bundle now covers regression, clustering, trees, bayes and kNN. [ml_regression_26.obs](programs/deploy/ml_regression_26.obs) has LinearRegression recover y = 3*x1 - 2*x2 + 5 exactly (R^2 = 1.0), demonstrating Fit with an intercept, GetCoefficients, GetRSquared/GetRMSE and Predict.

Both compile and run against the shipped `ai.obl` / `ml.obl`. Doc coverage was already complete (all 43 libraries in the five lists, api.zip pages and the LSP index present for every new bundle); this is only the example gap.

Game.OpenGL (2 shipped + 6 repo) and System.Concurrency (1 + 7) already have enough, so no new examples there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)