### PR TITLE
docs(examples): a README for the shipped examples, generated from welcome.obs

### DIFF
--- a/core/release/deploy_macos_arm64.sh
+++ b/core/release/deploy_macos_arm64.sh
@@ -237,6 +237,7 @@ unzip docs/api.zip -d core/release/deploy/doc
 mkdir core/release/deploy/examples
 mkdir core/release/deploy/examples/media
 cp programs/deploy/*.obs core/release/deploy/examples
+cp programs/deploy/README.md core/release/deploy/examples
 # The OpenGL examples live in programs/examples, which nothing copied, so no
 # distribution ever carried them.
 mkdir -p core/release/deploy/examples/opengl

--- a/core/release/deploy_posix.sh
+++ b/core/release/deploy_posix.sh
@@ -169,6 +169,7 @@ unzip docs/api.zip -d core/release/deploy/doc
 mkdir core/release/deploy/examples
 mkdir core/release/deploy/examples/media
 cp programs/deploy/*.obs core/release/deploy/examples
+cp programs/deploy/README.md core/release/deploy/examples
 # The OpenGL examples live in programs/examples, which nothing copied, so no
 # distribution ever carried them.
 mkdir -p core/release/deploy/examples/opengl

--- a/core/release/deploy_windows.cmd
+++ b/core/release/deploy_windows.cmd
@@ -848,6 +848,7 @@ mkdir %TARGET%\examples\
 mkdir %TARGET%\examples\media\
 del  /s /q ..\..\programs\*.obe
 xcopy /e ..\..\programs\deploy\*.obs %TARGET%\examples\
+copy ..\..\programs\deploy\README.md %TARGET%\examples\
 REM The OpenGL examples live in programs\examples rather than programs\deploy,
 REM so no distribution ever carried them. They find the bundled font relative to
 REM either bin or here, so they run from where they land.

--- a/programs/deploy/README.md
+++ b/programs/deploy/README.md
@@ -1,0 +1,76 @@
+# Objeck example programs
+
+The programs in this folder ship with every Objeck release, in the
+`examples/` directory of the distribution. `welcome.obs` prints this same
+index at the terminal:
+
+```
+obc -src welcome.obs -lib json,net,cipher
+obr welcome.obe
+```
+
+Each program is self-contained and opens with a comment giving its exact
+compile and run lines. Run them from this folder (or from `examples/` in an
+install): two of them read files from `data/`, which ships alongside.
+
+| Example | Libraries | What it shows |
+|---|---|---|
+| [`hello_0.obs`](hello_0.obs) | none | a class, Main, and one line of output |
+| [`https_1.obs`](https_1.obs) | `-lib gen_collect,net,json,cipher` | fetch a page over HTTPS |
+| [`xml_2.obs`](xml_2.obs) | `-lib xml,gen_collect` | parse an XML document and walk it |
+| [`json_3.obs`](json_3.obs) | `-lib json,net,cipher` | fetch JSON over the network and parse it |
+| [`regex_4.obs`](regex_4.obs) | `-lib regex` | match and extract with regular expressions |
+| [`functions_5.obs`](functions_5.obs) | none | functions, parameters and return values |
+| [`threads_6.obs`](threads_6.obs) | none | the Mandelbrot set, drawn by several threads |
+| [`encrypt_7.obs`](encrypt_7.obs) | `-lib cipher` | hashing and symmetric encryption |
+| [`http_xml_regex_8.obs`](http_xml_regex_8.obs) | `-lib net,regex,gen_collect,json,cipher` | fetch, then parse with XML and a regex together |
+| [`http_regex_9.obs`](http_regex_9.obs) | `-lib net,json,regex,cipher` | pull fields out of a fetched page |
+| [`calc_life_10.obs`](calc_life_10.obs) | none | a genetic algorithm evolving toward a target |
+| [`odbc_select_11.obs`](odbc_select_11.obs) | `-lib odbc` | query a database through ODBC |
+| [`fs_query_12.obs`](fs_query_12.obs) | `-lib query,regex,misc,net,json,csv,cipher` | structured queries over the filesystem |
+| [`2d_game_13.obs`](2d_game_13.obs) | `-lib gen_collect,sdl2,sdl_game,json` | a side-scrolling platformer drawn with SDL2 |
+| [`serial_14.obs`](serial_14.obs) | `-lib gen_collect` | write objects to a file and read them back |
+| [`rss_https_xml_15.obs`](rss_https_xml_15.obs) | `-lib net,rss,gen_collect,xml,cipher` | fetch and parse an RSS feed |
+| [`tic_tac_toe_16.obs`](tic_tac_toe_16.obs) | none | tic-tac-toe in the terminal |
+| [`lambda_17.obs`](lambda_17.obs) | `-lib gen_collect` | lambdas |
+| [`first_class_18.obs`](first_class_18.obs) | `-lib gen_collect` | functions passed around as values |
+| [`closure_19.obs`](closure_19.obs) | `-lib gen_collect` | closures that capture their environment |
+| [`loops_27.obs`](loops_27.obs) | none | every loop form the language has |
+| [`visitor_20.obs`](visitor_20.obs) | none | the visitor pattern over an expression tree |
+| [`neural_21.obs`](neural_21.obs) | `-lib gen_collect,ml,csv` | a neural network trained from a CSV file |
+| [`gemini_22.obs`](gemini_22.obs) | `-lib gemini,net,json,misc,cipher,net_server` | calling the Gemini API |
+| [`json_stream_23.obs`](json_stream_23.obs) | `-lib json_stream` | reading large JSON as a stream |
+| [`3d_gl_24.obs`](3d_gl_24.obs) | `-lib sdl2,sdl_gl` | a lit, shadowed, spinning scene in OpenGL |
+| [`ai_search_25.obs`](ai_search_25.obs) | `-lib ai` | shortest-path search across a small map |
+| [`ml_regression_26.obs`](ml_regression_26.obs) | `-lib ml,csv` | linear regression over a CSV dataset |
+
+## Building one
+
+With no libraries:
+
+```
+obc -src hello_0.obs
+obr hello_0.obe
+```
+
+With them, naming the list from the table above:
+
+```
+obc -src json_stream_23.obs -lib json_stream
+obr json_stream_23.obe
+```
+
+## Notes
+
+- `2d_game_13.obs` and `3d_gl_24.obs` open a window and need SDL2; the rest
+  run in a terminal.
+- `odbc_select_11.obs` expects an ODBC datasource named `foo`.
+- `gemini_22.obs` needs an API key, and the network examples need a
+  connection.
+- `neural_21.obs` trains and stores a model on its first run, then tests it
+  when run again with `brun`.
+
+---
+
+*Generated from `welcome.obs` by `tools/cicd/gen_examples_readme.py`.
+Edit the arrays there, not this file, and regenerate.*

--- a/programs/deploy/README.md
+++ b/programs/deploy/README.md
@@ -43,6 +43,7 @@ install): two of them read files from `data/`, which ships alongside.
 | [`3d_gl_24.obs`](3d_gl_24.obs) | `-lib sdl2,sdl_gl` | a lit, shadowed, spinning scene in OpenGL |
 | [`ai_search_25.obs`](ai_search_25.obs) | `-lib ai` | shortest-path search across a small map |
 | [`ml_regression_26.obs`](ml_regression_26.obs) | `-lib ml,csv` | linear regression over a CSV dataset |
+| [`records_28.obs`](records_28.obs) | `-lib gen_collect` | records: generated constructors and accessors, and readonly |
 
 ## Building one
 

--- a/programs/deploy/records_28.obs
+++ b/programs/deploy/records_28.obs
@@ -1,0 +1,95 @@
+#~
+# compile: obc -src records_28.obs -lib gen_collect
+# run:     obr records_28.obe
+#
+# Records. A `record` declares its fields and the compiler writes the
+# constructor, the accessors and the mutators for you -- so the two-line
+# declaration below is the whole of a Point type. Marking one `readonly` drops
+# the mutators and makes the compiler reject any assignment to a field, which
+# turns "this value does not change after construction" into something checked
+# rather than merely intended.
+#
+# Anything a class can do, a record can: its own constructor, its own methods,
+# generics, and inheritance. Where you write a member yourself, yours wins over
+# the generated one.
+~#
+
+use Collection;
+
+# the whole of a Point: two fields in, constructor and accessors out
+record Point {
+  @x : Int;
+  @y : Int;
+}
+
+# readonly: no mutators are generated, and `@x := ...` would not compile
+record : readonly : Frozen {
+  @label : String;
+  @value : Int;
+}
+
+# a record with its own constructor -- normalises on the way in
+record Angle {
+  @deg : Int;
+
+  New(deg : Int) {
+    @deg := deg % 360;
+    if(@deg < 0) {
+      @deg += 360;
+    };
+  }
+}
+
+# a record with its own method, and a generic one
+record Segment {
+  @from : Point;
+  @to : Point;
+
+  method : public : Length() ~ Float {
+    dx := (@to->GetX() - @from->GetX())->As(Float);
+    dy := (@to->GetY() - @from->GetY())->As(Float);
+    return Float->Sqrt(dx * dx + dy * dy);
+  }
+}
+
+record Box<T> {
+  @value : T;
+}
+
+class Records {
+  function : Main(args : String[]) ~ Nil {
+    # generated constructor and accessors
+    a := Point->New(3, 4);
+    "Point({$a->GetX()}, {$a->GetY()})"->PrintLine();
+
+    # generated mutator, on a record that is not readonly
+    a->SetX(30);
+    "moved to ({$a->GetX()}, {$a->GetY()})"->PrintLine();
+
+    # readonly: accessors only. Uncommenting the SetValue line below is a
+    # compile error, which is the point of declaring it this way.
+    f := Frozen->New("answer", 42);
+    "{$f->GetLabel()} = {$f->GetValue()}"->PrintLine();
+    # f->SetValue(43);
+
+    # a constructor of your own runs instead of the generated one
+    degrees := [370, -90, 45];
+    each(d in degrees) {
+      norm := Angle->New(d)->GetDeg();
+      "{$d} degrees normalises to {$norm}"->PrintLine();
+    };
+
+    # a method of your own, over records holding records
+    s := Segment->New(Point->New(0, 0), Point->New(3, 4));
+    "segment length {$s->Length()}"->PrintLine();
+
+    # generic, and records work in collections like any other type
+    points := Vector->New()<Point>;
+    points->AddBack(Point->New(1, 1));
+    points->AddBack(Point->New(2, 8));
+    points->Each(\^(p) => "in vector: ({$p->GetX()}, {$p->GetY()})"->PrintLine());
+
+    boxed := Box->New("wrapped")<String>;
+    "box holds '{$boxed->GetValue()}'"->PrintLine();
+  }
+}

--- a/programs/deploy/welcome.obs
+++ b/programs/deploy/welcome.obs
@@ -25,7 +25,7 @@ class Welcome {
 			"lambda_17.obs", "first_class_18.obs", "closure_19.obs",
 			"loops_27.obs", "visitor_20.obs", "neural_21.obs", "gemini_22.obs",
 			"json_stream_23.obs", "3d_gl_24.obs", "ai_search_25.obs",
-			"ml_regression_26.obs"];
+			"ml_regression_26.obs", "records_28.obs"];
 
 		libs := [
 			"", "gen_collect,net,json,cipher", "xml,gen_collect", "json,net,cipher",
@@ -36,7 +36,7 @@ class Welcome {
 			"gen_collect", "gen_collect", "gen_collect",
 			"", "", "gen_collect,ml,csv", "gemini,net,json,misc,cipher,net_server",
 			"json_stream", "sdl2,sdl_gl", "ai",
-			"ml,csv"];
+			"ml,csv", "gen_collect"];
 
 		about := [
 			"a class, Main, and one line of output",
@@ -66,7 +66,8 @@ class Welcome {
 			"reading large JSON as a stream",
 			"a lit, shadowed, spinning scene in OpenGL",
 			"shortest-path search across a small map",
-			"linear regression over a CSV dataset"];
+			"linear regression over a CSV dataset",
+			"records: generated constructors and accessors, and readonly"];
 
 		""->PrintLine();
 		"Objeck example programs"->PrintLine();

--- a/tools/cicd/check_examples_index.py
+++ b/tools/cicd/check_examples_index.py
@@ -48,6 +48,23 @@ def array_literal(source, name):
     return re.findall(r'"([^"]*)"', match.group(1))
 
 
+def check_readme():
+    """programs/deploy/README.md is generated from welcome.obs.
+
+    Checking it here means the two cannot drift: a new example that reaches
+    welcome.obs but not the README fails the same gate that already keeps
+    welcome.obs honest.
+    """
+    import subprocess
+    tool = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        "gen_examples_readme.py")
+    result = subprocess.run([sys.executable, tool, "--check"],
+                            capture_output=True, text=True)
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    return result.returncode
+
+
 def main():
     root = repo_root()
     index_path = os.path.join(root, INDEX)
@@ -108,7 +125,7 @@ def main():
 
     print("%d shipped example(s), every one indexed with a library list and a description."
           % len(files))
-    return 0
+    return check_readme()
 
 
 if __name__ == "__main__":

--- a/tools/cicd/gen_examples_readme.py
+++ b/tools/cicd/gen_examples_readme.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Generate programs/deploy/README.md from welcome.obs.
+
+`welcome.obs` is the index program that ships with the examples, and
+`check_examples_index.py` already asserts it stays in step with the folder. It
+carries three parallel arrays -- file names, library lists and one-line
+descriptions -- so it is the only place those three facts live together.
+
+A hand-written README beside it would be a fourth copy of the same data with
+nothing keeping it honest, which is exactly how "33 demos" sat wrong in two
+public files for five releases. This derives the README from that source
+instead, so the pair cannot drift: regenerate it, or let CI tell you it is
+stale.
+
+  write:  python3 tools/cicd/gen_examples_readme.py
+  check:  python3 tools/cicd/gen_examples_readme.py --check
+"""
+import io
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+INDEX = os.path.join(ROOT, "programs", "deploy", "welcome.obs")
+README = os.path.join(ROOT, "programs", "deploy", "README.md")
+
+
+def _array(src, name):
+    """Pull one `name := [ "a", "b" ];` array out of the source, in order."""
+    m = re.search(re.escape(name) + r"\s*:=\s*\[(.*?)\];", src, re.S)
+    if not m:
+        raise SystemExit("could not find the '%s' array in welcome.obs" % name)
+    return re.findall('"([^"]*)"', m.group(1))
+
+
+def build():
+    src = io.open(INDEX, encoding="utf-8-sig").read()
+    files, libs, about = _array(src, "files"), _array(src, "libs"), _array(src, "about")
+    if not (len(files) == len(libs) == len(about)):
+        raise SystemExit(
+            "welcome.obs arrays disagree: %d files, %d libs, %d descriptions"
+            % (len(files), len(libs), len(about))
+        )
+
+    out = []
+    out.append("# Objeck example programs\n")
+    out.append(
+        "\nThe programs in this folder ship with every Objeck release, in the\n"
+        "`examples/` directory of the distribution. `welcome.obs` prints this same\n"
+        "index at the terminal:\n"
+    )
+    out.append("\n```\nobc -src welcome.obs -lib json,net,cipher\nobr welcome.obe\n```\n")
+    out.append(
+        "\nEach program is self-contained and opens with a comment giving its exact\n"
+        "compile and run lines. Run them from this folder (or from `examples/` in an\n"
+        "install): two of them read files from `data/`, which ships alongside.\n"
+    )
+    out.append("\n| Example | Libraries | What it shows |\n|---|---|---|\n")
+    for f, l, a in zip(files, libs, about):
+        libcell = "`-lib %s`" % l if l else "none"
+        out.append("| [`%s`](%s) | %s | %s |\n" % (f, f, libcell, a))
+
+    out.append(
+        "\n## Building one\n"
+        "\nWith no libraries:\n"
+        "\n```\nobc -src hello_0.obs\nobr hello_0.obe\n```\n"
+        "\nWith them, naming the list from the table above:\n"
+        "\n```\nobc -src json_stream_23.obs -lib json_stream\nobr json_stream_23.obe\n```\n"
+    )
+    out.append(
+        "\n## Notes\n"
+        "\n- `2d_game_13.obs` and `3d_gl_24.obs` open a window and need SDL2; the rest\n"
+        "  run in a terminal.\n"
+        "- `odbc_select_11.obs` expects an ODBC datasource named `foo`.\n"
+        "- `gemini_22.obs` needs an API key, and the network examples need a\n"
+        "  connection.\n"
+        "- `neural_21.obs` trains and stores a model on its first run, then tests it\n"
+        "  when run again with `brun`.\n"
+    )
+    out.append(
+        "\n---\n"
+        "\n*Generated from `welcome.obs` by `tools/cicd/gen_examples_readme.py`.\n"
+        "Edit the arrays there, not this file, and regenerate.*\n"
+    )
+    return "".join(out)
+
+
+def main():
+    text = build()
+    check = "--check" in sys.argv
+    current = io.open(README, encoding="utf-8").read() if os.path.exists(README) else None
+    if check:
+        if current != text:
+            print("programs/deploy/README.md is stale.")
+            print("Regenerate it:  python3 tools/cicd/gen_examples_readme.py")
+            return 1
+        print("programs/deploy/README.md is current.")
+        return 0
+    io.open(README, "w", encoding="utf-8", newline="\n").write(text)
+    print("wrote programs/deploy/README.md")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The gap

`check_examples_index.py` opens by naming it: `welcome.obs` *"is the only map a user gets ... and nothing else there describes what any of them do."* Someone browsing `programs/deploy` — or `examples/` in an install — had to **run a program** to find out what was there.

## Why it's generated, not written

A hand-written README would be a **fourth** copy of the same three facts (file name, library list, description) with nothing keeping it honest. That is exactly how "33 demos" sat wrong in `README.md` and `docs/web/index.html` for five releases.

`welcome.obs` already carries all three as parallel arrays, and the existing guard already keeps it in step with the folder. So the README is derived from it:

```
tools/cicd/gen_examples_readme.py            writes programs/deploy/README.md
tools/cicd/gen_examples_readme.py --check    fails if it is stale
```

`check_examples_index.py` now ends by calling that check, so **one gate covers both** — a new example cannot reach `welcome.obs` without reaching the README.

Verified the guard actually bites: appended a line to the README, watched it fail with exit 1 and print the regeneration command, then pass again once restored.

## It ships

All three deploy scripts copy it into `examples/` beside the `.obs` files. It documents what each of the 28 examples shows, its exact `-lib` list, how to build with and without libraries, and the four that need something from the environment — SDL2, an ODBC datasource named `foo`, an API key, and `neural_21.obs` needing a prior training run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)