### PR TITLE
docs: the download markers name v2026.9.0 again, the version you can actually get

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://scan.coverity.com/projects/objeck"><img src="https://scan.coverity.com/projects/10314/badge.svg" alt="Coverity Scan Build Status"></a>
   <a href="https://github.com/objeck/objeck-lang/actions/workflows/ci-build.yml"><img src="https://github.com/objeck/objeck-lang/actions/workflows/ci-build.yml/badge.svg" alt="CI Build"></a>
   <a href="https://github.com/objeck/objeck-lang/actions/workflows/release-build.yml"><img src="https://github.com/objeck/objeck-lang/actions/workflows/release-build.yml/badge.svg" alt="Release Build"></a>
-  <a href="https://github.com/objeck/objeck-lang/releases"><img src="https://img.shields.io/badge/release-v2026.9.1-blue" alt="Latest Release"></a>
+  <a href="https://github.com/objeck/objeck-lang/releases"><img src="https://img.shields.io/badge/release-v2026.9.0-blue" alt="Latest Release"></a>
 </p>
 
 ## Why Objeck?
@@ -37,8 +37,8 @@ AI/ML prototyping • Computer vision • Web services • Real-time application
 
 ```bash
 # Install (example for macOS/Linux)
-curl -LO https://github.com/objeck/objeck-lang/releases/download/v2026.9.1/objeck-linux-x64_2026.9.1.tgz
-tar xzf objeck-linux-x64_2026.9.1.tgz
+curl -LO https://github.com/objeck/objeck-lang/releases/download/v2026.9.0/objeck-linux-x64_2026.9.0.tgz
+tar xzf objeck-linux-x64_2026.9.0.tgz
 export PATH=$PATH:./objeck-lang/bin
 export OBJECK_LIB_PATH=./objeck-lang/lib
 
@@ -94,7 +94,7 @@ obc hello && obr hello
 
 ## Downloads
 
-**Latest Release:** [v2026.9.1](https://github.com/objeck/objeck-lang/releases/latest)
+**Latest Release:** [v2026.9.0](https://github.com/objeck/objeck-lang/releases/latest)
 
 | Platform | Architecture | Download |
 |----------|--------------|----------|

--- a/docs/web/readme.html
+++ b/docs/web/readme.html
@@ -59,7 +59,7 @@
       AI, networking, and vision — built in. Every release moves the stack forward.
     </p>
     <div style="display: flex; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 2rem;">
-      <a class="btn btn-primary" href="https://github.com/objeck/objeck-lang/releases/latest">Download v2026.9.1</a>
+      <a class="btn btn-primary" href="https://github.com/objeck/objeck-lang/releases/latest">Download v2026.9.0</a>
       <a class="btn btn-secondary" href="getting_started.html">Quick Start</a>
       <a class="btn btn-secondary" href="https://github.com/objeck/objeck-lang">GitHub</a>
     </div>


### PR DESCRIPTION
## What

Moves four download-facing version markers back from `v2026.9.1` to `v2026.9.0`.

## Why

`433cf916cd` ("Release v2026.9.1 …") brought the release notes up to date and, along with them, flipped README's release badge and Quick Start install URL to `v2026.9.1`. But **v2026.9.1 was never tagged**: the newest tag is `v2026.9.0`, and the GitHub release for 2026.9.1 is still the empty auto-draft release-drafter opened on 2026-09-04.

So the GitHub landing page has been handing visitors a download that does not exist:

| URL | before |
|---|---|
| `.../releases/download/v2026.9.1/objeck-linux-x64_2026.9.1.tgz` | **404** |
| `.../releases/download/v2026.9.0/objeck-linux-x64_2026.9.0.tgz` | 200 |

This is the same early-flip that was corrected by hand on 2026-09-09 (`c4f5ec3f5a`); the `Latest Release:` label had survived that pass and was still wrong.

## What changed

- `README.md` — the `img.shields.io` release badge
- `README.md` — the Quick Start `curl`/`tar` lines
- `README.md` — the `**Latest Release:**` label over the Downloads table
- `docs/web/readme.html` — the hero `Download v2026.9.1` button (its `href` was already `/releases/latest`, so only the label was wrong)

All four now match, byte for byte, what shipped at the `v2026.9.0` tag. The Downloads table's per-platform links were already `/releases/latest` and needed nothing.

## Left alone deliberately

- **The v2026.9.1 What's New blocks and bullets** in every notes surface. Writing those ahead of the tag is intended; only the download promises must track the published version.
- **The checkmark**, which never moved off `### v2026.9.0 ✅`.
- **Two notes-heading links** (`docs/readme.html:64`, `docs/web/readme.html:68`) still point at `releases/tag/v2026.9.1` and 404 today. They follow the established per-version convention — at the `v2026.9.0` tag, that release's heading linked its own tag — and become correct the instant v2026.9.1 is tagged, so changing them would only create a flip-back chore. Say the word if you'd rather they point at `/releases` in the meantime.
- **No CHANGELOG entry.** This corrects release prep; it is not a change the release ships.

## At release time

Flip all four back to the new version as part of the release itself, then verify the download URLs return 200.

## Verification

```
404  .../releases/tag/v2026.9.1          (still, by design — untagged)
200  .../releases/tag/v2026.9.0
200  .../releases/download/v2026.9.0/objeck-linux-x64_2026.9.0.tgz   (the reverted Quick Start URL)
```

Docs-only; no build or test surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
