### PR TITLE
docs: the v2026.9.1 release notes carry the release date, not the prep date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Objeck will be documented in this file.
 
-## [v2026.9.1] - 2026-09-11
+## [v2026.9.1] - 2026-09-12
 
 Compiled code now calls compiled code directly -- a bound call 26.5 ns to 5.5 ns,
 a `virtual` call 125 ns to 6.0 ns, `Fib(32)` 0.208 s to 0.043 s -- and three ways

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -1,4 +1,4 @@
-v2026.9.1 (September 11, 2026)
+v2026.9.1 (September 12, 2026)
 ===
 Compiled code now calls compiled code directly -- a bound call 26.5 ns to 5.5 ns, a virtual call 125 ns to 6.0 ns, Fib(32) 0.208 s to 0.043 s. Every string hash was wrong and is now right, three ways compiled code could corrupt memory are closed, the debugger sees threads and tells the truth about its commands, and Game.OpenGL gains a sky, rotations, normal maps and emissive materials.
 


### PR DESCRIPTION
## What

Moves the v2026.9.1 release date from **2026-09-11** to **2026-09-12** on the two surfaces that carry one.

| file | before | after |
|---|---|---|
| `CHANGELOG.md:5` | `## [v2026.9.1] - 2026-09-11` | `## [v2026.9.1] - 2026-09-12` |
| `docs/readme.txt:1` | `v2026.9.1 (September 11, 2026)` | `v2026.9.1 (September 12, 2026)` |

Both formats match the v2026.9.0 entries directly above them (`2026-09-03`, `September 3, 2026`).

## Why

The notes were written on 2026-09-11, but v2026.9.1 was never tagged that day — it was held for the Windows signing token. Published notes dated a day the release didn't happen on are just wrong, and the date is the field people scan a CHANGELOG by.

## Nothing else needed changing

`README.md`, `docs/readme.html`, `docs/web/readme.html` and `readme.json` identify a release by version heading and tag link rather than by date. Verified by grep across all six notes surfaces — only the two above matched.

## This will not fix itself at tag time

Worth knowing rather than assuming: the `update-docs` step **adds** a new `## [vX.Y.Z] - YYYY-MM-DD` section, and v2026.9.1's section already exists from the prep run — so nothing in the release flow re-dates an existing entry.

**If the tag slips past 2026-09-12, this needs touching again.**

Docs-only; no build or test surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
