### PR TITLE
docs(perf): rewrite the benchmark task brief for the v2026.9.1 re-measurement

### DIFF
--- a/perf-results/BENCHMARK_TASK.md
+++ b/perf-results/BENCHMARK_TASK.md
@@ -1,170 +1,170 @@
-# Benchmark Task for Claude on AMD 7950X3D Box
+# Benchmark Task: re-measure `docs/performance.md` for v2026.9.1
 
-## Context
-Library-level optimizations were just pushed to master (commit `bcb5512f0`). Changes include:
-- **gen_collect.obs**: Hash load-factor auto-resize (>75% triggers upsize), Vector in-place Remove (shift instead of new array), 50% growth factor, Map.Filter uses GetKeyValues
-- **json.obs**: Fixed escape sequence scanning (`@input_index += 2`), fixed quoted keyword-as-key tokenization
-- **onnx.obs**: Tokenizer Encode/Decode use `String.Append()` instead of `+=` (O(n) vs O(n²))
-- **csv.obs**: Fixed Median value-as-index bug, fixed Average off-by-one
-- **net_common.obs**: Fixed swapped `$`/`&` URL encoding, fixed Response.ToString nil check
-- **regex.obs**: Cache ToCharArray across Find() loop
-- **query.obs**: Reserved keyword map moved to class field (init once)
-- **xml.obs**: Bulk String copy in ParseName, tag contents, CDATA
-- **lang.obs**: Added `String->New(capacity : Int)` constructor (needs sys_obc rebuild)
-- **New regression tests**: `core_collections_perf.obs` (7 tests), `core_json_escape.obs` (8 tests)
+**For:** the session on the AMD Ryzen 9 7950X3D box.
+**Written:** 2026-09-12, from the Zephyrus (x64 laptop), which cannot do this job —
+wrong CPU for the baseline, and it cannot even build the tree (the repo targets
+toolset v145, that box has VS 2022 v143).
 
-## Steps
+---
 
-### 1. Pull and rebuild
+## Why this exists
+
+`docs/performance.md` carries measured tables from **2026-06-21, against v2026.6.2**.
+Four releases have landed since. The largest of them changed how compiled code calls
+compiled code:
+
+| | before | after |
+|---|---|---|
+| bound call (AMD64) | 26.5 ns | **5.5 ns** |
+| `virtual` call (AMD64) | 125 ns | **6.0 ns** |
+| `Fib(32)` (AMD64) | 0.208 s | **0.043 s** |
+
+So every call-dominated row on that page is wrong, and wrong in the *pessimistic*
+direction. A banner now says so, and this task is what removes the banner.
+
+**The numbers were deliberately left unchanged** rather than guessed at or
+substituted from other hardware. Do not treat "update the page" as licence to
+estimate anything. Either a number is measured on that box in a unified run, or it
+does not go on the page.
+
+---
+
+## Read first
+
+- `docs/performance.md` — especially the banner and the P3 roadmap table.
+- `perf-results/docker/Dockerfile` — what the unified run actually builds.
+- The traps section below. Three of them have already cost someone a day.
+
+---
+
+## Step 0 — the trap that would silently corrupt the whole run
+
+**`Dockerfile:39` copies the committed `.obl` files instead of rebuilding them:**
+
+```dockerfile
+COPY core/lib/*.obl core/lib/
+```
+
+The image builds a fresh `obc` and `obr` from current source, then runs them against
+**standard libraries compiled on 2026-09-04** — before the recent compiler work. That
+is a v2026.9.1 VM measured against v2026.9.0-era libraries, and nothing in the output
+would look wrong.
+
+This is confirmed, not theoretical: on 2026-09-12, rebuilding `diags.obl` from
+identical source with identical flags produced a file **48 bytes smaller** than the
+committed one.
+
+**Rebuilding restores comparability rather than breaking it.** The 2026-06-21 baseline
+used committed `.obl` that were current *for v2026.6.2*. The like-for-like condition
+for v2026.9.1 is libraries current for v2026.9.1.
+
+So, in WSL, before building the image:
+
 ```bash
-cd /path/to/objeck-lang
-git pull
-cd core/release
-bash update_version.sh
+cd core/compiler && sh update_version.sh amd64
+git status --porcelain core/lib/
 ```
 
