### PR TITLE
fix(compiler): a post-operation in a do/while condition ran outside the loop

### DIFF
--- a/core/compiler/intermediate.cpp
+++ b/core/compiler/intermediate.cpp
@@ -3527,17 +3527,30 @@ void IntermediateEmitter::EmitDoWhile(DoWhile* do_while_stmt)
   imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(do_while_stmt, cur_line_num, LBL, unconditional_continue));
   
   // conditional
-  // A post statement runs between the test and the jump, so the value has to
-  // wait on the stack; without one the condition branches directly.
-  if(post_statements.empty()) {
-    EmitBranch(do_while_stmt->GetExpression(), conditional, true);
-  }
-  else {
-    EmitExpression(do_while_stmt->GetExpression());
+  //
+  // A post statement (`n--` inside the condition) runs between the test and the
+  // jump, so the tested value has to wait on the stack while the post statement
+  // executes -- which is what this non-branching form does.
+  //
+  // This used to take EmitBranch's fused test-and-jump when `post_statements`
+  // was empty. The queue is filled while the CONDITION is emitted, though, so at
+  // this point it is always empty and the fast path was always taken: the post
+  // statement was then queued by EmitBranch and emitted by the enclosing scope
+  // AFTER the loop's break label, outside the loop. `do { } while(n-- > 0)`
+  // decremented once, on the way out, so `n` never changed between iterations
+  // and the loop never terminated. Emitting the condition first and testing
+  // afterwards would not help: EmitBranch fuses the compare and the jump, and a
+  // post statement has to run on BOTH the taken and the untaken path, which that
+  // shape cannot express.
+  //
+  // EmitWhile is unaffected -- it drains the queue after the body, once the
+  // condition has already been emitted.
+  EmitExpression(do_while_stmt->GetExpression());
+  if(!post_statements.empty()) {
     EmitAssignment(post_statements.front());
     post_statements.pop();
-    imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(do_while_stmt, cur_line_num, JMP, conditional, true));
   }
+  imm_block->AddInstruction(IntermediateFactory::Instance()->MakeInstruction(do_while_stmt, cur_line_num, JMP, conditional, true));
   
   std::pair<int, int> break_continue_label = break_labels.top();
   break_labels.pop();

