### PR TITLE
docs(handoff): the calling-convention work is on master, and what the next session finds

### DIFF
--- a/docs/HANDOFF_2026_09_10.md
+++ b/docs/HANDOFF_2026_09_10.md
@@ -5,6 +5,27 @@ touching anything; every "where" below was checked against GitHub and the tree w
 The macOS-specific plan (`JIT_ARM64_HANDOFF_2026_09.md`) still applies for the ARM64 items and
 is referenced, not repeated.
 
+## Update, 2026-09-10 evening: the calling-convention work is on master
+
+Everything below the next heading is history. What the next session finds:
+
+| item | now |
+|---|---|
+| F7, the calling convention | **done on AMD64**, five PRs on master the same day: #757 (design + fixture), #758 (phase 1: the bridge resolves virtual callees, a per-thread frame pool, a direct entry), #759 (phase 2: the callee's prologue and epilogue), #760 (phase 3: the direct native call, inline caches for `virtual` and func-ref calls). `docs/JIT_CALLING_CONVENTION_DESIGN.md` sections 6 to 11 carry each step's numbers. A compiled call went from 26.5 ns to 7.0 ns, a `virtual` one from 125 ns to 7.5 ns, `Fib(32)` from 0.208 s to 0.071 s. The register-argument entry of the design's section 3 was measured and declined (section 11). |
+| a GC bug found on the way | **fixed, #761**: a compiled frame with a declared-but-unreferenced local was laid out from references and scanned by declaration, so every lower slot was read under the wrong type; the collector read objects as arrays. `jit_frame_unreferenced_local.obs` reproduces it on the shipped Windows binary. Both backends now lay the frame out from the declarations. |
+| CI | **#762**: the x64 legs run the suite a second time with `OBJECK_JIT_THRESHOLD=1`. No leg had ever run that mode, which is how #761's bug survived; ARM64 and macOS keep the single pass. |
+| a compiler bug found on the way | **open, #763**: a func-ref parameter call goes wrong once its method is inlined into a caller other than `Main` (the interpreter loops, the JIT returns garbage). Fixtures keep such helpers non-inlinable until it is fixed. |
+| the deploy trees | Windows `deploy-x64` holds master `1ec2893f07`'s VM (manifest-stamped); the Linux tree under `core/release/deploy` was rebuilt from the same master with `deploy_posix.sh x64` in WSL. |
+| ARM64 | phases 2 and 3 are AMD64 only; ARM64 keeps the bridge. `JIT_ARM64_HANDOFF_2026_09.md` plus the design's sections 7 to 10 are the plan for the Mac. |
+
+Learned today, in addition to the sections below:
+
+- **The tracing build's `_DEBUG_JIT` listing is the fastest way to see what a call site emits**, but under threads its output interleaves; use a single-threaded program. The `-O1 -g` Linux build under gdb, with `OBJECK_GC_TRACE=1`, is what found the frame-layout bug: the collector prints each JIT frame's slots with their declared types.
+- **WSL is a real second platform here**: `deploy_posix.sh x64` builds the Linux tree in about three minutes, `run_regression.sh linux` runs it (the `x64` argument prefers the Windows `deploy-x64` tree and fails every compile), and `/tmp` does not survive between invocations, so artifacts go under the scratchpad. The Windows and Linux runners share `programs/regression/results`, so they run one after the other.
+- **Every `RTRN` emits its own epilogue**: anything patched into the prologue must be patched into every epilogue.
+- **A probe in `vm_jit_equiv.obs` has no local budget left in `Main`**: print through the interpolation.
+- The tools guard `check_test_exit_codes.py` wants an asserting test to exit non-zero on failure.
+
 ## Update, 2026-09-09 evening: what the next session finds
 
 Sections 1–4 below were written before this session; this is what changed.


### PR DESCRIPTION
The day's outcome for the next session: F7 done on AMD64 (#757, #758, #759, #760), the frame-layout fix (#761), the CI pass (#762), the open compiler bug (#763), the state of both deploy trees, the ARM64 plan, and what was learned. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)