-### 2. Run regression tests
+**Record whether any `core/lib/*.obl` changed.** That answer belongs in the results —
+it tells us how stale the committed set had drifted. If they changed, the rebuilt ones
+are what should be measured, and they should probably be committed separately (their
+own PR, not mixed into the numbers PR).
+
+---
+
+## Step 1 — the run
+
+Same host as the baseline, or the cross-language rows stop being comparable to their
+own history. That is the entire reason this task is pinned to that box.
+
 ```bash
-cd programs/regression
-# Run full regression suite including new tests
-# Expected: all tests pass (19/19 minimum, including 2 new tests)
+git checkout master && git pull
+docker build -t objeck-bench -f perf-results/docker/Dockerfile .
+docker run --rm -v "$(pwd)/perf-results/docker-results:/results" objeck-bench
 ```
 
-### 3. Run performance benchmarks (3 runs each)
-```bash
-cd perf-results
-bash run_benchmarks.sh ../../core/release/deploy-x64 ./v2026.3.0 3
-```
-This runs all CLBG + perf benchmarks and writes `v2026.3.0/results.csv`.
+Record the **commit SHA** you measured. It goes on the page.
 
-### 4. Create library-specific micro-benchmarks
-The existing benchmarks (nbody, binarytrees, etc.) test JIT/compiler performance. They won't show the library changes. Create and run these targeted benchmarks:
+---
 
-#### a. Hash resize benchmark (`bench_hash_resize.obs`)
-```
-use Collection;
-class HashResize {
-    function : Main(args : String[]) ~ Nil {
-        # Insert 100K entries, measure total time
-        h := Hash->New()<String, IntRef>;
-        each(i : 100000) {
-            key := "key_{$i}";
-            h->Insert(key, IntRef->New(i));
-        };
-        # Verify all present
-        each(i : 100000) {
-            key := "key_{$i}";
-            val := h->Find(key);
-            if(val = Nil | val->Get() <> i) {
-                "FAIL"->PrintLine();
-                return;
-            };
-        };
-        sz := h->Size();
-        "Hash: {$sz} entries OK"->PrintLine();
-    }
-}
-```
+## Step 2 — what to look at hardest
 
-#### b. JSON parse benchmark (`bench_json_parse.obs`)
-```
-use Data.JSON;
-class JsonParseBench {
-    function : Main(args : String[]) ~ Nil {
-        # Build a large JSON string with escapes
-        builder := "";
-        each(i : 1000) {
-            if(i > 0) { builder += ","; };
-            builder += "\"key_{$i}\": \"value\\\\path\\\\{$i}\"";
-        };
-        json := "{" + builder + "}";
+`spectralnorm` is the interesting one, not just the stale one.
 
-        # Parse it 100 times
-        each(j : 100) {
-            p := JsonParser->New(json);
-            if(<>p->Parse()) {
-                "FAIL"->PrintLine();
-                return;
-            };
-        };
-        "JSON: 100 parses of 1000-key object OK"->PrintLine();
-    }
-}
-```
+The page currently argues its 44.86 s "is a JIT-warmup artifact, not raw capability,"
+and that the remaining lever is *threshold tuning, not coverage*. **That entire reading
+was written when a closure call cost 125 ns.** It now costs ~6 ns, and func-ref sites
+carry an inline cache. The warmup argument may simply have evaporated.
 
-#### c. Vector remove benchmark (`bench_vector_remove.obs`)
-```
-use Collection;
-class VectorRemoveBench {
-    function : Main(args : String[]) ~ Nil {
-        # Repeated remove-from-middle
-        each(round : 100) {
-            v := Vector->New()<IntRef>;
-            each(i : 1000) {
-                v->AddBack(IntRef->New(i));
-            };
-            # Remove from middle repeatedly
-            while(v->Size() > 0) {
-                mid := v->Size() / 2;
-                v->Remove(mid);
-            };
-        };
-        "Vector: 100 rounds of 1000 removes OK"->PrintLine();
-    }
-}
-```
+Do not copy that paragraph forward. Re-derive it from the new numbers:
 