--- a/programs/regression/TESTS.md
+++ b/programs/regression/TESTS.md
@@ -13,7 +13,7 @@ python gen_manifest.py
 ```
 
 
-**Total runtime tests: 242** (plus 14 debugger tests, see below).
+**Total runtime tests: 243** (plus 14 debugger tests, see below).
 
 
 ## Tests by Category
@@ -21,7 +21,7 @@ python gen_manifest.py
 | Category | Count |
 |----------|-------|
 | Other | 45 |
-| Core Language | 39 |
+| Core Language | 40 |
 | AMD64/JIT | 30 |
 | Negative | 21 |
 | Bug Fix | 13 |
@@ -123,181 +123,182 @@ python gen_manifest.py
 | 65 | `core_collections_perf.obs` | Core Language | core collections perf | ✅ |
 | 66 | `core_control_flow.obs` | Core Language | Core Control Flow Test Tests if/else, loops, and select statements | ✅ |
 | 67 | `core_do_while.obs` | Core Language | core do while | ✅ |
-| 68 | `core_each_loop.obs` | Core Language | core each loop | ✅ |
-| 69 | `core_enum.obs` | Core Language | core enum | ✅ |
-| 70 | `core_function_refs.obs` | Core Language | core function refs | ✅ |
-| 71 | `core_generic_compound_bounds.obs` | Generics | Compound generic bounds (T : A & B): a concrete type argument must satisfy ALL bounds. Person imp... | ✅ |
-| 72 | `core_generic_fbound.obs` | Generics | F-bounded type-parameter constraint (T : Compare<T>): the bound may be generic and self-referenti... | ✅ |
-| 73 | `core_generic_structural.obs` | Generics | Exercises the structural generic type comparison: deeply nested generic type arguments must round... | ✅ |
-| 74 | `core_generic_variance.obs` | Generics | Declaration-site variance: 'out T' (covariant) lets Producer<Dog> be used where Producer<Animal>... | ✅ |
-| 75 | `core_http_server.obs` | Core Language | HTTP Client/Server Loopback Test Tests HTTP GET and POST using raw TCP server + HttpClient. Verif... | ✅ |
-| 76 | `core_inheritance_chain.obs` | Core Language | core inheritance chain | ✅ |
-| 77 | `core_int_methods.obs` | Core Language | core int methods | ✅ |
-| 78 | `core_interfaces.obs` | Core Language | core interfaces | ✅ |
-| 79 | `core_json_escape.obs` | Core Language | core json escape | ✅ |
-| 80 | `core_method_overload.obs` | Core Language | core method overload | ✅ |
-| 81 | `core_multi_dim_array.obs` | Core Language | core multi dim array | ✅ |
-| 82 | `core_net_buffer.obs` | Core Language | Network Buffer Read Test Tests that TCP socket ReadBuffer correctly handles partial reads by veri... | ✅ |
-| 83 | `core_odbc.obs` | Core Language | Core ODBC Bindings Test Tests Date, Timestamp, and ColumnInfo classes without requiring a databas... | ✅ |
-| 84 | `core_opencv.obs` | Core Language | Core OpenCV Bindings Test Tests helper classes, constants, and VideoWriter FourCC without requiri... | ✅ |
-| 85 | `core_paren_method_chain.obs` | Core Language | Verifies a method call on a parenthesized method-call expression chains onto the parenthesized re... | ✅ |
-| 86 | `core_records.obs` | Core Language | Core Records Test Exercises record-generated constructors, accessors, mutators, generics, readonl... | ✅ |
-| 87 | `core_recursion.obs` | Core Language | Core Recursion Test Tests recursive function calls and tail recursion | ✅ |
-| 88 | `core_select_ops.obs` | Core Language | core select ops | ✅ |
-| 89 | `core_static_array_literals.obs` | Core Language | Regression test for the static-array literal pool (compiler bug, 2026-06): the bool literal-pool... | ✅ |
-| 90 | `core_static_fields.obs` | Core Language | core static fields | ✅ |
-| 91 | `core_string_format.obs` | Core Language | core string format | ✅ |
-| 92 | `core_string_interp_expr.obs` | Core Language | Verifies operator expressions inside "{$...}" string interpolation. | ✅ |
-| 93 | `core_string_interp_format.obs` | Core Language | Verifies inline format specifiers "{$expr:spec}" in string interpolation. | ✅ |
-| 94 | `core_string_methods.obs` | Core Language | core string methods | ✅ |
-| 95 | `core_strings_simple.obs` | Core Language | Core String Operations Test (Simplified) Tests basic string operations without complex method cha... | ✅ |
-| 96 | `core_thread_gc_stress.obs` | Concurrency/GC | Multithreaded GC stop-the-world stress test. Guards the GC bugs fixed on branch fix/gc-stop-the-w... | ✅ |
-| 97 | `core_type_checking.obs` | Core Language | core type checking | ✅ |
-| 98 | `dap_databreak_test.obs` | Debugger | Fixture for dap_databreak_test.py. Stops once with everything initialized, then mutates two local... | ✅ |
-| 99 | `dap_drilldown_test.obs` | Debugger | dap drilldown test | ✅ |
-| 100 | `dap_exception_test.obs` | Debugger (neg) | Triggers an uncaught runtime error (Nil dereference) so the DAP test suite can verify exception b... | ✅ |
-| 101 | `dap_frame_eval_test.obs` | Debugger | Fixture for frame-scoped DAP evaluation and hit-count breakpoints. The point of the nesting is th... | ✅ |
-| 102 | `dap_setvar_test.obs` | Debugger | Fixture for DAP setVariable through a drill-down handle. A local named 'count' and an object whos... | ✅ |
-| 103 | `date_arithmetic.obs` | Date/Time | date arithmetic | ✅ |
-| 104 | `date_basic_ops.obs` | Date/Time | date basic ops | ✅ |
-| 105 | `debugger_coll_test.obs` | Debugger | debugger coll test | ✅ |
-| 106 | `debugger_eval_test.obs` | Debugger | Fixture for the debugger's expression evaluator and breakpoint bookkeeping. Separate from debugge... | ✅ |
-| 107 | `debugger_test.obs` | Debugger | debugger test | ✅ |
-| 108 | `debugger_thread_test.obs` | Debugger | Fixture for debugging a program with several live threads. Each worker carries its own id and a l... | ✅ |
-| 109 | `diag_concurrent_analysis.obs` | Other | Concurrency guard for the diagnostics/LSP analysis path (#659). The LSP server spawns a worker th... | ✅ |
-| 110 | `fix524_array_cast_chain.obs` | Bug Fix | Fix #524: Cannot chain method calls on array-indexed elements after cast Tests that Get(index)->A... | ✅ |
-| 111 | `fix534_substring_crash.obs` | Bug Fix | Fix #534: String->SubString crash on negative or zero length argument Tests that negative or zero... | ✅ |
-| 112 | `fix_array_bounds.obs` | Bug Fix | fix array bounds | ✅ |
-| 113 | `fix_chained_calls.obs` | Bug Fix | fix chained calls | ✅ |
-| 114 | `fix_deep_recursion.obs` | Bug Fix | fix deep recursion | ✅ |
-| 115 | `fix_float_precision.obs` | Bug Fix | fix float precision | ✅ |
-| 116 | `fix_int_boundary.obs` | Bug Fix | fix int boundary | ✅ |
-| 117 | `fix_large_arrays.obs` | Bug Fix | fix large arrays | ✅ |
-| 118 | `fix_nested_generics.obs` | Bug Fix | fix nested generics | ✅ |
-| 119 | `fix_nil_chain_ops.obs` | Bug Fix | fix nil chain ops | ✅ |
-| 120 | `fix_polymorphic_calls.obs` | Bug Fix | fix polymorphic calls | ✅ |
-| 121 | `fix_scope_shadowing.obs` | Bug Fix | fix scope shadowing | ✅ |
-| 122 | `fix_string_concat.obs` | Bug Fix | fix string concat | ✅ |
-| 123 | `func_closure_field.obs` | Functional | func closure field | ✅ |
-| 124 | `func_filter_ops.obs` | Functional | func filter ops | ✅ |
-| 125 | `func_higher_order.obs` | Functional | func higher order | ✅ |
-| 126 | `func_reduce_ops.obs` | Functional | func reduce ops | ✅ |
-| 127 | `func_sort_custom.obs` | Functional | func sort custom | ✅ |
-| 128 | `gl_context_test.obs` | Other | Regression test for OpenGL 3.3 core support: proves a real context can be created AND that someth... | ✅ |
-| 129 | `gl_quaternion_test.obs` | Other | Game.OpenGL Quaternion -- arithmetic only, so it needs no window. Every other GL test in this sui... | ✅ |
-| 130 | `http_error_body.obs` | Other | HTTP error-response body test A client that reports a status code but no body for a server error... | ✅ |
-| 131 | `http_header_flatten_test.obs` | Other | Request-header flattening (Web.HTTP.HeaderCheck->Flatten). HTTP/2 and HTTP/3 hand the request to... | ✅ |
-| 132 | `http_header_validation_test.obs` | Other | Request-header validation (Web.HTTP.HeaderCheck). HttpClient->AddHeader was injectable: HTTP/1.1... | ✅ |
-| 133 | `http_persistence_test.obs` | Other | http persistence test | ✅ |
-| 134 | `https_persistence_test.obs` | Other | https persistence test | ✅ |
-| 135 | `indexed_call_result.obs` | Other | Subscripting the result of a method call: 'GetItems()[0]->Name()'. This was never implemented, an... | ✅ |
-| 136 | `inline_funcref_param.obs` | Other | A method that takes a func-ref parameter and is small enough for the compiler to inline: the inli... | ✅ |
-| 137 | `interp_float_fastpath.obs` | Other | reason: this test exercises the INTERPRETER's float fast path; compiled, it would test the JIT in... | ✅ |
-| 138 | `io_file_basic.obs` | I/O | io file basic | ✅ |
-| 139 | `jit_array_native.obs` | AMD64/JIT | jit array native | ✅ |
-| 140 | `jit_autojit_race.obs` | AMD64/JIT | Auto-JIT concurrency guard. Many threads call the same hot method, crossing the auto-JIT threshol... | ✅ |
-| 141 | `jit_branch_shapes.obs` | AMD64/JIT | Every branch shape the compiler emits for `&`, `\|` and `<>` in conditions, in loops that are JIT-... | ✅ |
-| 142 | `jit_bridge_exception.obs` | AMD64/JIT (neg) | A C++ exception thrown inside a call the JIT's bridge made ends the program with the VM's interna... | ✅ |
-| 143 | `jit_call_overhead.obs` | AMD64/JIT | F7 guard: a call from compiled code into compiled code must stay cheap. The calling convention (d... | ✅ |
-| 144 | `jit_closure_gc_fixup.obs` | AMD64/JIT | Regression for the generational-GC fixup of closure captures (bug B1). The GC mark phase descends... | ✅ |
-| 145 | `jit_concurrent_compile.obs` | AMD64/JIT | Concurrency guard for the JIT code-page allocator (PageManager::GetPage). Several threads JIT-com... | ✅ |
-| 146 | `jit_conditional_native.obs` | AMD64/JIT | jit conditional native | ✅ |
-| 147 | `jit_const_char_store.obs` | AMD64/JIT | ARM64 JIT: a constant character stored into a Char[] element was written with a full 8-byte store... | ✅ |
-| 148 | `jit_dispatch_native.obs` | AMD64/JIT | jit dispatch native | ✅ |
-| 149 | `jit_entry_compiled.obs` | AMD64/JIT | jit entry compiled | ✅ |
-| 150 | `jit_entry_shapes.obs` | AMD64/JIT | The entry and exit of a compiled method, in the shapes the ARM64 callee work touches (the AMD64 b... | ✅ |
-| 151 | `jit_float_compare_store.obs` | AMD64/JIT | A float comparison whose result is STORED must not clobber a live register. `cmov_reg`'s first ac... | ✅ |
-| 152 | `jit_float_equality.obs` | AMD64/JIT | Regression test for float equality compares on array elements (2026-06). The front-end chose EQL_... | ✅ |
-| 153 | `jit_float_intensive.obs` | AMD64/JIT | jit float intensive | ✅ |
-| 154 | `jit_float_mem_ops.obs` | AMD64/JIT | Float arithmetic and comparison against MEMORY operands, under the JIT. IMPORTANT: must run with... | ✅ |
-| 155 | `jit_float_round_trig.obs` | AMD64/JIT | Exercises two JIT float-codegen bugs that only surface once a method using them is auto-JIT'd (de... | ✅ |
-| 156 | `jit_frame_trap_test.obs` | AMD64/JIT | Regression test for the JIT frame-dependent trap crash (2026-06). Traps such as SERL_INT/SERL_FLO... | ✅ |
-| 157 | `jit_frame_unreferenced_local.obs` | AMD64/JIT | A compiled method declares a local that no instruction references, ahead of an object-array local... | ✅ |
-| 158 | `jit_func_ref_hot.obs` | AMD64/JIT | jit func ref hot | ✅ |
-| 159 | `jit_gc_safepoint.obs` | AMD64/JIT | jit gc safepoint | ✅ |
-| 160 | `jit_gc_stress.obs` | AMD64/JIT | JIT + GC interaction stress (2026-06). One CI run on linux-x64 failed with a JIT-to-JIT runtime e... | ✅ |
-| 161 | `jit_loop_native.obs` | AMD64/JIT | jit loop native | ✅ |
-| 162 | `jit_native_call_depth.obs` | AMD64/JIT (neg) | Recursion deeper than the call stack allows, through compiled-to-compiled native calls (the calli... | ✅ |
-| 163 | `jit_native_call_error.obs` | AMD64/JIT (neg) | A compiled callee, called straight from compiled code (the calling convention's phase 3), derefer... | ✅ |
-| 164 | `jit_native_cls_fields.obs` | AMD64/JIT | JIT Native Class Fields Test Tests object reference storage in class instance fields with GC pres... | ✅ |
-| 165 | `jit_native_float_array.obs` | AMD64/JIT | JIT Native Float Array Test Tests native function with float array creation and math operations R... | ✅ |
-| 166 | `jit_native_func_ref.obs` | AMD64/JIT | JIT Native Function Reference Test Tests native functions with function reference storage in clas... | ✅ |
-| 167 | `jit_native_inline.obs` | AMD64/JIT | jit native inline | ✅ |
-| 168 | `jit_native_math.obs` | AMD64/JIT | JIT Native Math Builtins Test Tests native math functions: Factorial, Sinh/Cosh/Tanh/Log2/Cbrt, P... | ✅ |
-| 169 | `jit_string_ops.obs` | AMD64/JIT | jit string ops | ✅ |
-| 170 | `jit_tco_bare_local.obs` | AMD64/JIT | Regression for the TCO deferred-local-load miscompile (both arches). A self-recursive tail call t... | ✅ |
-| 171 | `jit_virtual_equals.obs` | AMD64/JIT | Issue #722: on ARM64 the JIT miscompiled String->Equals inside a virtual request-handler callback... | ✅ |
-| 172 | `json_build_ops.obs` | JSON | json build ops | ✅ |
-| 173 | `json_escape_test.obs` | JSON | JsonElement must escape on serialization. Format's STRING branch appended the raw value between t... | ✅ |
-| 174 | `json_parse_ops.obs` | JSON | json parse ops | ✅ |
-| 175 | `lame_encode_test.obs` | Other | Audio.Lame->PcmToMp3 encodes PCM to MP3. EXTRA_LIBS: lame This library had no runtime test at all... | ✅ |
-| 176 | `lsp_features.obs` | LSP | lsp features | ✅ |
-| 177 | `math_float_ops.obs` | Math | math float ops | ✅ |
-| 178 | `math_log_exp.obs` | Math | math log exp | ✅ |
-| 179 | `math_random_ops.obs` | Math | math random ops | ✅ |
-| 180 | `math_rounding.obs` | Math | math rounding | ✅ |
-| 181 | `math_sqrt_ops.obs` | Math | math sqrt ops | ✅ |
-| 182 | `math_trig_funcs.obs` | Math | math trig funcs | ✅ |
-| 183 | `mcp_debug_test.obs` | MCP Server | DEBUG VERSION of mcp_server_test.obs Identical to programs/regression/mcp_server_test.obs except:... | ✅ |
-| 184 | `mcp_server_test.obs` | MCP Server | mcp server test | ✅ |
-| 185 | `minor_gc_stress.obs` | Other | Regression for generational MINOR GC: old objects holding young references. 'keep' is an object a... | ✅ |
-| 186 | `ml_adaboost_test.obs` | System.ML | Regression tests for System.ML AdaBoost (overhaul phase 3): boosting over boolean decision stumps... | ✅ |
-| 187 | `ml_api_test.obs` | System.ML | Regression tests for the System.ML estimator API consistency sweep (item 11): RandomForest Fit (r... | ✅ |
-| 188 | `ml_dbscan_test.obs` | System.ML | Regression tests for System.ML DBSCAN (overhaul phase 3): two dense blobs plus far-away outliers... | ✅ |
-| 189 | `ml_gbt_test.obs` | System.ML | Regression tests for System.ML gradient boosting (overhaul phase 3 leftover): a RegressionTree le... | ✅ |
-| 190 | `ml_gmm_test.obs` | System.ML | Regression tests for System.ML GaussianMixture (overhaul phase 3): EM on two well-separated blobs... | ✅ |
-| 191 | `ml_kdtree_test.obs` | System.ML | Regression tests for System.ML KDTree (overhaul phase 3): for several queries and k values over a... | ✅ |
-| 192 | `ml_library_test.obs` | System.ML | ml library test | ✅ |
-| 193 | `ml_linearclf_test.obs` | System.ML | Regression tests for the System.ML linear classifiers (overhaul phase 2): Perceptron (mistake-dri... | ✅ |
-| 194 | `ml_nn_test.obs` | System.ML | Regression tests for the System.ML NeuralNetwork with hidden/output bias vectors (ML overhaul ite... | ✅ |
-| 195 | `ml_pca_gnb_test.obs` | System.ML | Regression tests for System.ML PCA (power-iteration decomposition: dominant diagonal direction re... | ✅ |
-| 196 | `ml_phase1_test.obs` | System.ML | Regression tests for the System.ML correctness fixes (phase 1): seedable PRNG, DotSigmoid dimensi... | ✅ |
-| 197 | `ml_regularized_test.obs` | System.ML | Regression tests for the System.ML regularized linear models (overhaul phase 2): RidgeRegression... | ✅ |
-| 198 | `ml_trees_test.obs` | System.ML | Regression tests for the System.ML tree models: the real recursive DecisionTree (left/right child... | ✅ |
-| 199 | `native_gc_barrier_test.obs` | Other | A value returned by a native library must survive a collection. A C++ shared library returns a va... | ✅ |
-| 200 | `native_gc_leak_test.obs` | Other | Objects a native library returns must be RECLAIMED, not merely reachable. native_gc_barrier_test.... | ✅ |
-| 201 | `net_resolve_failure.obs` | Other | TCPSocket->Resolve failure-path test Resolve() freed its addrinfo result on the FAILURE path, whe... | ✅ |
-| 202 | `nil_safe_ops.obs` | Core Language | Nil-safe operators: '??' (nil-coalesce) and '?->' (nil-safe call). Both desugar onto existing int... | ✅ |
-| 203 | `oauth_test.obs` | Networking | oauth test | ✅ |
-| 204 | `odbc_sqlite_test.obs` | ODBC | ODBC SQLite Integration Test Tests live database operations against an in-memory SQLite database.... | ✅ |
-| 205 | `ollama_parse_test.obs` | Other | Completion->ParseGenerateResponse: the response handling behind every Completion->Generate overlo... | ✅ |
-| 206 | `onnx_runtime_test.obs` | Other | API.Onnx.OnnxRuntime->GetProviders() reaches the native ONNX Runtime. EXTRA_LIBS: onnx,opencv,cip... | ✅ |
-| 207 | `primitive_receiver_order.obs` | Other | Argument order for instance-style calls on primitives. Writing `v->Pow(10)` on a primitive does n... | ✅ |
-| 208 | `regex_bench.obs` | Regex | regex bench | ✅ |
-| 209 | `regex_dfa_test.obs` | Regex | regex dfa test | ✅ |
-| 210 | `runtime_feature_test.obs` | Other | Regression tests for the "runtime.feature.*" properties, which report which optional protocol eng... | ✅ |
-| 211 | `runtime_gc_stats.obs` | Other | The runtime.* GC statistics must stay inside their own stated ranges. runtime.gc.nursery.occupanc... | ✅ |
-| 212 | `select_dispatch_test.obs` | Control Flow | Single-case, linear (2-5 cases), jump-table (dense >=6), and binary-tree (sparse) paths | ✅ |
-| 213 | `socket_graceful_close_test.obs` | Other | TCPSocket->CloseGracefully() must not lose the data it just wrote (#669). The shape this guards i... | ✅ |
-| 214 | `string_concat_nesting.obs` | Strings | Nested string concatenation. The compiler lowers a concatenation to "allocate a System.String, st... | ✅ |
-| 215 | `string_find_ops.obs` | Strings | string find ops | ✅ |
-| 216 | `string_format_ops.obs` | Strings | Verifies String->Format() positional substitution. | ✅ |
-| 217 | `string_interp_concat.obs` | Strings | An interpolated string as the LEFT operand of a concatenation. "{$a}" + "{$b}" printed AAB. The c... | ✅ |
-| 218 | `string_number_conv.obs` | Strings | string number conv | ✅ |
-| 219 | `string_replace_ops.obs` | Strings | string replace ops | ✅ |
-| 220 | `string_split_ops.obs` | Strings | string split ops | ✅ |
-| 221 | `task_scope.obs` | Other | Regression for a structured-concurrency nursery (TaskScope) built purely on the existing System.C... | ✅ |
-| 222 | `tco_receiver.obs` | Other | Tail-call optimization must respect the receiver. TCO used to fire on matching class-id and metho... | ✅ |
-| 223 | `thread_accept_exit_test.obs` | Other | A thread parked in accept() must not take the VM down when Main returns (#681). The shape: one th... | ✅ |
-| 224 | `tls_verify_test.obs` | Other | TLS certificate verification must REFUSE. https_persistence_test proves the happy path (a pinned... | ✅ |
-| 225 | `trap_array_barrier_test.obs` | Other | A String[] returned by a VM trap must survive a collection. Every trap that returns an array of o... | ✅ |
-| 226 | `trap_array_mt_barrier_test.obs` | Other | A trap-returned array must survive ANOTHER THREAD's allocation. trap_array_barrier_test.obs cover... | ✅ |
-| 227 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
-| 228 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
-| 229 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
-| 230 | `vm_error_exit.obs` | Other (neg) | A program that dies inside the VM must leave obr with a non-zero exit status. Execute (core/vm/vm... | ✅ |
-| 231 | `vm_jit_equiv.obs` | Other | The interpreter and the JIT must agree. This program is run twice by run_vm_flag_tests.py -- once... | ✅ |
-| 232 | `vm_lib_path_native.obs` | Other | Fixture for run_vm_flag_tests.py: --lib-path must reach the VM's native-library loader. SHA256 is... | ✅ |
-| 233 | `vm_locale_wide.obs` | Other | Fixture for run_vm_flag_tests.py: obr must run, and write wide characters as UTF-8, under a local... | ✅ |
-| 234 | `vm_set_locale_refused.obs` | Other | Runtime->SetLocale with a name the system cannot supply. The VM switched the C library's locale a... | ✅ |
-| 235 | `vm_set_property_first.obs` | Other | A program whose first property access is a set still gets the runtime's own properties. The runti... | ✅ |
-| 236 | `vm_set_property_overwrite.obs` | Other | A runtime property set twice reads back the second value. StackProgram::SetProperty stored with s... | ✅ |
-| 237 | `vm_write_char_buffer.obs` | Other | Console->WriteBuffer(Char[]) wrote the buffer twice-encoded, and ignored num. The trap (STD_OUT_C... | ✅ |
-| 238 | `web_server_test.obs` | Other | Web.Server end-to-end coverage. Every method on Web.Server.Request and Response used to call a na... | ✅ |
-| 239 | `websocket_test.obs` | Networking | websocket test | ✅ |
-| 240 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
-| 241 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
-| 242 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
+| 68 | `core_do_while_post_op.obs` | Core Language | A post-operation in a `do`/`while` condition must run once per iteration. EmitDoWhile chose betwe... | ✅ |
+| 69 | `core_each_loop.obs` | Core Language | core each loop | ✅ |
+| 70 | `core_enum.obs` | Core Language | core enum | ✅ |
+| 71 | `core_function_refs.obs` | Core Language | core function refs | ✅ |
+| 72 | `core_generic_compound_bounds.obs` | Generics | Compound generic bounds (T : A & B): a concrete type argument must satisfy ALL bounds. Person imp... | ✅ |
+| 73 | `core_generic_fbound.obs` | Generics | F-bounded type-parameter constraint (T : Compare<T>): the bound may be generic and self-referenti... | ✅ |
+| 74 | `core_generic_structural.obs` | Generics | Exercises the structural generic type comparison: deeply nested generic type arguments must round... | ✅ |
+| 75 | `core_generic_variance.obs` | Generics | Declaration-site variance: 'out T' (covariant) lets Producer<Dog> be used where Producer<Animal>... | ✅ |
+| 76 | `core_http_server.obs` | Core Language | HTTP Client/Server Loopback Test Tests HTTP GET and POST using raw TCP server + HttpClient. Verif... | ✅ |
+| 77 | `core_inheritance_chain.obs` | Core Language | core inheritance chain | ✅ |
+| 78 | `core_int_methods.obs` | Core Language | core int methods | ✅ |
+| 79 | `core_interfaces.obs` | Core Language | core interfaces | ✅ |
+| 80 | `core_json_escape.obs` | Core Language | core json escape | ✅ |
+| 81 | `core_method_overload.obs` | Core Language | core method overload | ✅ |
+| 82 | `core_multi_dim_array.obs` | Core Language | core multi dim array | ✅ |
+| 83 | `core_net_buffer.obs` | Core Language | Network Buffer Read Test Tests that TCP socket ReadBuffer correctly handles partial reads by veri... | ✅ |
+| 84 | `core_odbc.obs` | Core Language | Core ODBC Bindings Test Tests Date, Timestamp, and ColumnInfo classes without requiring a databas... | ✅ |
+| 85 | `core_opencv.obs` | Core Language | Core OpenCV Bindings Test Tests helper classes, constants, and VideoWriter FourCC without requiri... | ✅ |
+| 86 | `core_paren_method_chain.obs` | Core Language | Verifies a method call on a parenthesized method-call expression chains onto the parenthesized re... | ✅ |
+| 87 | `core_records.obs` | Core Language | Core Records Test Exercises record-generated constructors, accessors, mutators, generics, readonl... | ✅ |
+| 88 | `core_recursion.obs` | Core Language | Core Recursion Test Tests recursive function calls and tail recursion | ✅ |
+| 89 | `core_select_ops.obs` | Core Language | core select ops | ✅ |
+| 90 | `core_static_array_literals.obs` | Core Language | Regression test for the static-array literal pool (compiler bug, 2026-06): the bool literal-pool... | ✅ |
+| 91 | `core_static_fields.obs` | Core Language | core static fields | ✅ |
+| 92 | `core_string_format.obs` | Core Language | core string format | ✅ |
+| 93 | `core_string_interp_expr.obs` | Core Language | Verifies operator expressions inside "{$...}" string interpolation. | ✅ |
+| 94 | `core_string_interp_format.obs` | Core Language | Verifies inline format specifiers "{$expr:spec}" in string interpolation. | ✅ |
+| 95 | `core_string_methods.obs` | Core Language | core string methods | ✅ |
+| 96 | `core_strings_simple.obs` | Core Language | Core String Operations Test (Simplified) Tests basic string operations without complex method cha... | ✅ |
+| 97 | `core_thread_gc_stress.obs` | Concurrency/GC | Multithreaded GC stop-the-world stress test. Guards the GC bugs fixed on branch fix/gc-stop-the-w... | ✅ |
+| 98 | `core_type_checking.obs` | Core Language | core type checking | ✅ |
+| 99 | `dap_databreak_test.obs` | Debugger | Fixture for dap_databreak_test.py. Stops once with everything initialized, then mutates two local... | ✅ |
+| 100 | `dap_drilldown_test.obs` | Debugger | dap drilldown test | ✅ |
+| 101 | `dap_exception_test.obs` | Debugger (neg) | Triggers an uncaught runtime error (Nil dereference) so the DAP test suite can verify exception b... | ✅ |
+| 102 | `dap_frame_eval_test.obs` | Debugger | Fixture for frame-scoped DAP evaluation and hit-count breakpoints. The point of the nesting is th... | ✅ |
+| 103 | `dap_setvar_test.obs` | Debugger | Fixture for DAP setVariable through a drill-down handle. A local named 'count' and an object whos... | ✅ |
+| 104 | `date_arithmetic.obs` | Date/Time | date arithmetic | ✅ |
+| 105 | `date_basic_ops.obs` | Date/Time | date basic ops | ✅ |
+| 106 | `debugger_coll_test.obs` | Debugger | debugger coll test | ✅ |
+| 107 | `debugger_eval_test.obs` | Debugger | Fixture for the debugger's expression evaluator and breakpoint bookkeeping. Separate from debugge... | ✅ |
+| 108 | `debugger_test.obs` | Debugger | debugger test | ✅ |
+| 109 | `debugger_thread_test.obs` | Debugger | Fixture for debugging a program with several live threads. Each worker carries its own id and a l... | ✅ |
+| 110 | `diag_concurrent_analysis.obs` | Other | Concurrency guard for the diagnostics/LSP analysis path (#659). The LSP server spawns a worker th... | ✅ |
+| 111 | `fix524_array_cast_chain.obs` | Bug Fix | Fix #524: Cannot chain method calls on array-indexed elements after cast Tests that Get(index)->A... | ✅ |
+| 112 | `fix534_substring_crash.obs` | Bug Fix | Fix #534: String->SubString crash on negative or zero length argument Tests that negative or zero... | ✅ |
+| 113 | `fix_array_bounds.obs` | Bug Fix | fix array bounds | ✅ |
+| 114 | `fix_chained_calls.obs` | Bug Fix | fix chained calls | ✅ |
+| 115 | `fix_deep_recursion.obs` | Bug Fix | fix deep recursion | ✅ |
+| 116 | `fix_float_precision.obs` | Bug Fix | fix float precision | ✅ |
+| 117 | `fix_int_boundary.obs` | Bug Fix | fix int boundary | ✅ |
+| 118 | `fix_large_arrays.obs` | Bug Fix | fix large arrays | ✅ |
+| 119 | `fix_nested_generics.obs` | Bug Fix | fix nested generics | ✅ |
+| 120 | `fix_nil_chain_ops.obs` | Bug Fix | fix nil chain ops | ✅ |
+| 121 | `fix_polymorphic_calls.obs` | Bug Fix | fix polymorphic calls | ✅ |
+| 122 | `fix_scope_shadowing.obs` | Bug Fix | fix scope shadowing | ✅ |
+| 123 | `fix_string_concat.obs` | Bug Fix | fix string concat | ✅ |
+| 124 | `func_closure_field.obs` | Functional | func closure field | ✅ |
+| 125 | `func_filter_ops.obs` | Functional | func filter ops | ✅ |
+| 126 | `func_higher_order.obs` | Functional | func higher order | ✅ |
+| 127 | `func_reduce_ops.obs` | Functional | func reduce ops | ✅ |
+| 128 | `func_sort_custom.obs` | Functional | func sort custom | ✅ |
+| 129 | `gl_context_test.obs` | Other | Regression test for OpenGL 3.3 core support: proves a real context can be created AND that someth... | ✅ |
+| 130 | `gl_quaternion_test.obs` | Other | Game.OpenGL Quaternion -- arithmetic only, so it needs no window. Every other GL test in this sui... | ✅ |
+| 131 | `http_error_body.obs` | Other | HTTP error-response body test A client that reports a status code but no body for a server error... | ✅ |
+| 132 | `http_header_flatten_test.obs` | Other | Request-header flattening (Web.HTTP.HeaderCheck->Flatten). HTTP/2 and HTTP/3 hand the request to... | ✅ |
+| 133 | `http_header_validation_test.obs` | Other | Request-header validation (Web.HTTP.HeaderCheck). HttpClient->AddHeader was injectable: HTTP/1.1... | ✅ |
+| 134 | `http_persistence_test.obs` | Other | http persistence test | ✅ |
+| 135 | `https_persistence_test.obs` | Other | https persistence test | ✅ |
+| 136 | `indexed_call_result.obs` | Other | Subscripting the result of a method call: 'GetItems()[0]->Name()'. This was never implemented, an... | ✅ |
+| 137 | `inline_funcref_param.obs` | Other | A method that takes a func-ref parameter and is small enough for the compiler to inline: the inli... | ✅ |
+| 138 | `interp_float_fastpath.obs` | Other | reason: this test exercises the INTERPRETER's float fast path; compiled, it would test the JIT in... | ✅ |
+| 139 | `io_file_basic.obs` | I/O | io file basic | ✅ |
+| 140 | `jit_array_native.obs` | AMD64/JIT | jit array native | ✅ |
+| 141 | `jit_autojit_race.obs` | AMD64/JIT | Auto-JIT concurrency guard. Many threads call the same hot method, crossing the auto-JIT threshol... | ✅ |
+| 142 | `jit_branch_shapes.obs` | AMD64/JIT | Every branch shape the compiler emits for `&`, `\|` and `<>` in conditions, in loops that are JIT-... | ✅ |
+| 143 | `jit_bridge_exception.obs` | AMD64/JIT (neg) | A C++ exception thrown inside a call the JIT's bridge made ends the program with the VM's interna... | ✅ |
+| 144 | `jit_call_overhead.obs` | AMD64/JIT | F7 guard: a call from compiled code into compiled code must stay cheap. The calling convention (d... | ✅ |
+| 145 | `jit_closure_gc_fixup.obs` | AMD64/JIT | Regression for the generational-GC fixup of closure captures (bug B1). The GC mark phase descends... | ✅ |
+| 146 | `jit_concurrent_compile.obs` | AMD64/JIT | Concurrency guard for the JIT code-page allocator (PageManager::GetPage). Several threads JIT-com... | ✅ |
+| 147 | `jit_conditional_native.obs` | AMD64/JIT | jit conditional native | ✅ |
+| 148 | `jit_const_char_store.obs` | AMD64/JIT | ARM64 JIT: a constant character stored into a Char[] element was written with a full 8-byte store... | ✅ |
+| 149 | `jit_dispatch_native.obs` | AMD64/JIT | jit dispatch native | ✅ |
+| 150 | `jit_entry_compiled.obs` | AMD64/JIT | jit entry compiled | ✅ |
+| 151 | `jit_entry_shapes.obs` | AMD64/JIT | The entry and exit of a compiled method, in the shapes the ARM64 callee work touches (the AMD64 b... | ✅ |
+| 152 | `jit_float_compare_store.obs` | AMD64/JIT | A float comparison whose result is STORED must not clobber a live register. `cmov_reg`'s first ac... | ✅ |
+| 153 | `jit_float_equality.obs` | AMD64/JIT | Regression test for float equality compares on array elements (2026-06). The front-end chose EQL_... | ✅ |
+| 154 | `jit_float_intensive.obs` | AMD64/JIT | jit float intensive | ✅ |
+| 155 | `jit_float_mem_ops.obs` | AMD64/JIT | Float arithmetic and comparison against MEMORY operands, under the JIT. IMPORTANT: must run with... | ✅ |
+| 156 | `jit_float_round_trig.obs` | AMD64/JIT | Exercises two JIT float-codegen bugs that only surface once a method using them is auto-JIT'd (de... | ✅ |
+| 157 | `jit_frame_trap_test.obs` | AMD64/JIT | Regression test for the JIT frame-dependent trap crash (2026-06). Traps such as SERL_INT/SERL_FLO... | ✅ |
+| 158 | `jit_frame_unreferenced_local.obs` | AMD64/JIT | A compiled method declares a local that no instruction references, ahead of an object-array local... | ✅ |
+| 159 | `jit_func_ref_hot.obs` | AMD64/JIT | jit func ref hot | ✅ |
+| 160 | `jit_gc_safepoint.obs` | AMD64/JIT | jit gc safepoint | ✅ |
+| 161 | `jit_gc_stress.obs` | AMD64/JIT | JIT + GC interaction stress (2026-06). One CI run on linux-x64 failed with a JIT-to-JIT runtime e... | ✅ |
+| 162 | `jit_loop_native.obs` | AMD64/JIT | jit loop native | ✅ |
+| 163 | `jit_native_call_depth.obs` | AMD64/JIT (neg) | Recursion deeper than the call stack allows, through compiled-to-compiled native calls (the calli... | ✅ |
+| 164 | `jit_native_call_error.obs` | AMD64/JIT (neg) | A compiled callee, called straight from compiled code (the calling convention's phase 3), derefer... | ✅ |
+| 165 | `jit_native_cls_fields.obs` | AMD64/JIT | JIT Native Class Fields Test Tests object reference storage in class instance fields with GC pres... | ✅ |
+| 166 | `jit_native_float_array.obs` | AMD64/JIT | JIT Native Float Array Test Tests native function with float array creation and math operations R... | ✅ |
+| 167 | `jit_native_func_ref.obs` | AMD64/JIT | JIT Native Function Reference Test Tests native functions with function reference storage in clas... | ✅ |
+| 168 | `jit_native_inline.obs` | AMD64/JIT | jit native inline | ✅ |
+| 169 | `jit_native_math.obs` | AMD64/JIT | JIT Native Math Builtins Test Tests native math functions: Factorial, Sinh/Cosh/Tanh/Log2/Cbrt, P... | ✅ |
+| 170 | `jit_string_ops.obs` | AMD64/JIT | jit string ops | ✅ |
+| 171 | `jit_tco_bare_local.obs` | AMD64/JIT | Regression for the TCO deferred-local-load miscompile (both arches). A self-recursive tail call t... | ✅ |
+| 172 | `jit_virtual_equals.obs` | AMD64/JIT | Issue #722: on ARM64 the JIT miscompiled String->Equals inside a virtual request-handler callback... | ✅ |
+| 173 | `json_build_ops.obs` | JSON | json build ops | ✅ |
+| 174 | `json_escape_test.obs` | JSON | JsonElement must escape on serialization. Format's STRING branch appended the raw value between t... | ✅ |
+| 175 | `json_parse_ops.obs` | JSON | json parse ops | ✅ |
+| 176 | `lame_encode_test.obs` | Other | Audio.Lame->PcmToMp3 encodes PCM to MP3. EXTRA_LIBS: lame This library had no runtime test at all... | ✅ |
+| 177 | `lsp_features.obs` | LSP | lsp features | ✅ |
+| 178 | `math_float_ops.obs` | Math | math float ops | ✅ |
+| 179 | `math_log_exp.obs` | Math | math log exp | ✅ |
+| 180 | `math_random_ops.obs` | Math | math random ops | ✅ |
+| 181 | `math_rounding.obs` | Math | math rounding | ✅ |
+| 182 | `math_sqrt_ops.obs` | Math | math sqrt ops | ✅ |
+| 183 | `math_trig_funcs.obs` | Math | math trig funcs | ✅ |
+| 184 | `mcp_debug_test.obs` | MCP Server | DEBUG VERSION of mcp_server_test.obs Identical to programs/regression/mcp_server_test.obs except:... | ✅ |
+| 185 | `mcp_server_test.obs` | MCP Server | mcp server test | ✅ |
+| 186 | `minor_gc_stress.obs` | Other | Regression for generational MINOR GC: old objects holding young references. 'keep' is an object a... | ✅ |
+| 187 | `ml_adaboost_test.obs` | System.ML | Regression tests for System.ML AdaBoost (overhaul phase 3): boosting over boolean decision stumps... | ✅ |
+| 188 | `ml_api_test.obs` | System.ML | Regression tests for the System.ML estimator API consistency sweep (item 11): RandomForest Fit (r... | ✅ |
+| 189 | `ml_dbscan_test.obs` | System.ML | Regression tests for System.ML DBSCAN (overhaul phase 3): two dense blobs plus far-away outliers... | ✅ |
+| 190 | `ml_gbt_test.obs` | System.ML | Regression tests for System.ML gradient boosting (overhaul phase 3 leftover): a RegressionTree le... | ✅ |
+| 191 | `ml_gmm_test.obs` | System.ML | Regression tests for System.ML GaussianMixture (overhaul phase 3): EM on two well-separated blobs... | ✅ |
+| 192 | `ml_kdtree_test.obs` | System.ML | Regression tests for System.ML KDTree (overhaul phase 3): for several queries and k values over a... | ✅ |
+| 193 | `ml_library_test.obs` | System.ML | ml library test | ✅ |
+| 194 | `ml_linearclf_test.obs` | System.ML | Regression tests for the System.ML linear classifiers (overhaul phase 2): Perceptron (mistake-dri... | ✅ |
+| 195 | `ml_nn_test.obs` | System.ML | Regression tests for the System.ML NeuralNetwork with hidden/output bias vectors (ML overhaul ite... | ✅ |
+| 196 | `ml_pca_gnb_test.obs` | System.ML | Regression tests for System.ML PCA (power-iteration decomposition: dominant diagonal direction re... | ✅ |
+| 197 | `ml_phase1_test.obs` | System.ML | Regression tests for the System.ML correctness fixes (phase 1): seedable PRNG, DotSigmoid dimensi... | ✅ |
+| 198 | `ml_regularized_test.obs` | System.ML | Regression tests for the System.ML regularized linear models (overhaul phase 2): RidgeRegression... | ✅ |
+| 199 | `ml_trees_test.obs` | System.ML | Regression tests for the System.ML tree models: the real recursive DecisionTree (left/right child... | ✅ |
+| 200 | `native_gc_barrier_test.obs` | Other | A value returned by a native library must survive a collection. A C++ shared library returns a va... | ✅ |
+| 201 | `native_gc_leak_test.obs` | Other | Objects a native library returns must be RECLAIMED, not merely reachable. native_gc_barrier_test.... | ✅ |
+| 202 | `net_resolve_failure.obs` | Other | TCPSocket->Resolve failure-path test Resolve() freed its addrinfo result on the FAILURE path, whe... | ✅ |
+| 203 | `nil_safe_ops.obs` | Core Language | Nil-safe operators: '??' (nil-coalesce) and '?->' (nil-safe call). Both desugar onto existing int... | ✅ |
+| 204 | `oauth_test.obs` | Networking | oauth test | ✅ |
+| 205 | `odbc_sqlite_test.obs` | ODBC | ODBC SQLite Integration Test Tests live database operations against an in-memory SQLite database.... | ✅ |
+| 206 | `ollama_parse_test.obs` | Other | Completion->ParseGenerateResponse: the response handling behind every Completion->Generate overlo... | ✅ |
+| 207 | `onnx_runtime_test.obs` | Other | API.Onnx.OnnxRuntime->GetProviders() reaches the native ONNX Runtime. EXTRA_LIBS: onnx,opencv,cip... | ✅ |
+| 208 | `primitive_receiver_order.obs` | Other | Argument order for instance-style calls on primitives. Writing `v->Pow(10)` on a primitive does n... | ✅ |
+| 209 | `regex_bench.obs` | Regex | regex bench | ✅ |
+| 210 | `regex_dfa_test.obs` | Regex | regex dfa test | ✅ |
+| 211 | `runtime_feature_test.obs` | Other | Regression tests for the "runtime.feature.*" properties, which report which optional protocol eng... | ✅ |
+| 212 | `runtime_gc_stats.obs` | Other | The runtime.* GC statistics must stay inside their own stated ranges. runtime.gc.nursery.occupanc... | ✅ |
+| 213 | `select_dispatch_test.obs` | Control Flow | Single-case, linear (2-5 cases), jump-table (dense >=6), and binary-tree (sparse) paths | ✅ |
+| 214 | `socket_graceful_close_test.obs` | Other | TCPSocket->CloseGracefully() must not lose the data it just wrote (#669). The shape this guards i... | ✅ |
+| 215 | `string_concat_nesting.obs` | Strings | Nested string concatenation. The compiler lowers a concatenation to "allocate a System.String, st... | ✅ |
+| 216 | `string_find_ops.obs` | Strings | string find ops | ✅ |
+| 217 | `string_format_ops.obs` | Strings | Verifies String->Format() positional substitution. | ✅ |
+| 218 | `string_interp_concat.obs` | Strings | An interpolated string as the LEFT operand of a concatenation. "{$a}" + "{$b}" printed AAB. The c... | ✅ |
+| 219 | `string_number_conv.obs` | Strings | string number conv | ✅ |
+| 220 | `string_replace_ops.obs` | Strings | string replace ops | ✅ |
+| 221 | `string_split_ops.obs` | Strings | string split ops | ✅ |
+| 222 | `task_scope.obs` | Other | Regression for a structured-concurrency nursery (TaskScope) built purely on the existing System.C... | ✅ |
+| 223 | `tco_receiver.obs` | Other | Tail-call optimization must respect the receiver. TCO used to fire on matching class-id and metho... | ✅ |
+| 224 | `thread_accept_exit_test.obs` | Other | A thread parked in accept() must not take the VM down when Main returns (#681). The shape: one th... | ✅ |
+| 225 | `tls_verify_test.obs` | Other | TLS certificate verification must REFUSE. https_persistence_test proves the happy path (a pinned... | ✅ |
+| 226 | `trap_array_barrier_test.obs` | Other | A String[] returned by a VM trap must survive a collection. Every trap that returns an array of o... | ✅ |
+| 227 | `trap_array_mt_barrier_test.obs` | Other | A trap-returned array must survive ANOTHER THREAD's allocation. trap_array_barrier_test.obs cover... | ✅ |
+| 228 | `try_otherwise.obs` | Exceptions | Try/Otherwise Error Handling Test Tests the Try() and Otherwise() intrinsic methods for error han... | ✅ |
+| 229 | `unsigned_literals.obs` | Other | Unsigned integer literals: the 'u'/'U' suffix, and hex/binary read as bit patterns. The suffix ch... | ✅ |
+| 230 | `unsigned_ops.obs` | Other | The '>>>' operator and the unsigned helpers on Int. Objeck stores every integer in a signed 64-bi... | ✅ |
+| 231 | `vm_error_exit.obs` | Other (neg) | A program that dies inside the VM must leave obr with a non-zero exit status. Execute (core/vm/vm... | ✅ |
+| 232 | `vm_jit_equiv.obs` | Other | The interpreter and the JIT must agree. This program is run twice by run_vm_flag_tests.py -- once... | ✅ |
+| 233 | `vm_lib_path_native.obs` | Other | Fixture for run_vm_flag_tests.py: --lib-path must reach the VM's native-library loader. SHA256 is... | ✅ |
+| 234 | `vm_locale_wide.obs` | Other | Fixture for run_vm_flag_tests.py: obr must run, and write wide characters as UTF-8, under a local... | ✅ |
+| 235 | `vm_set_locale_refused.obs` | Other | Runtime->SetLocale with a name the system cannot supply. The VM switched the C library's locale a... | ✅ |
+| 236 | `vm_set_property_first.obs` | Other | A program whose first property access is a set still gets the runtime's own properties. The runti... | ✅ |
+| 237 | `vm_set_property_overwrite.obs` | Other | A runtime property set twice reads back the second value. StackProgram::SetProperty stored with s... | ✅ |
+| 238 | `vm_write_char_buffer.obs` | Other | Console->WriteBuffer(Char[]) wrote the buffer twice-encoded, and ignored num. The trap (STD_OUT_C... | ✅ |
+| 239 | `web_server_test.obs` | Other | Web.Server end-to-end coverage. Every method on Web.Server.Request and Response used to call a na... | ✅ |
+| 240 | `websocket_test.obs` | Networking | websocket test | ✅ |
+| 241 | `xml_build_ops.obs` | XML | xml build ops | ✅ |
+| 242 | `xml_encoding_ops.obs` | XML | Unit tests for the 2026-06 Data.XML improvements: truncated/garbage input is rejected (previously... | ✅ |
+| 243 | `xml_parse_ops.obs` | XML | xml parse ops | ✅ |
 
 ## Debugger Tests (`run_debugger_tests.sh`)
 

--- a/programs/regression/core_do_while_post_op.obs
+++ b/programs/regression/core_do_while_post_op.obs
@@ -1,0 +1,69 @@
+#~
+# A post-operation in a `do`/`while` condition must run once per iteration.
+#
+# EmitDoWhile chose between EmitBranch's fused test-and-jump and a non-branching
+# form, on `post_statements.empty()`. That queue is filled while the CONDITION is
+# emitted, so at the point of the test it was always empty and the fused path was
+# always taken. The post statement was then queued and emitted by the enclosing
+# scope AFTER the loop's break label -- outside the loop. The bytecode read:
+#
+#     10  GTR_INT
+#     11  JMP index=4, conditional=true     <- back-edge
+#     12  LBL                               <- break label
+#     13..16  n = n - 1                     <- the decrement, OUTSIDE the loop
+#
+# So `n` never changed between iterations and `do { } while(n-- > 0)` never
+# terminated. It shipped in v2026.9.1; v2026.9.0 is correct. Found through
+# programs/web-playground/demos/math/primes.obs, whose Show() uses this shape
+# and which produced 29 MB of one repeated line before it was noticed.
+#
+# Every loop here is bounded by an iteration cap, because the failure mode is a
+# HANG -- an unbounded fixture would take the suite down with it rather than
+# reporting. Exits 1 on a mismatch.
+~#
+
+class DoWhilePostOp {
+  function : Main(args : String[]) ~ Nil {
+    bad := 0;
+
+    # post-decrement with '>'
+    a := 3; i := 0;
+    do { i += 1; if(i > 20) { break; }; } while(a-- > 0);
+    if(a <> -1 | i <> 4) {
+      "FAIL: do/while(a-- > 0) left a={$a} after {$i} iteration(s), expected a=-1 after 4"->PrintLine();
+      bad += 1;
+    };
+
+    # post-decrement with '<>' -- the shape primes.obs uses
+    b := 2; j := 0;
+    do { j += 1; if(j > 20) { break; }; } while(b-- <> 0);
+    if(b <> -1 | j <> 3) {
+      "FAIL: do/while(b-- <> 0) left b={$b} after {$j} iteration(s), expected b=-1 after 3"->PrintLine();
+      bad += 1;
+    };
+
+    # post-increment, the same path
+    c := 0; k := 0;
+    do { k += 1; if(k > 20) { break; }; } while(c++ < 3);
+    if(c <> 4 | k <> 4) {
+      "FAIL: do/while(c++ < 3) left c={$c} after {$k} iteration(s), expected c=4 after 4"->PrintLine();
+      bad += 1;
+    };
+
+    # a plain `while` drains the queue after the body and was never affected;
+    # pinned here so a future change to EmitWhile cannot pass unnoticed
+    d := 3; m := 0;
+    while(d-- > 0) { m += 1; if(m > 20) { break; }; };
+    if(m <> 3) {
+      "FAIL: while(d-- > 0) ran {$m} iteration(s), expected 3"->PrintLine();
+      bad += 1;
+    };
+
+    if(bad > 0) {
+      "FAIL: {$bad} check(s)"->PrintLine();
+      Runtime->Exit(1);
+    };
+
+    "PASS: post-operations in do/while conditions run once per iteration"->PrintLine();
+  }
+}


### PR DESCRIPTION
## The bug

**`do { ... } while(n-- > 0)` never terminates.** v2026.9.0 is correct, so this shipped in v2026.9.1 and would have gone out in the tag.

`EmitDoWhile` chose between `EmitBranch`'s fused test-and-jump and a non-branching form based on `post_statements.empty()`. But that queue is filled **while the condition is emitted** — so at the point of the test it is always empty. The fast path was always taken, the post statement was queued by `EmitBranch`, and the enclosing scope emitted it *after the loop's break label*.

From `obc -asm`:

```
 10   GTR_INT
 11   JMP index=4, conditional=true     <- back-edge
 12   LBL                               <- break label
 13   LOAD_INT_LIT 1
 14   LOAD_INT_VAR id=1
 15   SUB_INT
 16   STOR_INT_VAR id=1                 <- the decrement, OUTSIDE the loop
