### PR TITLE
fix(vm): Console->WriteBuffer(Char[]) encoded its output twice

### DIFF
--- a/core/vm/common.cpp
+++ b/core/vm/common.cpp
@@ -3529,12 +3529,21 @@ bool TrapProcessor::StdOutCharAryLen(StackProgram* program, size_t* inst, size_t
 #endif
 
   if(array && offset >= 0 && num >= 0 && offset <= (INT64_VALUE)array[0] && num <= (INT64_VALUE)array[0] - offset) {
+    const wchar_t* chars = (wchar_t*)(array + 3) + offset;
 #ifdef _MODULE_STDIO
-    std::wstring wide_buffer((wchar_t*)(array + 3) + offset);
-    program->output_buffer.write(wide_buffer.c_str(), wide_buffer.size());
+    program->output_buffer.write(chars, num);
+    PushInt(num, op_stack, stack_pos);
 #else
-    std::string buffer = UnicodeToBytes((wchar_t*)(array + 3) + offset);
-    PushInt(fwrite(buffer.c_str(), 1, buffer.size(), stdout), op_stack, stack_pos);
+    // stdout is in a wide CRT mode -- _O_U8TEXT by default, or whatever
+    // --objeck-stdio selected -- so the CRT performs the UTF-8 conversion. This
+    // encoded to UTF-8 here as well and wrote the resulting BYTES, which that
+    // stream reads back a pair at a time as one wchar_t: 'A','B' arrived as
+    // U+4241, and the invalid sequence left the stream unusable for every later
+    // write, so one call corrupted the rest of the program's output. It also
+    // ignored num and stopped at a NUL instead. Hand wcout the wide characters
+    // and let the stream's own mode decide the encoding, as the rest of the VM does.
+    std::wcout.write(chars, num);
+    PushInt(std::wcout.good() ? num : -1, op_stack, stack_pos);
 #endif
   }
   else {

--- a/programs/regression/TESTS.md
+++ b/programs/regression/TESTS.md
@@ -13,14 +13,14 @@ python gen_manifest.py
 ```
 
 
-**Total runtime tests: 241** (plus 14 debugger tests, see below).
+**Total runtime tests: 242** (plus 14 debugger tests, see below).
 
 
 ## Tests by Category
 
 | Category | Count |
 |----------|-------|
-| Other | 44 |
+| Other | 45 |
 | Core Language | 39 |
 | AMD64/JIT | 30 |
 | Negative | 21 |
@@ -292,11 +292,12 @@ python gen_manifest.py
 | 234 | `vm_set_locale_refused.obs` | Other | Runtime->SetLocale with a name the system cannot supply. The VM switched the C library's locale a... | ✅ |
 | 235 | `vm_set_property_first.obs` | Other | A program whose first property access is a set still gets the runtime's own properties. The runti... | ✅ |
 | 236 | `vm_set_property_overwrite.obs` | Other | A runtime property set twice reads back the second value. StackProgram::SetProperty stored with s... | ✅ |
-| 237 | `web_server_test.obs` | Other | Web.Server end-to-end coverage. Every method on Web.Server.Request and Response used to call a na... | ✅ |
-| 238 | `websocket_test.obs` | Networking | websocket test | ✅ |
-| 239 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
-| 240 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
-| 241 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
+| 237 | `vm_write_char_buffer.obs` | Other | Console->WriteBuffer(Char[]) wrote the buffer twice-encoded, and ignored num. The trap (STD_OUT_C... | ✅ |
+| 238 | `web_server_test.obs` | Other | Web.Server end-to-end coverage. Every method on Web.Server.Request and Response used to call a na... | ✅ |
+| 239 | `websocket_test.obs` | Networking | websocket test | ✅ |
+| 240 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
+| 241 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
+| 242 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
 
 ## Debugger Tests (`run_debugger_tests.sh`)
 

--- a/programs/regression/vm_write_char_buffer.obs
+++ b/programs/regression/vm_write_char_buffer.obs
@@ -1,0 +1,57 @@
+#~
+# Console->WriteBuffer(Char[]) wrote the buffer twice-encoded, and ignored num.
+#
+# The trap (STD_OUT_CHAR_ARY_LEN) converted the wide characters to UTF-8 itself
+# and fwrite'd the resulting BYTES. But obr puts stdout in a wide CRT mode
+# (_O_U8TEXT by default on Windows, or whatever --objeck-stdio selected), so the
+# CRT performs that conversion -- it reads the bytes back a pair at a time as one
+# wchar_t. 'A','B' arrived as U+4241, and the invalid sequence left the stream
+# unusable, so a single call corrupted the rest of the program's output. The trap
+# also ignored num and stopped at a NUL instead.
+#
+# Output correctness cannot be asserted from inside the program, but the return
+# value distinguishes both faults:
+#
+#   num honoured   -- asking for 4 of 8 characters returns 4, not 8
+#   no re-encoding -- 3 non-ASCII characters return 3 (the character count), not
+#                     6 (their UTF-8 byte count, which is what the old path
+#                     returned because it counted the bytes it had built)
+#
+# Both read the same for plain ASCII written in full, which is why this uses a
+# partial write and characters above U+007F. Exits 1 on a mismatch.
+~#
+
+class WriteCharBuffer {
+  function : Main(args : String[]) ~ Nil {
+    bad := 0;
+
+    # a partial write: 8 characters in the buffer, 4 requested
+    a := Char->New[8];
+    for(i := 0; i < 8; i += 1;) {
+      a[i] := 'x';
+    };
+    n := Console->WriteBuffer(0, 4, a);
+    ""->PrintLine();
+    if(n <> 4) {
+      "FAIL: partial write returned {$n}, expected 4"->PrintLine();
+      bad += 1;
+    };
+
+    # non-ASCII: the character count and the UTF-8 byte count differ
+    b := Char->New[3];
+    b[0] := 'é'; b[1] := 'ü'; b[2] := 'ñ';
+    m := Console->WriteBuffer(0, 3, b);
+    ""->PrintLine();
+    if(m <> 3) {
+      "FAIL: non-ASCII write returned {$m}, expected 3 (characters, not UTF-8 bytes)"->PrintLine();
+      bad += 1;
+    };
+
+    if(bad > 0) {
+      "FAIL: {$bad} check(s)"->PrintLine();
+      Runtime->Exit(1);
+    };
+
+    "PASS: Console->WriteBuffer(Char[]) honours num and does not re-encode"->PrintLine();
+  }
+}

--- a/programs/tests/clbg/fasta.obs
+++ b/programs/tests/clbg/fasta.obs
@@ -53,10 +53,10 @@ bundle Default {
 			IUB[14] := Frequency->New('Y', 0.02);
 
 			HomoSapiens := Frequency->New[4];
-			HomoSapiens[0] := Frequency->New('a', 0.3029549426680d);
-			HomoSapiens[1] := Frequency->New('c', 0.1979883004921d);
-			HomoSapiens[2] := Frequency->New('g', 0.1975473066391d);
-			HomoSapiens[3] := Frequency->New('t', 0.3015094502008d);
+			HomoSapiens[0] := Frequency->New('a', 0.3029549426680);
+			HomoSapiens[1] := Frequency->New('c', 0.1979883004921);
+			HomoSapiens[2] := Frequency->New('g', 0.1975473066391);
+			HomoSapiens[3] := Frequency->New('t', 0.3015094502008);
 
 			BUFFER_SIZE := 32768;
 			index := 0;


### PR DESCRIPTION
## The bug

`obr` puts stdout in a wide CRT mode — `_O_U8TEXT` by default, or whatever `--objeck-stdio` selected — and the rest of the VM writes wide characters through `wcout`, letting the CRT encode them. `StdOutCharAryLen` did the conversion itself and wrote the resulting **bytes**:

```c
std::string buffer = UnicodeToBytes((wchar_t*)(array + 3) + offset);
fwrite(buffer.c_str(), 1, buffer.size(), stdout);
```

The data is UTF-8 encoded **twice** — once here, once by the CRT, which reads those bytes back a pair at a time as one `wchar_t`. `'A','B'` arrives as U+4241 (䉁). And the invalid sequence leaves the stream unusable, so **one call corrupts every later write in the program**; the `PrintLine` after one of these came out mangled too.

It also ignored `num`: `UnicodeToBytes` takes a NUL-terminated pointer, so it wrote to the first NUL rather than the count it was given.

Repro before the fix:

```
char-overload returned 5   →  䉁䑃挊栀愀爀ⴀ漀瘀攀爀氀漀愀搀...
byte-overload returned 5   →  ABCD
```

## The fix

Hand `wcout` the wide characters and let the stream's mode decide the encoding — what every other output path already does. The `_MODULE_STDIO` branch gets the same `num` honoured, plus a return value it was not pushing at all.

## How it was found

`programs/tests/clbg/fasta.obs`, which the benchmark harness has been silently skipping. That file had a **second, unrelated** defect: four float literals with a `d` suffix (`0.3029549426680d`), a Java-ism from the original shootout source. Objeck has only ever had a `u` suffix — `git log -S` shows the scanner never had a `d`, `fasta` is absent from the June results table (so it was already failing then), and it is the only file in the repo that used one.

Both fixed. `fasta` now emits the real ALU sequence instead of CJK.

## Test

`vm_write_char_buffer.obs` asserts what is visible from inside the program: a partial write returns the count requested (**4** of 8, not 8), and a non-ASCII write returns the character count (**3**, not the 6 UTF-8 bytes the old path counted). Both read identically for plain ASCII written in full, which is why it uses a partial write and characters above U+007F.

Built a VM from the previous `common.cpp` to confirm it actually catches the bug:

```
FAIL: partial write returned 8, expected 4
FAIL: non-ASCII write returned 6, expected 3 (characters, not UTF-8 bytes)
exit 1
```

## Verification

| run | result |
|---|---|
| Windows x64, default | **239 / 3 / 0** |
| Windows x64, `OBJECK_JIT_THRESHOLD=1` | **239 / 3 / 0** |
| Linux x64 | **238 / 4 / 0** |

Verified on **both** platforms deliberately: the changed branch is shared, and POSIX stdout is a plain byte stream where the old code was correct — so this could have fixed Windows and broken Linux. It doesn't; `wcout` honours each platform's conventions (`ABCD\n` on Linux, `ABCD\r\n` on Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)