-Compile and time each:
-```bash
-cd core/release/deploy-x64/bin
-./obc -src bench_hash_resize.obs -dest bench_hash_resize.obe -lib gen_collect -opt s3
-./obc -src bench_json_parse.obs -dest bench_json_parse.obe -lib json -opt s3
-./obc -src bench_vector_remove.obs -dest bench_vector_remove.obe -lib gen_collect -opt s3
+- If default-threshold `spectralnorm` is now close to its `OBJECK_JIT_THRESHOLD=1`
+  time, the warmup story is dead and should be deleted, not softened.
+- If the gap persists, it is a genuinely different finding than it was in June and
+  needs its own explanation.
 
-for bench in bench_hash_resize bench_json_parse bench_vector_remove; do
-    echo "=== $bench ==="
-    for run in 1 2 3; do
-        /usr/bin/time -f "  Run $run: %e seconds" ./obr ${bench}.obe 2>&1
-    done
-done
-```
+Also expect movement in `binarytrees` and `fannkuchredux` (both call-bound). If
+`binarytrees` is *still* the weak spot, that strengthens the P1 allocation-throughput
+case rather than weakening it — say so plainly.
 
-### 5. Update `docs/performance.md`
+---
 
-Add a new section **after section 5** (before Benchmark Results):
+## Step 3 — updating the page
 