```

`n` never changed between iterations. It now reads `10 → decrement → jump`, between the test and the back-edge, where the old code had it.

## Why not keep the optimisation

Emitting the condition first and choosing afterwards doesn't work either: `EmitBranch` fuses the compare and the jump, and a post statement must run on **both** the taken and untaken path — a shape that form cannot express. So `do`/`while` always takes the non-branching form now.

Nothing covered is lost: `core_bool_short_circuit.obs` contains **no `do` block at all**, and no fixture anywhere used a post-operation in a loop condition.

`EmitWhile` was never affected — it drains the queue *after* the body, once the condition is already emitted — and the new fixture pins that too.

## How it was found

`programs/web-playground/demos/math/primes.obs`, whose `Show()` uses this shape. It produced **29 MB of one repeated line in 25 s**. Two other defects kept it hidden: the demo was unreachable in the playground because the validator blocked it on `Runtime->Exit`, and no regression test used the shape.

Post-**increment** was equally broken (`c++ < 3` never advanced); the fixture covers both.

## Libraries

No `.obl` rebuild needed. The only post-op-in-condition in `lib_src` is `lang.obs:8219`, a plain `while`, which never took this path.

## Test

`core_do_while_post_op.obs` bounds every loop with an iteration cap, because the failure mode is a **hang** — an unbounded fixture would take the suite down instead of reporting. Validated three ways:

| compiler | result |
|---|---|
| broken (this tree's `HEAD`) | **FAIL**, 3 checks, exit 1 |
| fixed | PASS |
| published v2026.9.0 | PASS (so it is not over-strict) |

| suite | result |
|---|---|
| Windows x64, default | **240 / 3 / 0** |
| Windows x64, `OBJECK_JIT_THRESHOLD=1` | **240 / 3 / 0** |
| Linux x64 | **239 / 4 / 0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)