### PR TITLE
docs(handoff): state at the move to the home server

### DIFF
--- a/docs/HANDOFF_2026_09_10.md
+++ b/docs/HANDOFF_2026_09_10.md
@@ -5,6 +5,38 @@ touching anything; every "where" below was checked against GitHub and the tree w
 The macOS-specific plan (`JIT_ARM64_HANDOFF_2026_09.md`) still applies for the ARM64 items and
 is referenced, not repeated.
 
+## Update, 2026-09-11 afternoon: the work moves to the home server
+
+The next session runs on an x64 Windows Server at home, not the desktop PC. x64 covers the
+Windows builds, both regression passes, WSL Linux checks and long runs; ARM64 stays with the Mac
+and with GitHub's hosted ARM64 runners.
+
+| item | now |
+|---|---|
+| #773 | fixed, [PR #780](https://github.com/objeck/objeck-lang/pull/780) (`e034fae228`): a Windows-only `RSI`/`RDI` register holder freed twice by the AMD64 compiler; see the 2026-09-11 section below |
+| a constant character stored into a `Char[]` | [PR #781](https://github.com/objeck/objeck-lang/pull/781) (open at the move: every leg green except windows-arm64, which failed once on the unrelated `http_persistence_test`, an out-of-memory in `Map->Insert` while a response was parsed, and was being rerun; the user asked for the merge once CI is green): both `move_imm_mem32` helpers stored 8 bytes, so `a[i] := 'x'` zeroed the next element on Linux x64, Linux and macOS ARM64 (4-byte characters) and the next three on Windows ARM64, and overran the array at the last index; Windows x64 stores 16 bits and was never affected. `jit_const_char_store.obs` failed with 96 characters overwritten on all four affected legs before the fix. The Windows x64 native entry's four-byte `ip`/`jit_offset` stores went through the same AMD64 helper and are exact now. The library's own terminator stores in `String->Pop()` (always compiled: `native`) and `String->Delete()` took that path, so on ARM64 they could write past the end of a nearly full string buffer |
+| the windows-arm64 `core_thread_gc_stress` flake | not reproducible on master. It failed twice, both times with exactly 203 corruptions (one worker's 201-node list plus one churn iteration's two checks), within one hour on #768's and #770's branches. Since then: 0 in 34 windows-arm64 suite legs, and 0 in 180 runs of a probe on the hosted runner (default, every method compiled, a 1 MB GC threshold, the JIT off, and a diagnostic copy). Ruled out by reading: the `_ARM64` define, the operand-stack count's width, `X18`, the `jit_offset` store (it lands in padding), mark/fixup asymmetry, the look-back window, stale `jit_mem` on pooled frames |
+| the probe | branch `probe/gc-stress-arm64`: its workflow runs only for `probe/**` pushes, builds the windows-arm64 toolchain as ci-build does, and loops the test (`programs/regression/probe/`). Rerun by pushing to a `probe/**` branch; delete it when it is no longer wanted; never merge it |
+| an ARM64 Windows machine | not needed: the hosted `windows-11-arm` runner is the configuration that failed |
+
+**Setting up the server.** Git and `gh` (logged in); Visual Studio with the C++ workload and the
+Windows SDK (the projects use `$(DefaultPlatformToolset)`, so VS 2022 or VS 2026 both work);
+vcpkg with `mbedtls:x64-windows nghttp2:x64-windows`; Python 3; 7-Zip; WSL2 Ubuntu with g++ and
+make for Linux x64 checks. Then build and verify before trusting anything: MSBuild
+`core/release/objeck.sln` and `core/lib/diags/diag.sln`, assemble `core/release/deploy-x64`, run
+`programs/regression/run_regression.cmd x64` twice (plainly and with `OBJECK_JIT_THRESHOLD=1`)
+and `programs/regression/run_vm_flag_tests.py core/release/deploy-x64/bin`.
+`deploy_windows.cmd x64` needs a VS Developer prompt and deletes `deploy-x64` before it checks
+anything.
+
+**Learned today.** A crash with no output under `OBJECK_JIT_THRESHOLD=1` can be the JIT
+compiler's own heap corruption rather than the code it emits: the Win32 debug-loop catcher named
+`~JitAmd64` in one run where the issue's suspects (the emitters) were all innocent. A local check
+on Windows x64 does not cover the AMD64 backend's POSIX branches (`#ifdef _WIN64` splits the
+char stores); WSL's `deploy_posix.sh x64` does, in about five minutes. From an agent shell on
+the desktop, `NoDefaultCurrentDirectoryInExePath=1` meant a wrapper `.cmd` had to call the
+regression runner by its full path.
+
 ## Update, 2026-09-11: #773 on the Windows box
 
 [#773](https://github.com/objeck/objeck-lang/issues/773) was not a miscompile. The AMD64 compiler


### PR DESCRIPTION
The handoff's new top section, for the next session on the x64 home server: #773 fixed (#780); #781 (constant-character `Char[]` stores on ARM64 and Linux x64) and its CI state at the move; the windows-arm64 `core_thread_gc_stress` flake, not reproducible on master (a probe on the hosted runner, 0 in 180 runs; 0 in 34 suite legs since the second failure); the `probe/gc-stress-arm64` branch; the server's setup checklist; and what was learned. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)