-**Section: v2026.3.0 — Standard Library Optimizations**
+- Replace the measured tables; keep the structure.
+- Delete the staleness banner at the top — it exists only until this run lands.
+- Stamp the **Objeck version and commit SHA beside every table**, not just in the
+  footer. The absence of that is precisely how the page went four releases without
+  anyone noticing it was stale (it is P3's second item).
+- Rewrite every *reading* that the new numbers no longer support. The prose asserts
+  specific ratios ("7.5x faster than Python", "~16x", "3.8x faster than LuaJIT") —
+  each one needs recomputing, not adjusting by feel.
+- Update both the footer dates: prose *and* tables.
 
-Include:
-- Summary table of all changes with category (Bug Fix / Performance / Both)
-- Benchmark results from step 3 (CLBG/perf — confirm no regressions)
-- Micro-benchmark results from step 4 (library-specific improvements)
-- Algorithmic complexity improvements table:
+Then open a PR. **Merges happen only on the maintainer's explicit word** — the gate is
+the five build legs, `Tools (formatter, LSP, VS Code extension)` and `CI Status` all
+green, then `gh pr merge N --merge --delete-branch`. Never `gh pr merge --auto`: this
+repo has no auto-merge, so `--auto` merges *immediately*.
 
-| Component | Operation | Before | After |
-|-----------|-----------|--------|-------|
-| Hash.Insert | Auto-resize | Fixed capacity (769 default) | Load-factor resize at 75% (769→12289→1.5M→...) |
-| Vector.Remove | Element removal | O(n) new array + copy all | O(n) in-place shift (no allocation) |
-| Vector.Expand | Growth | 25% increase | 50% increase (fewer resizes) |
-| Map.Filter | Filtering | GetKeys + Find per key (2 lookups) | GetKeyValues (1 lookup per pair) |
-| JsonParser.Scan | Escape handling | Stateful flag (buggy on \\) | Skip +2 (correct, branchless) |
-| JsonParser.Scan | Keyword matching | Always matched true/false/null | Only matches unquoted identifiers |
-| Tokenizer.Decode | String building | += concatenation O(n²) | String.Append O(n) |
-| Tokenizer.Encode | String building | += concatenation O(n²) | String.Append O(n) |
-| Regex.Find | Input conversion | ToCharArray every call | Cached (skip if same input) |
-| Query.Scan | Reserved words | New Map per Scan() call | Class field (init once) |
-| Xml.ParseName | Name extraction | Char-by-char append | Bulk String.New(buffer, start, len) |
+---
 
-Update the timeline table in section 3 to add:
-```
-| v2026.3.0 | Mar 2026 | Standard library: Hash auto-resize, Vector in-place Remove, JSON escape/keyword fixes, tokenizer O(n) string building |
-```
+## Traps, all previously paid for
 
-Update `*Last updated:*` at the bottom to `March 2026 — v2026.3.0`.
+1. **Check AC vs battery before trusting any timing.** Windows throttles CPU on DC and
+   this workload is exactly the CPU-bound shape that suffers most. A run once took an
+   hour on battery and read convincingly as a livelock.
+2. **Do not estimate run counts from an assumed per-run time.** A "~130 runs" figure
+   was once derived from an assumed 15 s/run; one run actually took an hour, so every
+   progress number was inflated.
+3. **A hung-looking process is not a hang until the threads say so.** Use
+   `analyze_hang.py`, which buckets threads by module+offset and distinguishes blocked
+   (deadlock), shared-RIP (spin) and dispersed (real work). `analyze_dump.py` reads an
+   exception record and is useless on a hang dump.
+4. **Identical numbers across two configurations are indistinguishable from a
+   configuration that never applied.** This bit two sessions in one night. If two runs
+   come back the same, prove the knob reached the process — time a workload known to be
+   sensitive to it — before reporting them as two results. On 2026-09-12,
+   `OBJECK_JIT_THRESHOLD=1` vs `--jit=off` on `jit_call_overhead.obe` gave 9065 ms vs
+   1012 ms; that is what a knob that works looks like.
+5. **Verify a measurement harness can detect a failure before trusting a clean run.**
+   A loop using `start /affinity F /b /wait` reported a perfect score while running
+   nothing, because that form does not propagate the child's exit code.
 
-### 6. Commit and push
-```bash
-git add -A
-git commit -m "Update performance.md with v2026.3.0 library optimization benchmarks"
-git push
-```
+---
+
+## Do not
+
+- Put any number on the page that was not measured in this run on this box.
+- Mix the `.obl` rebuild (if it changes files) into the numbers PR.
+- Carry forward a *reading* without re-deriving it from the new numbers. The prose is
+  the part most likely to be quietly wrong, because it survives a table replacement
+  unchanged.
+
+---
+
+## Send back
+
+- `perf-results/docker-results/` output.
+- The commit SHA measured.
+- Whether any `core/lib/*.obl` changed in step 0.
+- Whether the machine was on AC.


### PR DESCRIPTION
## What

Rewrites `perf-results/BENCHMARK_TASK.md`, the brief addressed to the session on the AMD Ryzen 9 7950X3D box.

## Why

It had sat at **v2026.3.0 (March 2026)** since it was written. It described library changes from commit `bcb5512f0`, told the reader to write results into a `v2026.3.0` section, and ended by setting `docs/performance.md`'s footer to "March 2026". Every instruction in it was wrong for any run someone would do today — and it's the first file that box would read.

## What the brief now carries

Things the other machine needs and cannot derive locally:

- **Why the re-run exists.** The page's tables are v2026.6.2; the calling convention has since taken a bound call from 26.5 ns to 5.5 ns, so every call-dominated row is wrong in the *pessimistic* direction.
- **Step 0 — the trap that would corrupt the run silently.** `perf-results/docker/Dockerfile:39` `COPY`s the committed `.obl` rather than rebuilding, so a fresh v2026.9.1 VM gets measured against 2026-09-04 libraries with nothing in the output looking wrong. Confirmed, not theoretical: rebuilding `diags.obl` from identical source and flags produced a file **48 bytes smaller**. Rebuilding *restores* the like-for-like the June baseline had rather than changing methodology.
- **That `spectralnorm` is the interesting row, not merely the stale one.** Its entire "44.86 s is JIT warmup, not capability" argument was written when a closure call cost 125 ns and now costs ~6 — so that reading must be re-derived or deleted, not softened.
- **Stamp version and SHA beside every table.** The absence of that is precisely how the page went four releases without anyone noticing it was stale.
- **Five traps already paid for**, including today's two: identical numbers across two configurations are indistinguishable from a configuration that never applied; and a harness must be shown able to detect a failure before a clean run from it means anything.
- **An explicit "do not"**: no number on the page that wasn't measured in that run on that box, and no *reading* carried forward without re-deriving it.

## Gotcha worth knowing

`perf-results/` is in `.gitignore` (line 127) **but this file is tracked**. So `git add` refuses it and `git add -f` is required — my first attempt at this commit silently produced an empty branch. Noted in the commit message so the next person doesn't lose time to it.

Docs-only; no build or test surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
