### PR TITLE
build(windows): the version stamper writes LF, so a deploy stops dirtying eight tracked files

### DIFF
--- a/core/release/update_version.ps1
+++ b/core/release/update_version.ps1
@@ -11,6 +11,27 @@ $version_posix = $version -replace "\.\d+$", ("-" + ($version.SubString($version
 $version_posix_long = $version_posix + "-1"
 $version_windows = $version.Replace(".", ",")
 
+# Set-Content joins lines with CRLF on Windows PowerShell, but .gitattributes
+# declares these files LF ("* text=auto eol=lf"). Every deploy therefore left
+# eight tracked files modified with an empty content diff, which blocked the
+# next pull until someone discarded them by hand. Rewrite them LF.
+#
+# This works on the raw bytes so the encoding is untouched: Get-Content and
+# Set-Content round-trip the ANSI codepage, which is what preserves the UTF-8
+# em dashes in readme.json, and re-encoding here would corrupt them.
+#
+# code_doc64.cmd is deliberately not in the list below: *.cmd is declared
+# eol=crlf because cmd.exe needs CRLF, so its CRLF is correct.
+function ConvertTo-LfEol {
+  param([string] $Path)
+  # .NET resolves a relative path against the process directory, which
+  # Set-Location does not change, so resolve it through PowerShell first.
+  $full = (Resolve-Path -LiteralPath $Path).ProviderPath
+  $latin1 = [System.Text.Encoding]::GetEncoding(28591)
+  $text = $latin1.GetString([System.IO.File]::ReadAllBytes($full))
+  [System.IO.File]::WriteAllBytes($full, $latin1.GetBytes(($text -replace "`r`n", "`n")))
+}
+
 # update source version header
 (Get-Content ..\shared\version.in) | ForEach-Object { $_ -replace "@VERSION@", $version } | ForEach-Object { $_ -replace "@VERSION_NUMBER@", $version_number } | Set-Content ..\shared\version.h
 (Get-Content code_doc64.in) | ForEach-Object { $_ -replace "@VERSION@", $version } | ForEach-Object { $_ -replace "@VERSION_WINDOWS@", $version_windows } | Set-Content code_doc64.cmd
@@ -30,3 +51,16 @@ $package_json = "..\..\tools\lsp\clients\vscode\package.json"
 (Get-Content ..\debugger\vs\objeck.in) | ForEach-Object { $_ -replace "@VERSION@", $version } | ForEach-Object { $_ -replace "@YEAR_END@", $year_end } | ForEach-Object { $_ -replace "@VERSION_WINDOWS@", $version_windows } | Set-Content ..\debugger\vs\objeck.rc
 (Get-Content ..\repl\vs\objeck.in) | ForEach-Object { $_ -replace "@VERSION@", $version } | ForEach-Object { $_ -replace "@YEAR_END@", $year_end } | ForEach-Object { $_ -replace "@VERSION_WINDOWS@", $version_windows } | Set-Content ..\repl\vs\objeck.rc
 (Get-Content ..\utils\launcher\vs\builder\objeck.in) | ForEach-Object { $_ -replace "@VERSION@", $version } | ForEach-Object { $_ -replace "@YEAR_END@", $year_end } | ForEach-Object { $_ -replace "@VERSION_WINDOWS@", $version_windows } | Set-Content ..\utils\launcher\vs\builder\objeck.rc
+
+
+# every file stamped above is declared LF; see ConvertTo-LfEol
+@(
+  "..\shared\version.h",
+  "..\..\programs\deploy\util\readme\readme.json",
+  $package_json,
+  "..\compiler\vs\objeck.rc",
+  "..\vm\vs\objeck.rc",
+  "..\debugger\vs\objeck.rc",
+  "..\repl\vs\objeck.rc",
+  "..\utils\launcher\vs\builder\objeck.rc"
+) | ForEach-Object { ConvertTo-LfEol $_ }


### PR DESCRIPTION
## The symptom

Every `deploy_windows.cmd` run leaves **eight tracked files modified with an empty content diff**, and the next `git pull` refuses to merge until someone discards them by hand.

Hit today on the Windows ARM64 box during a routine regression run — the deploy dirtied the tree, the pull was blocked, and the files had to be backed up and discarded to get moving. It is not specific to that machine: it happens on every Windows deploy, on every machine, and has been doing so silently.

## The cause

`core/release/update_version.ps1` stamps the version through `Set-Content`. On Windows PowerShell that joins lines with `[Environment]::NewLine` — **CRLF**. But `.gitattributes` line 2 declares the repository LF:

```
* text=auto eol=lf
```

So git reports all eight as modified and warns, in its own words:

```
warning: in the working copy of 'core/shared/version.h',
CRLF will be replaced by LF the next time Git touches it
```

The byte delta is exactly the line count — the signature of a change that is nothing but line endings.

The eight: `core/shared/version.h`, the five `.rc` files, `programs/deploy/util/readme/readme.json`, and `tools/lsp/clients/vscode/package.json`.

## The fix

`ConvertTo-LfEol` rewrites each stamped file LF after it is written. Two details that are load-bearing:

- **It works on raw bytes, via the byte-preserving Latin-1 encoding, instead of re-encoding the text.** `Get-Content`/`Set-Content` round-trip the ANSI codepage, and that accidental round-trip is what keeps `readme.json`'s UTF-8 em dashes (`E2 80 94`) intact. A `WriteAllText`-style rewrite would re-encode and corrupt them.
- **It resolves through `Resolve-Path` first.** .NET resolves a relative path against the *process* directory, which `Set-Location` does not change — the classic PowerShell trap, and these paths are all relative.

`code_doc64.cmd` is deliberately excluded. `*.cmd` is declared `eol=crlf` because `cmd.exe` needs CRLF, so its CRLF is correct.

## Verification, on Windows x64

| | before | after |
|---|---|---|
| tracked files modified by a run | 8 | 0 |
| the eight stamped files | CRLF | pure LF, 0 CRLF |
| `code_doc64.cmd` | CRLF | still CRLF (55 lines, 0 LF-only) |
| `readme.json` em dashes | 15 | 15, decodes as valid UTF-8 |

## Why nothing in the build is at risk

- **`ci-build.yml` never runs this script.** It runs the POSIX `update_version.sh` / `update_version_arm.sh` on the Linux and macOS legs. The Windows legs compile the `.rc` files straight from the LF checkout and are green on every run — which is what proves `rc.exe` accepts LF `.rc` files. This change makes the post-deploy state match the checkout state that CI has always built from.
- **`release-build.yml` rewrites only the three version lines** at the top of this file, with an anchored `sed -i` (`^$year_end = `, `^$month_end = `, `^$version = "[0-9]*"`). Those three lines are untouched and still match, as does the `grep -q` guard that follows.

Windows-only build tooling; no compiler, VM, or runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
