### PR TITLE
ci: run the every-method-compiled regression pass on every leg, ARM64 included

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -756,23 +756,28 @@ jobs:
     # called a few times never runs compiled here. The frame-layout bug of
     # #761 (a declared-but-unreferenced local shifted every lower slot under
     # the collector) crashed mcp_debug_test only in this mode, and only this
-    # mode had never run in CI. One x64 leg per OS: the bug class is
-    # platform-independent, and the pass doubles a leg's regression time.
-    - name: Run regression tests with every method compiled (Linux x64)
-      if: runner.os == 'Linux' && matrix.arch == 'x64'
+    # mode had never run in CI. Every leg runs it. It used to be one x64 leg
+    # per OS, on the grounds that the bug class is platform-independent, but
+    # AMD64 and ARM64 are separate backends and Windows and POSIX take
+    # different branches inside each: #781's constant-character store wrote
+    # 8 bytes on ARM64 and on Linux x64 through two different helpers, and
+    # the ARM64 legs had never run this mode. The suite takes about three
+    # minutes a leg, so the pass costs minutes.
+    - name: Run regression tests with every method compiled (POSIX)
+      if: runner.os != 'Windows'
       working-directory: ./programs/regression
       env:
         OBJECK_JIT_THRESHOLD: "1"
         OBJECK_GL_REQUIRED: "1"
-      run: ./run_regression.sh x64
+      run: ./run_regression.sh ${{ matrix.arch }}
 
-    - name: Run regression tests with every method compiled (Windows x64)
-      if: runner.os == 'Windows' && matrix.arch == 'x64'
+    - name: Run regression tests with every method compiled (Windows)
+      if: runner.os == 'Windows'
       working-directory: ./programs/regression
       shell: cmd
       env:
         OBJECK_JIT_THRESHOLD: "1"
-      run: run_regression.cmd x64
+      run: run_regression.cmd ${{ matrix.arch }}
 
     - name: Run debugger tests (POSIX)
       if: runner.os != 'Windows'


### PR DESCRIPTION
The `OBJECK_JIT_THRESHOLD=1` regression pass (#762) ran on the two x64 legs only, on the grounds that the bug class is platform-independent. It isn't: AMD64 and ARM64 are separate backends, and Windows and POSIX take different branches inside each. #781's constant-character store wrote 8 bytes on ARM64 *and* on Linux x64, through two different helpers, and linux-arm64, macos-arm64 and windows-arm64 had never run this mode.

The two steps now run on every POSIX leg and every Windows leg with the leg's own architecture (`matrix.arch`), with the same environment as before (`OBJECK_GL_REQUIRED=1` on POSIX). Cost: the suite takes about three minutes on a leg (windows-arm64: about 2.5 minutes in recent runs), so the pass adds minutes, not a doubling of the job.

**This PR's own CI is the first every-method-compiled run on linux-arm64 and windows-arm64** (the Mac runs both passes locally). If it finds something, that is the point: it gets fixed at the cause, not opted out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)