### PR TITLE
Deploy scripts: banner, live progress and quiet build output

### DIFF
--- a/core/release/deploy_posix.sh
+++ b/core/release/deploy_posix.sh
@@ -5,6 +5,21 @@ if [ $# -eq 0 ]; then
 	exit 1
 fi
 
+# -v or --verbose after the target streams every build, as VERBOSE=1 does.
+for _a in "$@"; do
+	case "$_a" in -v|--verbose) VERBOSE=1 ;; esac
+done
+
+# Presentation -- banner, stage progress, quiet build output -- lives in
+# ui.sh. UI_TOTAL must equal the ui_step calls on the path taken: one per
+# stage below, plus the tarball stage when $2 is deploy. A build that fails
+# is reported by ui_fail and the deploy carries on, as it always has.
+. "$(dirname "$0")/ui.sh"
+if [ "$2" = "deploy" ]; then UI_TOTAL=19; else UI_TOTAL=18; fi
+_ver=$(grep VERSION_STRING ../shared/version.h 2>/dev/null | cut -d'"' -f2)
+ui_banner "linux-$1" "${_ver:-dev}"
+
+ui_step "directories"
 # setup directories
 rm -rf deploy
 mkdir deploy
@@ -16,6 +31,7 @@ mkdir deploy/lib/native
 mkdir deploy/lib/native/misc
 mkdir deploy/doc
 
+ui_step "compiler (obc)"
 # build compiler
 cd ../compiler
 if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
@@ -23,12 +39,13 @@ if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
 else
 	cp make/Makefile.amd64 Makefile
 fi
-make clean; make -j3 OBJECK_LIB_PATH=///".///"
+ui_q make clean; ui_q make -j3 OBJECK_LIB_PATH=///".///" || ui_fail
 cp obc ../release/deploy/bin
 cp ../lib/*.obl ../release/deploy/lib
 cp ../lib/*.ini ../release/deploy/lib
 cp ../vm/misc/*.pem ../release/deploy/lib
 
+ui_step "virtual machine (obr)"
 # build VM
 cd ../vm
 if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
@@ -36,9 +53,10 @@ if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
 else 
 	cp make/Makefile.amd64 Makefile
 fi
-make clean; make -j3
+ui_q make clean; ui_q make -j3 || ui_fail
 cp obr ../release/deploy/bin
 
+ui_step "debugger (obd)"
 # build debugger
 cd ../debugger
 if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
@@ -46,9 +64,10 @@ if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
 else
 	cp make/Makefile.amd64 Makefile
 fi
-make clean; make -j3
+ui_q make clean; ui_q make -j3 || ui_fail
 cp obd ../release/deploy/bin
 
+ui_step "repl (obi)"
 # build repl
 cd ../repl
 if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
@@ -56,30 +75,36 @@ if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
 else
 	cp make/Makefile.amd64 Makefile
 fi
-make clean; make -j3
+ui_q make clean; ui_q make -j3 || ui_fail
 cp obi ../release/deploy/bin
 
+ui_step "library: odbc"
 # build libraries
 cd ../lib/odbc
-./build_linux.sh odbc
+ui_q ./build_linux.sh odbc || ui_fail
 cp odbc.so ../../release/deploy/lib/native/libobjk_odbc.so
 
+ui_step "library: crypto"
 cd ../crypto
-./build_linux.sh crypto
+ui_q ./build_linux.sh crypto || ui_fail
 cp crypto.so ../../release/deploy/lib/native/libobjk_crypto.so
 
+ui_step "library: lame"
 cd ../lame
-./build_linux.sh lame
+ui_q ./build_linux.sh lame || ui_fail
 cp lame.so ../../release/deploy/lib/native/libobjk_lame.so
 
+ui_step "library: matrix (ml)"
 cd ../matrix
-./build_linux.sh matrix
+ui_q ./build_linux.sh matrix || ui_fail
 cp matrix.so ../../release/deploy/lib/native/libobjk_ml.so
 
+ui_step "library: opencv"
 cd ../opencv
-./build_linux.sh opencv
+ui_q ./build_linux.sh opencv || ui_fail
 cp opencv.so ../../release/deploy/lib/native/libobjk_opencv.so
 
+ui_step "library: onnx (cpu)"
 cd ../onnx/eq
 # The vendored libonnxruntime here is a CPU-ONLY build -- it reports only
 # CPUExecutionProvider despite living under eq/cuda/lib. Building with
@@ -87,7 +112,7 @@ cd ../onnx/eq
 # catch returned without setting the session handle it surfaced as a silently
 # null session rather than an error. Link a CUDA-enabled onnxruntime before
 # switching this back to cuda.
-./build.sh cpu
+ui_q ./build.sh cpu || ui_fail
 cp libobjk_onnx.so ../../../release/deploy/lib/native/libobjk_onnx.so
 
 # copy ONNX Runtime shared libraries
@@ -98,45 +123,50 @@ ln -sf libonnxruntime.so.1 libonnxruntime.so
 cd ../../../../lib/onnx/eq
 
 cp cuda/lib/x64/lib/libonnxruntime_providers_shared.so ../../../release/deploy/lib/native/libonnxruntime_providers_shared.so
+ui_step "library: sdl"
 cd ../../sdl
-./build_linux.sh sdl
+ui_q ./build_linux.sh sdl || ui_fail
 cp sdl.so ../../release/deploy/lib/native/libobjk_sdl.so
 cp lib/fonts/*.ttf ../../release/deploy/lib/sdl/fonts
 
+ui_step "library: diags"
 cd ../diags
-./build_linux.sh diags
+ui_q ./build_linux.sh diags || ui_fail
 cp diags.so ../../release/deploy/lib/native/libobjk_diags.so
 
+ui_step "verify native libraries"
 # Every native library this script builds must be present (and, on Linux,
 # resolvable) before the tree is packaged. Without this a failed build was
 # dropped from the release with a green exit -- the obu incident, again.
 sh ../../release/verify_native_libs.sh ../../release/deploy/lib/native so crypto diags lame ml odbc onnx opencv sdl
 
+ui_step "launchers (obb, obn)"
 cd ../../utils/launcher
 if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
-	make -f make/Makefile.obb.arm64 clean; make -f make/Makefile.obb.arm64 -j3
+	ui_q make -f make/Makefile.obb.arm64 clean; ui_q make -f make/Makefile.obb.arm64 -j3 || ui_fail
 else
-	make -f make/Makefile.obb.amd64 clean; make -f make/Makefile.obb.amd64 -j3
+	ui_q make -f make/Makefile.obb.amd64 clean; ui_q make -f make/Makefile.obb.amd64 -j3 || ui_fail
 fi
 cp obb ../../release/deploy/bin
 
 if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
-	make -f make/Makefile.obn.arm64 clean; make -f make/Makefile.obn.arm64 -j3
+	ui_q make -f make/Makefile.obn.arm64 clean; ui_q make -f make/Makefile.obn.arm64 -j3 || ui_fail
 else
-	make -f make/Makefile.obn.amd64 clean; make -f make/Makefile.obn.amd64 -j3
+	ui_q make -f make/Makefile.obn.amd64 clean; ui_q make -f make/Makefile.obn.amd64 -j3 || ui_fail
 fi
 cp obn ../../release/deploy/lib/native/misc/
 
 cp ../../vm/misc/config.prop ../../release/deploy/lib/native/misc
 
+ui_step "updater (obu)"
 # build updater
 # obu ships in bin/ like every other user-facing tool; without this the release
 # advertises 'obu check/update/rollback' and delivers no binary.
 cd ../updater
 if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
-	make -f make/Makefile.arm64 clean; make -f make/Makefile.arm64 -j3
+	ui_q make -f make/Makefile.arm64 clean; ui_q make -f make/Makefile.arm64 -j3 || ui_fail
 else
-	make -f make/Makefile.amd64 clean; make -f make/Makefile.amd64 -j3
+	ui_q make -f make/Makefile.amd64 clean; ui_q make -f make/Makefile.amd64 -j3 || ui_fail
 fi
 cp obu ../../release/deploy/bin
 # This script does not use 'set -e', so a failed make or cp would otherwise be
@@ -149,6 +179,7 @@ fi
 
 cd ../../release
 
+ui_step "documentation"
 # copy docs
 cd ../..
 cp -R docs/syntax core/release/deploy/doc/syntax
@@ -163,8 +194,9 @@ cp LICENSE core/release/deploy
 # and never cloned the repo.
 cp tools/install_deps.sh core/release/deploy
 chmod +x core/release/deploy/install_deps.sh
-unzip docs/api.zip -d core/release/deploy/doc
+unzip -q docs/api.zip -d core/release/deploy/doc
 
+ui_step "examples"
 # copy examples
 mkdir core/release/deploy/examples
 mkdir core/release/deploy/examples/media
@@ -189,6 +221,7 @@ cd core/release
 
 # deploy
 if [ ! -z "$2" ] && [ "$2" = "deploy" ]; then
+	ui_step "package tarball"
 	mkdir -p ~/Desktop
 	rm -rf ~/Desktop/objeck*
 	cp -rf deploy ~/Desktop/objeck-lang
@@ -204,3 +237,5 @@ if [ ! -z "$2" ] && [ "$2" = "deploy" ]; then
 		mv objeck.tar.gz objeck-linux-x64_0.0.0.tgz
 	fi
 fi
+
+ui_ok "deploy complete"

--- a/core/release/deploy_posix.sh
+++ b/core/release/deploy_posix.sh
@@ -10,10 +10,10 @@ for _a in "$@"; do
 	case "$_a" in -v|--verbose) VERBOSE=1 ;; esac
 done
 
-# Presentation -- banner, stage progress, quiet build output -- lives in
-# ui.sh. UI_TOTAL must equal the ui_step calls on the path taken: one per
-# stage below, plus the tarball stage when $2 is deploy. A build that fails
-# is reported by ui_fail and the deploy carries on, as it always has.
+# Presentation -- banner, live progress, quiet build output -- lives in ui.sh.
+# UI_TOTAL must equal the ui_step calls on the path taken: one per stage below,
+# plus the tarball stage when $2 is deploy. A step that fails is reported by
+# ui_fail and the deploy carries on, as it always has.
 . "$(dirname "$0")/ui.sh"
 if [ "$2" = "deploy" ]; then UI_TOTAL=19; else UI_TOTAL=18; fi
 _ver=$(grep VERSION_STRING ../shared/version.h 2>/dev/null | cut -d'"' -f2)
@@ -39,7 +39,7 @@ if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
 else
 	cp make/Makefile.amd64 Makefile
 fi
-ui_q make clean; ui_q make -j3 OBJECK_LIB_PATH=///".///" || ui_fail
+make clean; make -j3 OBJECK_LIB_PATH=///".///" || ui_fail
 cp obc ../release/deploy/bin
 cp ../lib/*.obl ../release/deploy/lib
 cp ../lib/*.ini ../release/deploy/lib
@@ -53,7 +53,7 @@ if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
 else 
 	cp make/Makefile.amd64 Makefile
 fi
-ui_q make clean; ui_q make -j3 || ui_fail
+make clean; make -j3 || ui_fail
 cp obr ../release/deploy/bin
 
 ui_step "debugger (obd)"
@@ -64,7 +64,7 @@ if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
 else
 	cp make/Makefile.amd64 Makefile
 fi
-ui_q make clean; ui_q make -j3 || ui_fail
+make clean; make -j3 || ui_fail
 cp obd ../release/deploy/bin
 
 ui_step "repl (obi)"
@@ -75,33 +75,33 @@ if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
 else
 	cp make/Makefile.amd64 Makefile
 fi
-ui_q make clean; ui_q make -j3 || ui_fail
+make clean; make -j3 || ui_fail
 cp obi ../release/deploy/bin
 
 ui_step "library: odbc"
 # build libraries
 cd ../lib/odbc
-ui_q ./build_linux.sh odbc || ui_fail
+./build_linux.sh odbc || ui_fail
 cp odbc.so ../../release/deploy/lib/native/libobjk_odbc.so
 
 ui_step "library: crypto"
 cd ../crypto
-ui_q ./build_linux.sh crypto || ui_fail
+./build_linux.sh crypto || ui_fail
 cp crypto.so ../../release/deploy/lib/native/libobjk_crypto.so
 
 ui_step "library: lame"
 cd ../lame
-ui_q ./build_linux.sh lame || ui_fail
+./build_linux.sh lame || ui_fail
 cp lame.so ../../release/deploy/lib/native/libobjk_lame.so
 
 ui_step "library: matrix (ml)"
 cd ../matrix
-ui_q ./build_linux.sh matrix || ui_fail
+./build_linux.sh matrix || ui_fail
 cp matrix.so ../../release/deploy/lib/native/libobjk_ml.so
 
 ui_step "library: opencv"
 cd ../opencv
-ui_q ./build_linux.sh opencv || ui_fail
+./build_linux.sh opencv || ui_fail
 cp opencv.so ../../release/deploy/lib/native/libobjk_opencv.so
 
 ui_step "library: onnx (cpu)"
@@ -112,7 +112,7 @@ cd ../onnx/eq
 # catch returned without setting the session handle it surfaced as a silently
 # null session rather than an error. Link a CUDA-enabled onnxruntime before
 # switching this back to cuda.
-ui_q ./build.sh cpu || ui_fail
+./build.sh cpu || ui_fail
 cp libobjk_onnx.so ../../../release/deploy/lib/native/libobjk_onnx.so
 
 # copy ONNX Runtime shared libraries
@@ -125,34 +125,34 @@ cd ../../../../lib/onnx/eq
 cp cuda/lib/x64/lib/libonnxruntime_providers_shared.so ../../../release/deploy/lib/native/libonnxruntime_providers_shared.so
 ui_step "library: sdl"
 cd ../../sdl
-ui_q ./build_linux.sh sdl || ui_fail
+./build_linux.sh sdl || ui_fail
 cp sdl.so ../../release/deploy/lib/native/libobjk_sdl.so
 cp lib/fonts/*.ttf ../../release/deploy/lib/sdl/fonts
 
 ui_step "library: diags"
 cd ../diags
-ui_q ./build_linux.sh diags || ui_fail
+./build_linux.sh diags || ui_fail
 cp diags.so ../../release/deploy/lib/native/libobjk_diags.so
 
 ui_step "verify native libraries"
 # Every native library this script builds must be present (and, on Linux,
 # resolvable) before the tree is packaged. Without this a failed build was
 # dropped from the release with a green exit -- the obu incident, again.
-sh ../../release/verify_native_libs.sh ../../release/deploy/lib/native so crypto diags lame ml odbc onnx opencv sdl
+sh ../../release/verify_native_libs.sh ../../release/deploy/lib/native so crypto diags lame ml odbc onnx opencv sdl || ui_fail
 
 ui_step "launchers (obb, obn)"
 cd ../../utils/launcher
 if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
-	ui_q make -f make/Makefile.obb.arm64 clean; ui_q make -f make/Makefile.obb.arm64 -j3 || ui_fail
+	make -f make/Makefile.obb.arm64 clean; make -f make/Makefile.obb.arm64 -j3 || ui_fail
 else
-	ui_q make -f make/Makefile.obb.amd64 clean; ui_q make -f make/Makefile.obb.amd64 -j3 || ui_fail
+	make -f make/Makefile.obb.amd64 clean; make -f make/Makefile.obb.amd64 -j3 || ui_fail
 fi
 cp obb ../../release/deploy/bin
 
 if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
-	ui_q make -f make/Makefile.obn.arm64 clean; ui_q make -f make/Makefile.obn.arm64 -j3 || ui_fail
+	make -f make/Makefile.obn.arm64 clean; make -f make/Makefile.obn.arm64 -j3 || ui_fail
 else
-	ui_q make -f make/Makefile.obn.amd64 clean; ui_q make -f make/Makefile.obn.amd64 -j3 || ui_fail
+	make -f make/Makefile.obn.amd64 clean; make -f make/Makefile.obn.amd64 -j3 || ui_fail
 fi
 cp obn ../../release/deploy/lib/native/misc/
 
@@ -164,9 +164,9 @@ ui_step "updater (obu)"
 # advertises 'obu check/update/rollback' and delivers no binary.
 cd ../updater
 if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then
-	ui_q make -f make/Makefile.arm64 clean; ui_q make -f make/Makefile.arm64 -j3 || ui_fail
+	make -f make/Makefile.arm64 clean; make -f make/Makefile.arm64 -j3 || ui_fail
 else
-	ui_q make -f make/Makefile.amd64 clean; ui_q make -f make/Makefile.amd64 -j3 || ui_fail
+	make -f make/Makefile.amd64 clean; make -f make/Makefile.amd64 -j3 || ui_fail
 fi
 cp obu ../../release/deploy/bin
 # This script does not use 'set -e', so a failed make or cp would otherwise be

--- a/core/release/deploy_windows.cmd
+++ b/core/release/deploy_windows.cmd
@@ -10,6 +10,13 @@ IF "%VCINSTALLDIR%"=="" (
 	goto end
 )
 
+REM Presentation -- banner, stage progress, quiet tool output -- lives in
+REM ui.cmd. UI_TOTAL must equal the ui_step calls on the path taken: one per
+REM stage below, plus the packaging stage when %2 is deploy.
+set UI_TOTAL=15
+if [%2] == [deploy] set UI_TOTAL=16
+call "%~dp0ui.cmd" :ui_init %1 %2 %3
+
 REM mbedTLS and nghttp2 come from vcpkg, for both x64 and ARM64.
 REM
 REM They used to be binaries committed under lib\openssl\win\<arch>, and this
@@ -71,37 +78,40 @@ if [%1] == [x64] (
 	set TARGET=deploy-x64
 )
 
+call "%~dp0ui.cmd" :ui_step "clean tree + version stamp"
 REM debug installer
 REM goto installer
 
-rmdir /s /q %TARGET%
-mkdir %TARGET%
-mkdir %TARGET%\app
-mkdir %TARGET%\lib
-mkdir %TARGET%\lib\sdl
-mkdir %TARGET%\lib\sdl\fonts
-mkdir %TARGET%\lib\native
-mkdir %TARGET%\lib\native\misc
-copy ..\lib\*.obl %TARGET%\lib
-copy ..\lib\*.ini %TARGET%\lib
+rmdir /s /q %TARGET% %UI_REDIR%
+mkdir %TARGET% %UI_REDIR%
+mkdir %TARGET%\app %UI_REDIR%
+mkdir %TARGET%\lib %UI_REDIR%
+mkdir %TARGET%\lib\sdl %UI_REDIR%
+mkdir %TARGET%\lib\sdl\fonts %UI_REDIR%
+mkdir %TARGET%\lib\native %UI_REDIR%
+mkdir %TARGET%\lib\native\misc %UI_REDIR%
+copy ..\lib\*.obl %TARGET%\lib %UI_REDIR%
+copy ..\lib\*.ini %TARGET%\lib %UI_REDIR%
 
 REM update version information
-powershell.exe -executionpolicy remotesigned -file  update_version.ps1
+powershell.exe -executionpolicy remotesigned -file  update_version.ps1 %UI_REDIR%
 if errorlevel 1 (
 	echo.
 	echo ============================================================
 	echo  ERROR: update_version.ps1 failed - aborting deploy
 	echo ============================================================
+	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 
+call "%~dp0ui.cmd" :ui_step "compiler, vm, debugger, repl"
 REM compiler, runtime and debugger
 if [%1] == [arm64] (
-	devenv objeck.sln /rebuild "Release|ARM64"
+	devenv objeck.sln /rebuild "Release|ARM64" %UI_REDIR%
 )
 
 if [%1] == [x64] (
-	devenv objeck.sln /rebuild "Release|x64"
+	devenv objeck.sln /rebuild "Release|x64" %UI_REDIR%
 )
 
 if errorlevel 1 (
@@ -109,6 +119,7 @@ if errorlevel 1 (
 	echo ============================================================
 	echo  ERROR: objeck.sln build failed - aborting deploy
 	echo ============================================================
+	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 REM Verify build output exists (catches Ctrl+C kills where devenv returns errorlevel 0)
@@ -118,6 +129,7 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: objeck.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 )
@@ -127,17 +139,18 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: objeck.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 )
 
-mkdir %TARGET%\bin
+mkdir %TARGET%\bin %UI_REDIR%
 if [%1] == [arm64] (
-	copy ARM64\Release\*.exe %TARGET%\bin
+	copy ARM64\Release\*.exe %TARGET%\bin %UI_REDIR%
 	REM Cross-compilation: use x64 host mt.exe (ARM64 mt.exe can't run on x64 host)
 	REM WindowsSdkVerBinPath has trailing backslash, e.g., "C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\"
-	"%WindowsSdkVerBinPath%x64\mt.exe" -manifest ..\vm\vs\manifest.xml -outputresource:%TARGET%\bin\obr.exe;1
-	"%WindowsSdkVerBinPath%x64\mt.exe" -manifest ..\vm\vs\manifest.xml -outputresource:%TARGET%\bin\obi.exe;1
+	"%WindowsSdkVerBinPath%x64\mt.exe" -manifest ..\vm\vs\manifest.xml -outputresource:%TARGET%\bin\obr.exe;1 %UI_REDIR%
+	"%WindowsSdkVerBinPath%x64\mt.exe" -manifest ..\vm\vs\manifest.xml -outputresource:%TARGET%\bin\obi.exe;1 %UI_REDIR%
 	REM VCToolsRedistDir is EMPTY on the GitHub ARM64 runner, so this matched
 	REM nothing and copied NOTHING -- silently. Both native libraries then failed
 	REM to load with error 126: OpenCV and ONNX are C++ and import msvcp140.dll,
@@ -148,17 +161,17 @@ if [%1] == [arm64] (
 	REM has no delayed expansion, so a flag set inside these parentheses could not
 	REM be read back here. A second copy over the first is harmless.
 	for /d %%d in ("%VCToolsRedistDir%\arm64\Microsoft.VC*.CRT") do (
-		copy "%%d\vcruntime140.dll" %TARGET%\bin
-		copy "%%d\vcruntime140_1.dll" %TARGET%\bin
-		copy "%%d\msvcp140*.dll" %TARGET%\bin
-		copy "%%d\concrt140.dll" %TARGET%\bin
+		copy "%%d\vcruntime140.dll" %TARGET%\bin %UI_REDIR%
+		copy "%%d\vcruntime140_1.dll" %TARGET%\bin %UI_REDIR%
+		copy "%%d\msvcp140*.dll" %TARGET%\bin %UI_REDIR%
+		copy "%%d\concrt140.dll" %TARGET%\bin %UI_REDIR%
 	)
 	for /d %%v in ("%VCINSTALLDIR%Redist\MSVC\*") do (
 		for /d %%d in ("%%v\arm64\Microsoft.VC*.CRT") do (
-			copy "%%d\vcruntime140.dll" %TARGET%\bin
-			copy "%%d\vcruntime140_1.dll" %TARGET%\bin
-			copy "%%d\msvcp140*.dll" %TARGET%\bin
-			copy "%%d\concrt140.dll" %TARGET%\bin
+			copy "%%d\vcruntime140.dll" %TARGET%\bin %UI_REDIR%
+			copy "%%d\vcruntime140_1.dll" %TARGET%\bin %UI_REDIR%
+			copy "%%d\msvcp140*.dll" %TARGET%\bin %UI_REDIR%
+			copy "%%d\concrt140.dll" %TARGET%\bin %UI_REDIR%
 		)
 	)
 )
@@ -167,17 +180,18 @@ if errorlevel 1 (
 	echo ============================================================
 	echo  ERROR: ARM64 binary copy/manifest step failed - aborting deploy
 	echo ============================================================
+	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 
 if [%1] == [x64] (
-	copy ..\compiler\release\win64\*.exe %TARGET%\bin
-	copy ..\repl\release\win64\*.exe %TARGET%\bin
-	copy ..\vm\release\win64\*.exe %TARGET%\bin
-	copy ..\debugger\release\win64\*.exe %TARGET%\bin
+	copy ..\compiler\release\win64\*.exe %TARGET%\bin %UI_REDIR%
+	copy ..\repl\release\win64\*.exe %TARGET%\bin %UI_REDIR%
+	copy ..\vm\release\win64\*.exe %TARGET%\bin %UI_REDIR%
+	copy ..\debugger\release\win64\*.exe %TARGET%\bin %UI_REDIR%
 	REM Embed manifests AFTER copying binaries
-	mt.exe -manifest ..\vm\vs\manifest.xml -outputresource:%TARGET%\bin\obr.exe;1
-	mt.exe -manifest ..\vm\vs\manifest.xml -outputresource:%TARGET%\bin\obi.exe;1
+	mt.exe -manifest ..\vm\vs\manifest.xml -outputresource:%TARGET%\bin\obr.exe;1 %UI_REDIR%
+	mt.exe -manifest ..\vm\vs\manifest.xml -outputresource:%TARGET%\bin\obi.exe;1 %UI_REDIR%
 	REM VCToolsRedistDir is EMPTY on the GitHub ARM64 runner, so this matched
 	REM nothing and copied NOTHING -- silently. Both native libraries then failed
 	REM to load with error 126: OpenCV and ONNX are C++ and import msvcp140.dll,
@@ -188,17 +202,17 @@ if [%1] == [x64] (
 	REM has no delayed expansion, so a flag set inside these parentheses could not
 	REM be read back here. A second copy over the first is harmless.
 	for /d %%d in ("%VCToolsRedistDir%\x64\Microsoft.VC*.CRT") do (
-		copy "%%d\vcruntime140.dll" %TARGET%\bin
-		copy "%%d\vcruntime140_1.dll" %TARGET%\bin
-		copy "%%d\msvcp140*.dll" %TARGET%\bin
-		copy "%%d\concrt140.dll" %TARGET%\bin
+		copy "%%d\vcruntime140.dll" %TARGET%\bin %UI_REDIR%
+		copy "%%d\vcruntime140_1.dll" %TARGET%\bin %UI_REDIR%
+		copy "%%d\msvcp140*.dll" %TARGET%\bin %UI_REDIR%
+		copy "%%d\concrt140.dll" %TARGET%\bin %UI_REDIR%
 	)
 	for /d %%v in ("%VCINSTALLDIR%Redist\MSVC\*") do (
 		for /d %%d in ("%%v\x64\Microsoft.VC*.CRT") do (
-			copy "%%d\vcruntime140.dll" %TARGET%\bin
-			copy "%%d\vcruntime140_1.dll" %TARGET%\bin
-			copy "%%d\msvcp140*.dll" %TARGET%\bin
-			copy "%%d\concrt140.dll" %TARGET%\bin
+			copy "%%d\vcruntime140.dll" %TARGET%\bin %UI_REDIR%
+			copy "%%d\vcruntime140_1.dll" %TARGET%\bin %UI_REDIR%
+			copy "%%d\msvcp140*.dll" %TARGET%\bin %UI_REDIR%
+			copy "%%d\concrt140.dll" %TARGET%\bin %UI_REDIR%
 		)
 	)
 )
@@ -207,6 +221,7 @@ if errorlevel 1 (
 	echo ============================================================
 	echo  ERROR: x64 binary copy/manifest step failed - aborting deploy
 	echo ============================================================
+	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 
@@ -218,15 +233,17 @@ if not exist %TARGET%\bin\msvcp140.dll (
 	echo ============================================================
 	echo  ERROR: VC++ runtime not deployed to bin - aborting deploy
 	echo ============================================================
+	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 
-copy ..\lib\lame\win\%1\*.dll %TARGET%\bin
+copy ..\lib\lame\win\%1\*.dll %TARGET%\bin %UI_REDIR%
 if errorlevel 1 (
 	echo.
 	echo ============================================================
 	echo  ERROR: lame runtime DLL copy failed - aborting deploy
 	echo ============================================================
+	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 
@@ -234,24 +251,27 @@ REM nghttp2 runtime DLL (required by obr for HTTP/2 support).
 REM Taken from vcpkg so the shipped DLL matches the import library linked
 REM against. The committed copy it replaces was byte-identical to vcpkg's,
 REM having come from there in the first place.
-copy "%VCPKG_DIR%\installed\%VCPKG_TRIPLET%\bin\nghttp2.dll" %TARGET%\bin
+copy "%VCPKG_DIR%\installed\%VCPKG_TRIPLET%\bin\nghttp2.dll" %TARGET%\bin %UI_REDIR%
 if errorlevel 1 (
 	echo.
 	echo ============================================================
 	echo  ERROR: nghttp2 runtime DLL copy failed - aborting deploy
 	echo ============================================================
+	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 
+call "%~dp0ui.cmd" :ui_step "launchers + updater"
 REM native launcher
 if [%1] == [arm64] (
 	cd ..\utils\launcher
-	devenv native_launcher.sln /rebuild "Release|ARM64"
+	devenv native_launcher.sln /rebuild "Release|ARM64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: native_launcher.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "ARM64\Release\obn.exe" (
@@ -259,21 +279,23 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: native_launcher.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy ARM64\Release\obn.exe ..\..\release\%TARGET%\lib\native\misc
-	copy ARM64\Release\obb.exe ..\..\release\%TARGET%\bin
-	copy ..\..\vm\misc\config.prop ..\..\release\%TARGET%\lib\native\misc
+	copy ARM64\Release\obn.exe ..\..\release\%TARGET%\lib\native\misc %UI_REDIR%
+	copy ARM64\Release\obb.exe ..\..\release\%TARGET%\bin %UI_REDIR%
+	copy ..\..\vm\misc\config.prop ..\..\release\%TARGET%\lib\native\misc %UI_REDIR%
 	REM build updater. There is no .sln for this single project, so drive msbuild
 	REM directly -- it is on PATH in a VS Developer Command Prompt and in CI via
 	REM setup-msbuild. obu.vcxproj selects $(DefaultPlatformToolset), so it needs
 	REM no toolset override on either VS2022 or VS2026.
-	msbuild ..\updater\vs\obu.vcxproj /p:Configuration=Release /p:Platform=ARM64 /t:Rebuild /v:minimal /nologo
+	msbuild ..\updater\vs\obu.vcxproj /p:Configuration=Release /p:Platform=ARM64 /t:Rebuild /v:minimal /nologo %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: obu.vcxproj build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "..\updater\vs\ARM64\Release\obu.exe" (
@@ -281,20 +303,22 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: obu.vcxproj build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy ..\updater\vs\ARM64\Release\obu.exe ..\..\release\%TARGET%\bin
+	copy ..\updater\vs\ARM64\Release\obu.exe ..\..\release\%TARGET%\bin %UI_REDIR%
 	cd ..\..\release
 )
 
 if [%1] == [x64] (
 	cd ..\utils\launcher
-	devenv native_launcher.sln /rebuild "Release|x64"
+	devenv native_launcher.sln /rebuild "Release|x64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: native_launcher.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "x64\Release\obn.exe" (
@@ -302,18 +326,20 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: native_launcher.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy x64\Release\obn.exe ..\..\release\%TARGET%\lib\native\misc
-	copy x64\Release\obb.exe ..\..\release\%TARGET%\bin
-	copy ..\..\vm\misc\config.prop ..\..\release\%TARGET%\lib\native\misc
+	copy x64\Release\obn.exe ..\..\release\%TARGET%\lib\native\misc %UI_REDIR%
+	copy x64\Release\obb.exe ..\..\release\%TARGET%\bin %UI_REDIR%
+	copy ..\..\vm\misc\config.prop ..\..\release\%TARGET%\lib\native\misc %UI_REDIR%
 	REM build updater -- see the ARM64 branch above for why this uses msbuild.
-	msbuild ..\updater\vs\obu.vcxproj /p:Configuration=Release /p:Platform=x64 /t:Rebuild /v:minimal /nologo
+	msbuild ..\updater\vs\obu.vcxproj /p:Configuration=Release /p:Platform=x64 /t:Rebuild /v:minimal /nologo %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: obu.vcxproj build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "..\updater\vs\x64\Release\obu.exe" (
@@ -321,62 +347,68 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: obu.vcxproj build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy ..\updater\vs\x64\Release\obu.exe ..\..\release\%TARGET%\bin
+	copy ..\updater\vs\x64\Release\obu.exe ..\..\release\%TARGET%\bin %UI_REDIR%
 	cd ..\..\release
 )
 
 REM libraries
-del /q %TARGET%\bin\a.*
-copy ..\vm\misc\*.pem %TARGET%\lib
+del /q %TARGET%\bin\a.* %UI_REDIR%
+copy ..\vm\misc\*.pem %TARGET%\lib %UI_REDIR%
 
+call "%~dp0ui.cmd" :ui_step "library: crypto"
 REM crypto support (optional - requires mbedtls)
 cd ..\lib\crypto
 
 if [%1] == [arm64] (
-	devenv crypto.sln /rebuild "Release|ARM64"
+	devenv crypto.sln /rebuild "Release|ARM64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: crypto.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if exist ARM64\Release\*.dll (
-		copy ARM64\Release\*.dll ..\..\release\%TARGET%\lib\native
+		copy ARM64\Release\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
 	) else (
 		echo Warning: Crypto library DLL not found - skipping (mbedtls may not be available)
 	)
 )
 
 if [%1] == [x64] (
-	devenv crypto.sln /rebuild "Release|x64"
+	devenv crypto.sln /rebuild "Release|x64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: crypto.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if exist Release\win64\*.dll (
-		copy Release\win64\*.dll ..\..\release\%TARGET%\lib\native
+		copy Release\win64\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
 	) else (
 		echo Warning: Crypto library DLL not found - skipping (mbedtls may not be available)
 	)
 )
 cd ..\..\release
 
+call "%~dp0ui.cmd" :ui_step "library: lame"
 REM lame support
 cd ..\lib\lame
 
 if [%1] == [arm64] (
-	devenv lame.sln /rebuild "Release|ARM64"
+	devenv lame.sln /rebuild "Release|ARM64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: lame.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "ARM64\Release\libobjk_lame.dll" (
@@ -384,18 +416,20 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: lame.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy ARM64\Release\libobjk_lame.dll ..\..\release\%TARGET%\lib\native
+	copy ARM64\Release\libobjk_lame.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
 )
 
 if [%1] == [x64] (
-	devenv lame.sln /rebuild "Release|x64"
+	devenv lame.sln /rebuild "Release|x64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: lame.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "x64\Release\libobjk_lame.dll" (
@@ -403,21 +437,24 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: lame.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy x64\Release\libobjk_lame.dll ..\..\release\%TARGET%\lib\native
+	copy x64\Release\libobjk_lame.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
 )
 cd ..\..\release
 
+call "%~dp0ui.cmd" :ui_step "app launcher"
 REM app
 cd ..\utils\WindowsApp
 if [%1] == [arm64] (
-	devenv AppLauncher.sln /rebuild "Release|ARM64"
+	devenv AppLauncher.sln /rebuild "Release|ARM64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: AppLauncher.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "ARM64\Release\ObLauncher.exe" (
@@ -425,18 +462,20 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: AppLauncher.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy ARM64\Release\*.exe ..\..\release\%TARGET%\app
+	copy ARM64\Release\*.exe ..\..\release\%TARGET%\app %UI_REDIR%
 )
 
 if [%1] == [x64] (
-	devenv AppLauncher.sln /rebuild "Release|x64"
+	devenv AppLauncher.sln /rebuild "Release|x64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: AppLauncher.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "x64\Release\ObLauncher.exe" (
@@ -444,21 +483,24 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: AppLauncher.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy x64\Release\*.exe ..\..\release\%TARGET%\app
+	copy x64\Release\*.exe ..\..\release\%TARGET%\app %UI_REDIR%
 )
 cd ..\..\release
 
+call "%~dp0ui.cmd" :ui_step "library: diags"
 REM diags
 cd ..\lib\diags
 if [%1] == [arm64] (
-	devenv diag.sln /rebuild "Release|ARM64"
+	devenv diag.sln /rebuild "Release|ARM64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: diag.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "vs\Release\ARM64\libobjk_diags.dll" (
@@ -466,18 +508,20 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: diag.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy vs\Release\ARM64\*.dll* ..\..\release\%TARGET%\lib\native
+	copy vs\Release\ARM64\*.dll* ..\..\release\%TARGET%\lib\native %UI_REDIR%
 )
 
 if [%1] == [x64] (
-	devenv diag.sln /rebuild "Release|x64"
+	devenv diag.sln /rebuild "Release|x64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: diag.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "vs\Release\x64\libobjk_diags.dll" (
@@ -485,22 +529,25 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: diag.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy vs\Release\x64\*.dll ..\..\release\%TARGET%\lib\native
+	copy vs\Release\x64\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
 )
 cd ..\..\release
 
 
+call "%~dp0ui.cmd" :ui_step "library: odbc"
 REM odbc support
 cd ..\lib\odbc
 if [%1] == [arm64] (
-	devenv odbc.sln /rebuild "Release|ARM64"
+	devenv odbc.sln /rebuild "Release|ARM64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: odbc.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "ARM64\Release\libobjk_odbc.dll" (
@@ -508,18 +555,20 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: odbc.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy ARM64\Release\*.dll ..\..\release\%TARGET%\lib\native
+	copy ARM64\Release\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
 )
 
 if [%1] == [x64] (
-	devenv odbc.sln /rebuild "Release|x64"
+	devenv odbc.sln /rebuild "Release|x64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: odbc.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "Release\win64\libobjk_odbc.dll" (
@@ -527,21 +576,24 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: odbc.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy Release\win64\*.dll ..\..\release\%TARGET%\lib\native
+	copy Release\win64\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
 )
 cd ..\..\release
 
+call "%~dp0ui.cmd" :ui_step "library: matrix"
 REM matrix support
 cd ..\lib\matrix
 if [%1] == [arm64] (
-	devenv matrix.sln /rebuild "Release|ARM64"
+	devenv matrix.sln /rebuild "Release|ARM64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: matrix.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "Release\ARM64\libobjk_ml.dll" (
@@ -549,18 +601,20 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: matrix.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy Release\ARM64\*.dll ..\..\release\%TARGET%\lib\native
+	copy Release\ARM64\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
 )
 
 if [%1] == [x64] (
-	devenv matrix.sln /rebuild "Release|x64"
+	devenv matrix.sln /rebuild "Release|x64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: matrix.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "Release\x64\libobjk_ml.dll" (
@@ -568,21 +622,24 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: matrix.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy Release\x64\*.dll ..\..\release\%TARGET%\lib\native
+	copy Release\x64\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
 )
 cd ..\..\release
 
+call "%~dp0ui.cmd" :ui_step "library: opencv"
 REM opencv support
 cd ..\lib\opencv
 if [%1] == [arm64] (
-	devenv opencv.sln /rebuild "Release|ARM64"
+	devenv opencv.sln /rebuild "Release|ARM64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: opencv.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "arm64\Release\libobjk_opencv.dll" (
@@ -590,12 +647,13 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: opencv.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy arm64\Release\libobjk_opencv.dll ..\..\release\%TARGET%\lib\native
+	copy arm64\Release\libobjk_opencv.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
 
 	for %%f in (win\arm64\bin\opencv_*4.dll) do (
-		copy /y %%f ..\..\release\%TARGET%\bin
+		copy /y %%f ..\..\release\%TARGET%\bin %UI_REDIR%
 	)
 
 	REM The modular OpenCV build externalises its codecs. Copy every known
@@ -608,12 +666,13 @@ if [%1] == [arm64] (
 )
 
 if [%1] == [x64] (
-	devenv opencv.sln /rebuild "Release|x64"
+	devenv opencv.sln /rebuild "Release|x64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: opencv.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "x64\Release\libobjk_opencv.dll" (
@@ -621,21 +680,23 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: opencv.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy x64\Release\libobjk_opencv.dll ..\..\release\%TARGET%\lib\native
+	copy x64\Release\libobjk_opencv.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
 
 	if exist win\x64\bin\opencv_world4120.dll (
-		copy /y win\x64\bin\opencv_world4120.dll ..\..\release\%TARGET%\bin
+		copy /y win\x64\bin\opencv_world4120.dll ..\..\release\%TARGET%\bin %UI_REDIR%
 	) else (
 		echo Warning: win\x64\bin\opencv_world4120.dll not found - OpenCV runtime unavailable
 	)
 	if exist win\x64\bin\opencv_videoio_ffmpeg4120_64.dll (
-		copy /y win\x64\bin\opencv_videoio_ffmpeg4120_64.dll ..\..\release\%TARGET%\bin
+		copy /y win\x64\bin\opencv_videoio_ffmpeg4120_64.dll ..\..\release\%TARGET%\bin %UI_REDIR%
 	)
 )
 cd ..\..\release
 
+call "%~dp0ui.cmd" :ui_step "library: onnx"
 REM onnx support
 cd ..\lib\onnx
 
@@ -659,6 +720,7 @@ if "%NUGET_EXE%"=="" (
 	echo  ERROR: nuget.exe not found and download failed - aborting deploy
 	echo  Install NuGet CLI: choco install nuget.commandline
 	echo ============================================================
+	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 REM Retry the restore: nuget.org intermittently returns transient errors
@@ -668,13 +730,14 @@ set NUGET_MAX_ATTEMPTS=5
 set NUGET_ATTEMPT=0
 :nuget_restore_retry
 set /a NUGET_ATTEMPT+=1
-"%NUGET_EXE%" restore onnx.sln
+"%NUGET_EXE%" restore onnx.sln %UI_REDIR%
 if not errorlevel 1 goto nuget_restore_ok
 if %NUGET_ATTEMPT% geq %NUGET_MAX_ATTEMPTS% (
 	echo.
 	echo ============================================================
 	echo  ERROR: NuGet restore failed after %NUGET_MAX_ATTEMPTS% attempts - aborting deploy
 	echo ============================================================
+	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 echo NuGet restore attempt %NUGET_ATTEMPT% of %NUGET_MAX_ATTEMPTS% failed ^(transient nuget.org error?^) - retrying in 15s...
@@ -683,12 +746,13 @@ goto nuget_restore_retry
 :nuget_restore_ok
 
 if [%1] == [arm64] (
-	devenv onnx.sln /rebuild "Release-QNN|ARM64"
+	devenv onnx.sln /rebuild "Release-QNN|ARM64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: onnx.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "ARM64\Release-QNN\libobjk_onnx.dll" (
@@ -696,12 +760,13 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: onnx.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy ARM64\Release-QNN\libobjk_onnx.dll ..\..\release\%TARGET%\lib\native
+	copy ARM64\Release-QNN\libobjk_onnx.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
 
 	if exist eq\qnn\win\onnx\arm64\bin (
-		copy /y eq\qnn\win\onnx\arm64\bin\*.dll ..\..\release\%TARGET%\bin
+		copy /y eq\qnn\win\onnx\arm64\bin\*.dll ..\..\release\%TARGET%\bin %UI_REDIR%
 		REM onnxruntime.dll ships COMPRESSED and nothing ever unpacked it, so the
 		REM copy above moved the Qnn and provider DLLs and left the core runtime
 		REM behind. libobjk_onnx.dll imports it, so loading failed with error 126
@@ -712,14 +777,16 @@ if [%1] == [arm64] (
 				echo ============================================================
 				echo  ERROR: 7-Zip not found, cannot unpack onnxruntime.7z - aborting deploy
 				echo ============================================================
+				call "%~dp0ui.cmd" :ui_fail
 				exit /b 1
 			)
-			"%ZIP_EXE%" x -y -o..\..\release\%TARGET%\bin eq\qnn\win\onnx\arm64\bin\onnxruntime.7z
+			"%ZIP_EXE%" x -y -o..\..\release\%TARGET%\bin eq\qnn\win\onnx\arm64\bin\onnxruntime.7z %UI_REDIR%
 			if errorlevel 1 (
 				echo.
 				echo ============================================================
 				echo  ERROR: onnxruntime.7z extraction failed - aborting deploy
 				echo ============================================================
+				call "%~dp0ui.cmd" :ui_fail
 				exit /b 1
 			)
 		)
@@ -732,6 +799,7 @@ if [%1] == [arm64] (
 			echo ============================================================
 			echo  ERROR: onnxruntime.dll missing from bin - aborting deploy
 			echo ============================================================
+			call "%~dp0ui.cmd" :ui_fail
 			exit /b 1
 		)
 	) else (
@@ -739,17 +807,19 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: ONNX QNN runtime tree not found for arm64 - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 )
 
 if [%1] == [x64] (
-	devenv onnx.sln /rebuild "Release-DML|x64"
+	devenv onnx.sln /rebuild "Release-DML|x64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: onnx.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "x64\Release-DML\libobjk_onnx.dll" (
@@ -757,12 +827,13 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: onnx.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy x64\Release-DML\libobjk_onnx.dll ..\..\release\%TARGET%\lib\native
+	copy x64\Release-DML\libobjk_onnx.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
 
 	if exist packages\Microsoft.ML.OnnxRuntime.DirectML.1.22.1\runtimes\win-x64\native (
-		copy /y packages\Microsoft.ML.OnnxRuntime.DirectML.1.22.1\runtimes\win-x64\native\*.dll ..\..\release\%TARGET%\bin
+		copy /y packages\Microsoft.ML.OnnxRuntime.DirectML.1.22.1\runtimes\win-x64\native\*.dll ..\..\release\%TARGET%\bin %UI_REDIR%
 	) else (
 		echo Warning: OnnxRuntime.DirectML nuget packages not found - ONNX runtime unavailable
 	)
@@ -778,7 +849,7 @@ if [%1] == [x64] (
 	) else (
 		if exist packages\Microsoft.AI.DirectML.1.15.4\bin\x64-win\DirectML.dll (
 			echo No OS DirectML.dll - shipping the vendored redistributable
-			copy /y packages\Microsoft.AI.DirectML.1.15.4\bin\x64-win\DirectML.dll ..\..\release\%TARGET%\bin
+			copy /y packages\Microsoft.AI.DirectML.1.15.4\bin\x64-win\DirectML.dll ..\..\release\%TARGET%\bin %UI_REDIR%
 		) else (
 			echo Warning: no OS DirectML.dll and no vendored package - GPU inference unavailable
 		)
@@ -786,16 +857,18 @@ if [%1] == [x64] (
 )
 cd ..\..\release
 
+call "%~dp0ui.cmd" :ui_step "library: sdl"
 REM sdl support
 cd ..\lib\sdl
 if [%1] == [arm64] (
 	REM sdl
-	devenv sdl\sdl.sln /rebuild "Release|ARM64"
+	devenv sdl\sdl.sln /rebuild "Release|ARM64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: sdl.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "sdl\Release\arm64\libobjk_sdl.dll" (
@@ -803,10 +876,11 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: sdl.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy sdl\Release\arm64\*.dll ..\..\release\%TARGET%\lib\native
-	copy lib\fonts\*.ttf ..\..\release\%TARGET%\lib\sdl\fonts
+	copy sdl\Release\arm64\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
+	copy lib\fonts\*.ttf ..\..\release\%TARGET%\lib\sdl\fonts %UI_REDIR%
 	REM SDL2's own runtime DLLs go to bin, NOT next to libobjk_sdl.dll.
 	REM Windows resolves a dynamically-loaded DLL's imports against the
 	REM EXECUTABLE's directory; the directory holding the DLL itself is never
@@ -815,17 +889,18 @@ if [%1] == [arm64] (
 	REM Left in lib\sdl they resolve only when something has put lib\sdl on
 	REM PATH, and nothing shipped to a user does: the MSI puts only bin on
 	REM PATH. lib\sdl\fonts stays where it is -- Overlay loads it by path.
-	copy lib\arm64\*.dll ..\..\release\%TARGET%\bin
+	copy lib\arm64\*.dll ..\..\release\%TARGET%\bin %UI_REDIR%
 )
 
 if [%1] == [x64] (
 	REM sdl
-	devenv sdl\sdl.sln /rebuild "Release|x64"
+	devenv sdl\sdl.sln /rebuild "Release|x64" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: sdl.sln build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "sdl\Release\x64\libobjk_sdl.dll" (
@@ -833,96 +908,105 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: sdl.sln build incomplete - was the build interrupted?
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy sdl\Release\x64\*.dll ..\..\release\%TARGET%\lib\native
-	copy lib\fonts\*.ttf ..\..\release\%TARGET%\lib\sdl\fonts
+	copy sdl\Release\x64\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
+	copy lib\fonts\*.ttf ..\..\release\%TARGET%\lib\sdl\fonts %UI_REDIR%
 	REM bin, not lib\sdl -- see the note on the arm64 copy above.
-	copy lib\x64\*.dll ..\..\release\%TARGET%\bin
+	copy lib\x64\*.dll ..\..\release\%TARGET%\bin %UI_REDIR%
 )
 cd ..\..\release
 
+call "%~dp0ui.cmd" :ui_step "examples"
 REM copy examples
-mkdir %TARGET%\examples\
+mkdir %TARGET%\examples\ %UI_REDIR%
 
-mkdir %TARGET%\examples\media\
-del  /s /q ..\..\programs\*.obe
-xcopy /e ..\..\programs\deploy\*.obs %TARGET%\examples\
-copy ..\..\programs\deploy\README.md %TARGET%\examples\
+mkdir %TARGET%\examples\media\ %UI_REDIR%
+del  /s /q ..\..\programs\*.obe %UI_REDIR%
+xcopy /e ..\..\programs\deploy\*.obs %TARGET%\examples\ %UI_REDIR%
+copy ..\..\programs\deploy\README.md %TARGET%\examples\ %UI_REDIR%
 REM The OpenGL examples live in programs\examples rather than programs\deploy,
 REM so no distribution ever carried them. They find the bundled font relative to
 REM either bin or here, so they run from where they land.
-mkdir %TARGET%\examples\opengl
-copy ..\..\programs\examples\gl_*.obs %TARGET%\examples\opengl
-copy ..\..\programs\examples\cube_gl.obs %TARGET%\examples\opengl
-copy ..\..\programs\examples\gl_crystal.obj %TARGET%\examples\opengl
-xcopy /e ..\..\programs\deploy\media\*.png %TARGET%\examples\media\
-xcopy /e ..\..\programs\deploy\media\*.wav %TARGET%\examples\media\
-xcopy /e ..\..\programs\deploy\data\* %TARGET%\examples\data\
+mkdir %TARGET%\examples\opengl %UI_REDIR%
+copy ..\..\programs\examples\gl_*.obs %TARGET%\examples\opengl %UI_REDIR%
+copy ..\..\programs\examples\cube_gl.obs %TARGET%\examples\opengl %UI_REDIR%
+copy ..\..\programs\examples\gl_crystal.obj %TARGET%\examples\opengl %UI_REDIR%
+xcopy /e ..\..\programs\deploy\media\*.png %TARGET%\examples\media\ %UI_REDIR%
+xcopy /e ..\..\programs\deploy\media\*.wav %TARGET%\examples\media\ %UI_REDIR%
+xcopy /e ..\..\programs\deploy\data\* %TARGET%\examples\data\ %UI_REDIR%
 
 REM copy ONNX demo programs
-copy ..\..\programs\frameworks\opencv_onnx\demo_phi3*.obs %TARGET%\examples\
+copy ..\..\programs\frameworks\opencv_onnx\demo_phi3*.obs %TARGET%\examples\ %UI_REDIR%
 
 REM copy ONNX models (phi3 text and phi3v vision) if downloaded
 set MODELS_SRC=..\..\programs\frameworks\opencv_onnx\data\models
 if exist "%MODELS_SRC%\phi3\directml\directml-int4-awq-block-128\model.onnx" (
-	mkdir %TARGET%\examples\data\models\phi3
-	xcopy /y /q "%MODELS_SRC%\phi3\directml\directml-int4-awq-block-128\*.onnx" %TARGET%\examples\data\models\phi3\
-	xcopy /y /q "%MODELS_SRC%\phi3\directml\directml-int4-awq-block-128\*.onnx.data" %TARGET%\examples\data\models\phi3\
-	xcopy /y /q "%MODELS_SRC%\phi3\directml\directml-int4-awq-block-128\*.json" %TARGET%\examples\data\models\phi3\
+	mkdir %TARGET%\examples\data\models\phi3 %UI_REDIR%
+	xcopy /y /q "%MODELS_SRC%\phi3\directml\directml-int4-awq-block-128\*.onnx" %TARGET%\examples\data\models\phi3\ %UI_REDIR%
+	xcopy /y /q "%MODELS_SRC%\phi3\directml\directml-int4-awq-block-128\*.onnx.data" %TARGET%\examples\data\models\phi3\ %UI_REDIR%
+	xcopy /y /q "%MODELS_SRC%\phi3\directml\directml-int4-awq-block-128\*.json" %TARGET%\examples\data\models\phi3\ %UI_REDIR%
 )
 if exist "%MODELS_SRC%\phi3v\directml-int4-rtn-block-32\model.onnx" (
-	mkdir %TARGET%\examples\data\models\phi3v
-	xcopy /y /q "%MODELS_SRC%\phi3v\directml-int4-rtn-block-32\*.onnx" %TARGET%\examples\data\models\phi3v\
-	xcopy /y /q "%MODELS_SRC%\phi3v\directml-int4-rtn-block-32\*.onnx.data" %TARGET%\examples\data\models\phi3v\
-	xcopy /y /q "%MODELS_SRC%\phi3v\directml-int4-rtn-block-32\*.json" %TARGET%\examples\data\models\phi3v\
+	mkdir %TARGET%\examples\data\models\phi3v %UI_REDIR%
+	xcopy /y /q "%MODELS_SRC%\phi3v\directml-int4-rtn-block-32\*.onnx" %TARGET%\examples\data\models\phi3v\ %UI_REDIR%
+	xcopy /y /q "%MODELS_SRC%\phi3v\directml-int4-rtn-block-32\*.onnx.data" %TARGET%\examples\data\models\phi3v\ %UI_REDIR%
+	xcopy /y /q "%MODELS_SRC%\phi3v\directml-int4-rtn-block-32\*.json" %TARGET%\examples\data\models\phi3v\ %UI_REDIR%
 )
 
+call "%~dp0ui.cmd" :ui_step "documentation"
 REM build and update docs
-mkdir %TARGET%\doc
-mkdir %TARGET%\doc\syntax
-xcopy /e ..\..\docs\syntax\* %TARGET%\doc\syntax
+mkdir %TARGET%\doc %UI_REDIR%
+mkdir %TARGET%\doc\syntax %UI_REDIR%
+xcopy /e ..\..\docs\syntax\* %TARGET%\doc\syntax %UI_REDIR%
 
 REM update and process readme
-mkdir %TARGET%\style
-copy ..\..\docs\style\*.css %TARGET%\style
-copy ..\lib\code_doc\templates\resources\*.png %TARGET%\style
-copy ..\..\docs\readme.html %TARGET%
-copy ..\..\LICENSE %TARGET%
+mkdir %TARGET%\style %UI_REDIR%
+copy ..\..\docs\style\*.css %TARGET%\style %UI_REDIR%
+copy ..\lib\code_doc\templates\resources\*.png %TARGET%\style %UI_REDIR%
+copy ..\..\docs\readme.html %TARGET% %UI_REDIR%
+copy ..\..\LICENSE %TARGET% %UI_REDIR%
 
 REM copy docs (skip for ARM64 cross-compilation - can't run ARM64 binaries on x64 host)
 if [%1] == [x64] (
-	call "%~dp0code_doc64.cmd" %1 deploy
-	rmdir /s /q %1
+	call "%~dp0code_doc64.cmd" %1 deploy %UI_REDIR%
+	if errorlevel 1 call "%~dp0ui.cmd" :ui_warn "API docs step exited with an error - the deploy continues, as it always has"
+	rmdir /s /q %1 %UI_REDIR%
 ) else (
 	echo Skipping code_doc for ARM64 cross-compilation - using pre-built API docs
-	mkdir %TARGET%\doc\api
-	powershell -Command "Expand-Archive -Path '..\..\docs\api.zip' -DestinationPath '%TARGET%\doc' -Force"
+	mkdir %TARGET%\doc\api %UI_REDIR%
+	powershell -Command "Expand-Archive -Path '..\..\docs\api.zip' -DestinationPath '%TARGET%\doc' -Force" %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: API docs extraction failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 )
 
+call "%~dp0ui.cmd" :ui_step "verify native libraries"
 REM Verify the native-library closure before producing an artifact. x64 can use
 REM LoadLibrary directly. ARM64 is cross-compiled on an x64 runner, so the script
 REM uses dumpbin to walk imports and require every non-system dependency locally.
-powershell.exe -executionpolicy remotesigned -file verify_native_libs.ps1 -DeployDir %TARGET% -TargetArchitecture %1
+powershell.exe -executionpolicy remotesigned -file verify_native_libs.ps1 -DeployDir %TARGET% -TargetArchitecture %1 %UI_REDIR%
 if errorlevel 1 (
 	echo.
 	echo ============================================================
 	echo  ERROR: a native library in %TARGET% cannot load - aborting deploy
 	echo ============================================================
+	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 
 :installer
 
 REM finished
+if [%2] NEQ [deploy] call "%~dp0ui.cmd" :ui_ok "deploy complete"
 if [%2] NEQ [deploy] goto end
+	call "%~dp0ui.cmd" :ui_step "package: msi + zip"
 	if [%1] == [arm64] (
 		set INSTALL_TARGET=objeck-lang-arm64
 	)
@@ -931,28 +1015,28 @@ if [%2] NEQ [deploy] goto end
 		set INSTALL_TARGET=objeck-lang-x64
 	)
 
-	rmdir /q /s %TARGET%\examples\doc
+	rmdir /q /s %TARGET%\examples\doc %UI_REDIR%
 
 	REM Create directory structure for MSI build (files must be in release-x64 or release-arm64)
 	REM Use repo-relative path (..\..\Objeck-Build) to match MSI project expectations
 	if [%1] == [arm64] (
-		rmdir /q /s ..\..\Objeck-Build\release-arm64
-		mkdir ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%
-		xcopy /e %TARGET% ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%
-		mkdir ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%\doc\icons
-		copy ..\..\docs\images\setup_icons\*.ico ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%\doc\icons
-		copy ..\..\docs\images\setup_icons\*.jpg ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%\doc\icons
-		copy ..\..\docs\eula.rtf ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%\doc
+		rmdir /q /s ..\..\Objeck-Build\release-arm64 %UI_REDIR%
+		mkdir ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET% %UI_REDIR%
+		xcopy /e %TARGET% ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET% %UI_REDIR%
+		mkdir ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%\doc\icons %UI_REDIR%
+		copy ..\..\docs\images\setup_icons\*.ico ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%\doc\icons %UI_REDIR%
+		copy ..\..\docs\images\setup_icons\*.jpg ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%\doc\icons %UI_REDIR%
+		copy ..\..\docs\eula.rtf ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%\doc %UI_REDIR%
 	)
 
 	if [%1] == [x64] (
-		rmdir /q /s ..\..\Objeck-Build\release-x64
-		mkdir ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%
-		xcopy /e %TARGET% ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%
-		mkdir ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%\doc\icons
-		copy ..\..\docs\images\setup_icons\*.ico ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%\doc\icons
-		copy ..\..\docs\images\setup_icons\*.jpg ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%\doc\icons
-		copy ..\..\docs\eula.rtf ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%\doc
+		rmdir /q /s ..\..\Objeck-Build\release-x64 %UI_REDIR%
+		mkdir ..\..\Objeck-Build\release-x64\%INSTALL_TARGET% %UI_REDIR%
+		xcopy /e %TARGET% ..\..\Objeck-Build\release-x64\%INSTALL_TARGET% %UI_REDIR%
+		mkdir ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%\doc\icons %UI_REDIR%
+		copy ..\..\docs\images\setup_icons\*.ico ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%\doc\icons %UI_REDIR%
+		copy ..\..\docs\images\setup_icons\*.jpg ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%\doc\icons %UI_REDIR%
+		copy ..\..\docs\eula.rtf ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%\doc %UI_REDIR%
 	)
 
 	REM Build MSI installer with WiX v5
@@ -975,12 +1059,13 @@ if [%2] NEQ [deploy] goto end
 		-d Platform=%WIX_ARCH% -d Version=0.0.0 ^
 		-d SourceDir=%WIX_SOURCEDIR% ^
 		-ext WixToolset.UI.wixext -ext WixToolset.Util.wixext ^
-		..\utils\setup\objeck.wxs
+		..\utils\setup\objeck.wxs %UI_REDIR%
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: WiX MSI build failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 
@@ -994,16 +1079,18 @@ if [%2] NEQ [deploy] goto end
 
 	REM Create ZIP
 	if [%1] == [arm64] (
-		powershell -Command "Compress-Archive -Path '..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%' -DestinationPath '..\..\Objeck-Build\release-arm64\objeck-windows-arm64_0.0.0.zip' -Force"
+		powershell -Command "Compress-Archive -Path '..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%' -DestinationPath '..\..\Objeck-Build\release-arm64\objeck-windows-arm64_0.0.0.zip' -Force" %UI_REDIR%
 	)
 	if [%1] == [x64] (
-		powershell -Command "Compress-Archive -Path '..\..\Objeck-Build\release-x64\%INSTALL_TARGET%' -DestinationPath '..\..\Objeck-Build\release-x64\objeck-windows-x64_0.0.0.zip' -Force"
+		powershell -Command "Compress-Archive -Path '..\..\Objeck-Build\release-x64\%INSTALL_TARGET%' -DestinationPath '..\..\Objeck-Build\release-x64\objeck-windows-x64_0.0.0.zip' -Force" %UI_REDIR%
 	)
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: ZIP creation failed - aborting deploy
 		echo ============================================================
+		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
+call "%~dp0ui.cmd" :ui_ok "deploy complete, packaged"
 :end

--- a/core/release/deploy_windows.cmd
+++ b/core/release/deploy_windows.cmd
@@ -1,3 +1,17 @@
+@REM Presentation lives in ui.cmd and ui.ps1. Run by hand, this script re-runs
+@REM itself under ui.ps1, which draws live progress while the build writes to a
+@REM log -- cmd cannot redraw anything while devenv is running. In CI, or with
+@REM -v, output streams as it always has. UI_TOTAL must equal the ui_step calls
+@REM on the path taken: one per stage below, plus packaging when %2 is deploy.
+@REM Every line added for the UI starts with @, so an echo-on log is unchanged.
+@set UI_TOTAL=15
+@if [%2] == [deploy] set UI_TOTAL=16
+@call "%~dp0ui.cmd" :ui_init %1 %2 %3
+@if not "%UI_RELAUNCH%"=="1" goto ui_ready
+@powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0ui.ps1" %*
+@exit /b %errorlevel%
+:ui_ready
+
 REM clean up
 
 if not [%1]==[x64] if not [%1]==[arm64] (
@@ -9,13 +23,6 @@ IF "%VCINSTALLDIR%"=="" (
 	echo Could not Visual Studio build environment
 	goto end
 )
-
-REM Presentation -- banner, stage progress, quiet tool output -- lives in
-REM ui.cmd. UI_TOTAL must equal the ui_step calls on the path taken: one per
-REM stage below, plus the packaging stage when %2 is deploy.
-set UI_TOTAL=15
-if [%2] == [deploy] set UI_TOTAL=16
-call "%~dp0ui.cmd" :ui_init %1 %2 %3
 
 REM mbedTLS and nghttp2 come from vcpkg, for both x64 and ARM64.
 REM
@@ -78,40 +85,39 @@ if [%1] == [x64] (
 	set TARGET=deploy-x64
 )
 
-call "%~dp0ui.cmd" :ui_step "clean tree + version stamp"
+@call "%~dp0ui.cmd" :ui_step "clean tree + version stamp"
 REM debug installer
 REM goto installer
 
-rmdir /s /q %TARGET% %UI_REDIR%
-mkdir %TARGET% %UI_REDIR%
-mkdir %TARGET%\app %UI_REDIR%
-mkdir %TARGET%\lib %UI_REDIR%
-mkdir %TARGET%\lib\sdl %UI_REDIR%
-mkdir %TARGET%\lib\sdl\fonts %UI_REDIR%
-mkdir %TARGET%\lib\native %UI_REDIR%
-mkdir %TARGET%\lib\native\misc %UI_REDIR%
-copy ..\lib\*.obl %TARGET%\lib %UI_REDIR%
-copy ..\lib\*.ini %TARGET%\lib %UI_REDIR%
+rmdir /s /q %TARGET%
+mkdir %TARGET%
+mkdir %TARGET%\app
+mkdir %TARGET%\lib
+mkdir %TARGET%\lib\sdl
+mkdir %TARGET%\lib\sdl\fonts
+mkdir %TARGET%\lib\native
+mkdir %TARGET%\lib\native\misc
+copy ..\lib\*.obl %TARGET%\lib
+copy ..\lib\*.ini %TARGET%\lib
 
 REM update version information
-powershell.exe -executionpolicy remotesigned -file  update_version.ps1 %UI_REDIR%
+powershell.exe -executionpolicy remotesigned -file  update_version.ps1
 if errorlevel 1 (
 	echo.
 	echo ============================================================
 	echo  ERROR: update_version.ps1 failed - aborting deploy
 	echo ============================================================
-	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 
-call "%~dp0ui.cmd" :ui_step "compiler, vm, debugger, repl"
+@call "%~dp0ui.cmd" :ui_step "compiler, vm, debugger, repl"
 REM compiler, runtime and debugger
 if [%1] == [arm64] (
-	devenv objeck.sln /rebuild "Release|ARM64" %UI_REDIR%
+	devenv objeck.sln /rebuild "Release|ARM64"
 )
 
 if [%1] == [x64] (
-	devenv objeck.sln /rebuild "Release|x64" %UI_REDIR%
+	devenv objeck.sln /rebuild "Release|x64"
 )
 
 if errorlevel 1 (
@@ -119,7 +125,6 @@ if errorlevel 1 (
 	echo ============================================================
 	echo  ERROR: objeck.sln build failed - aborting deploy
 	echo ============================================================
-	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 REM Verify build output exists (catches Ctrl+C kills where devenv returns errorlevel 0)
@@ -129,7 +134,6 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: objeck.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 )
@@ -139,18 +143,17 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: objeck.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 )
 
-mkdir %TARGET%\bin %UI_REDIR%
+mkdir %TARGET%\bin
 if [%1] == [arm64] (
-	copy ARM64\Release\*.exe %TARGET%\bin %UI_REDIR%
+	copy ARM64\Release\*.exe %TARGET%\bin
 	REM Cross-compilation: use x64 host mt.exe (ARM64 mt.exe can't run on x64 host)
 	REM WindowsSdkVerBinPath has trailing backslash, e.g., "C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\"
-	"%WindowsSdkVerBinPath%x64\mt.exe" -manifest ..\vm\vs\manifest.xml -outputresource:%TARGET%\bin\obr.exe;1 %UI_REDIR%
-	"%WindowsSdkVerBinPath%x64\mt.exe" -manifest ..\vm\vs\manifest.xml -outputresource:%TARGET%\bin\obi.exe;1 %UI_REDIR%
+	"%WindowsSdkVerBinPath%x64\mt.exe" -manifest ..\vm\vs\manifest.xml -outputresource:%TARGET%\bin\obr.exe;1
+	"%WindowsSdkVerBinPath%x64\mt.exe" -manifest ..\vm\vs\manifest.xml -outputresource:%TARGET%\bin\obi.exe;1
 	REM VCToolsRedistDir is EMPTY on the GitHub ARM64 runner, so this matched
 	REM nothing and copied NOTHING -- silently. Both native libraries then failed
 	REM to load with error 126: OpenCV and ONNX are C++ and import msvcp140.dll,
@@ -161,17 +164,17 @@ if [%1] == [arm64] (
 	REM has no delayed expansion, so a flag set inside these parentheses could not
 	REM be read back here. A second copy over the first is harmless.
 	for /d %%d in ("%VCToolsRedistDir%\arm64\Microsoft.VC*.CRT") do (
-		copy "%%d\vcruntime140.dll" %TARGET%\bin %UI_REDIR%
-		copy "%%d\vcruntime140_1.dll" %TARGET%\bin %UI_REDIR%
-		copy "%%d\msvcp140*.dll" %TARGET%\bin %UI_REDIR%
-		copy "%%d\concrt140.dll" %TARGET%\bin %UI_REDIR%
+		copy "%%d\vcruntime140.dll" %TARGET%\bin
+		copy "%%d\vcruntime140_1.dll" %TARGET%\bin
+		copy "%%d\msvcp140*.dll" %TARGET%\bin
+		copy "%%d\concrt140.dll" %TARGET%\bin
 	)
 	for /d %%v in ("%VCINSTALLDIR%Redist\MSVC\*") do (
 		for /d %%d in ("%%v\arm64\Microsoft.VC*.CRT") do (
-			copy "%%d\vcruntime140.dll" %TARGET%\bin %UI_REDIR%
-			copy "%%d\vcruntime140_1.dll" %TARGET%\bin %UI_REDIR%
-			copy "%%d\msvcp140*.dll" %TARGET%\bin %UI_REDIR%
-			copy "%%d\concrt140.dll" %TARGET%\bin %UI_REDIR%
+			copy "%%d\vcruntime140.dll" %TARGET%\bin
+			copy "%%d\vcruntime140_1.dll" %TARGET%\bin
+			copy "%%d\msvcp140*.dll" %TARGET%\bin
+			copy "%%d\concrt140.dll" %TARGET%\bin
 		)
 	)
 )
@@ -180,18 +183,17 @@ if errorlevel 1 (
 	echo ============================================================
 	echo  ERROR: ARM64 binary copy/manifest step failed - aborting deploy
 	echo ============================================================
-	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 
 if [%1] == [x64] (
-	copy ..\compiler\release\win64\*.exe %TARGET%\bin %UI_REDIR%
-	copy ..\repl\release\win64\*.exe %TARGET%\bin %UI_REDIR%
-	copy ..\vm\release\win64\*.exe %TARGET%\bin %UI_REDIR%
-	copy ..\debugger\release\win64\*.exe %TARGET%\bin %UI_REDIR%
+	copy ..\compiler\release\win64\*.exe %TARGET%\bin
+	copy ..\repl\release\win64\*.exe %TARGET%\bin
+	copy ..\vm\release\win64\*.exe %TARGET%\bin
+	copy ..\debugger\release\win64\*.exe %TARGET%\bin
 	REM Embed manifests AFTER copying binaries
-	mt.exe -manifest ..\vm\vs\manifest.xml -outputresource:%TARGET%\bin\obr.exe;1 %UI_REDIR%
-	mt.exe -manifest ..\vm\vs\manifest.xml -outputresource:%TARGET%\bin\obi.exe;1 %UI_REDIR%
+	mt.exe -manifest ..\vm\vs\manifest.xml -outputresource:%TARGET%\bin\obr.exe;1
+	mt.exe -manifest ..\vm\vs\manifest.xml -outputresource:%TARGET%\bin\obi.exe;1
 	REM VCToolsRedistDir is EMPTY on the GitHub ARM64 runner, so this matched
 	REM nothing and copied NOTHING -- silently. Both native libraries then failed
 	REM to load with error 126: OpenCV and ONNX are C++ and import msvcp140.dll,
@@ -202,17 +204,17 @@ if [%1] == [x64] (
 	REM has no delayed expansion, so a flag set inside these parentheses could not
 	REM be read back here. A second copy over the first is harmless.
 	for /d %%d in ("%VCToolsRedistDir%\x64\Microsoft.VC*.CRT") do (
-		copy "%%d\vcruntime140.dll" %TARGET%\bin %UI_REDIR%
-		copy "%%d\vcruntime140_1.dll" %TARGET%\bin %UI_REDIR%
-		copy "%%d\msvcp140*.dll" %TARGET%\bin %UI_REDIR%
-		copy "%%d\concrt140.dll" %TARGET%\bin %UI_REDIR%
+		copy "%%d\vcruntime140.dll" %TARGET%\bin
+		copy "%%d\vcruntime140_1.dll" %TARGET%\bin
+		copy "%%d\msvcp140*.dll" %TARGET%\bin
+		copy "%%d\concrt140.dll" %TARGET%\bin
 	)
 	for /d %%v in ("%VCINSTALLDIR%Redist\MSVC\*") do (
 		for /d %%d in ("%%v\x64\Microsoft.VC*.CRT") do (
-			copy "%%d\vcruntime140.dll" %TARGET%\bin %UI_REDIR%
-			copy "%%d\vcruntime140_1.dll" %TARGET%\bin %UI_REDIR%
-			copy "%%d\msvcp140*.dll" %TARGET%\bin %UI_REDIR%
-			copy "%%d\concrt140.dll" %TARGET%\bin %UI_REDIR%
+			copy "%%d\vcruntime140.dll" %TARGET%\bin
+			copy "%%d\vcruntime140_1.dll" %TARGET%\bin
+			copy "%%d\msvcp140*.dll" %TARGET%\bin
+			copy "%%d\concrt140.dll" %TARGET%\bin
 		)
 	)
 )
@@ -221,7 +223,6 @@ if errorlevel 1 (
 	echo ============================================================
 	echo  ERROR: x64 binary copy/manifest step failed - aborting deploy
 	echo ============================================================
-	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 
@@ -233,17 +234,15 @@ if not exist %TARGET%\bin\msvcp140.dll (
 	echo ============================================================
 	echo  ERROR: VC++ runtime not deployed to bin - aborting deploy
 	echo ============================================================
-	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 
-copy ..\lib\lame\win\%1\*.dll %TARGET%\bin %UI_REDIR%
+copy ..\lib\lame\win\%1\*.dll %TARGET%\bin
 if errorlevel 1 (
 	echo.
 	echo ============================================================
 	echo  ERROR: lame runtime DLL copy failed - aborting deploy
 	echo ============================================================
-	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 
@@ -251,27 +250,25 @@ REM nghttp2 runtime DLL (required by obr for HTTP/2 support).
 REM Taken from vcpkg so the shipped DLL matches the import library linked
 REM against. The committed copy it replaces was byte-identical to vcpkg's,
 REM having come from there in the first place.
-copy "%VCPKG_DIR%\installed\%VCPKG_TRIPLET%\bin\nghttp2.dll" %TARGET%\bin %UI_REDIR%
+copy "%VCPKG_DIR%\installed\%VCPKG_TRIPLET%\bin\nghttp2.dll" %TARGET%\bin
 if errorlevel 1 (
 	echo.
 	echo ============================================================
 	echo  ERROR: nghttp2 runtime DLL copy failed - aborting deploy
 	echo ============================================================
-	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 
-call "%~dp0ui.cmd" :ui_step "launchers + updater"
+@call "%~dp0ui.cmd" :ui_step "launchers + updater"
 REM native launcher
 if [%1] == [arm64] (
 	cd ..\utils\launcher
-	devenv native_launcher.sln /rebuild "Release|ARM64" %UI_REDIR%
+	devenv native_launcher.sln /rebuild "Release|ARM64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: native_launcher.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "ARM64\Release\obn.exe" (
@@ -279,23 +276,21 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: native_launcher.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy ARM64\Release\obn.exe ..\..\release\%TARGET%\lib\native\misc %UI_REDIR%
-	copy ARM64\Release\obb.exe ..\..\release\%TARGET%\bin %UI_REDIR%
-	copy ..\..\vm\misc\config.prop ..\..\release\%TARGET%\lib\native\misc %UI_REDIR%
+	copy ARM64\Release\obn.exe ..\..\release\%TARGET%\lib\native\misc
+	copy ARM64\Release\obb.exe ..\..\release\%TARGET%\bin
+	copy ..\..\vm\misc\config.prop ..\..\release\%TARGET%\lib\native\misc
 	REM build updater. There is no .sln for this single project, so drive msbuild
 	REM directly -- it is on PATH in a VS Developer Command Prompt and in CI via
 	REM setup-msbuild. obu.vcxproj selects $(DefaultPlatformToolset), so it needs
 	REM no toolset override on either VS2022 or VS2026.
-	msbuild ..\updater\vs\obu.vcxproj /p:Configuration=Release /p:Platform=ARM64 /t:Rebuild /v:minimal /nologo %UI_REDIR%
+	msbuild ..\updater\vs\obu.vcxproj /p:Configuration=Release /p:Platform=ARM64 /t:Rebuild /v:minimal /nologo
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: obu.vcxproj build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "..\updater\vs\ARM64\Release\obu.exe" (
@@ -303,22 +298,20 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: obu.vcxproj build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy ..\updater\vs\ARM64\Release\obu.exe ..\..\release\%TARGET%\bin %UI_REDIR%
+	copy ..\updater\vs\ARM64\Release\obu.exe ..\..\release\%TARGET%\bin
 	cd ..\..\release
 )
 
 if [%1] == [x64] (
 	cd ..\utils\launcher
-	devenv native_launcher.sln /rebuild "Release|x64" %UI_REDIR%
+	devenv native_launcher.sln /rebuild "Release|x64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: native_launcher.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "x64\Release\obn.exe" (
@@ -326,20 +319,18 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: native_launcher.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy x64\Release\obn.exe ..\..\release\%TARGET%\lib\native\misc %UI_REDIR%
-	copy x64\Release\obb.exe ..\..\release\%TARGET%\bin %UI_REDIR%
-	copy ..\..\vm\misc\config.prop ..\..\release\%TARGET%\lib\native\misc %UI_REDIR%
+	copy x64\Release\obn.exe ..\..\release\%TARGET%\lib\native\misc
+	copy x64\Release\obb.exe ..\..\release\%TARGET%\bin
+	copy ..\..\vm\misc\config.prop ..\..\release\%TARGET%\lib\native\misc
 	REM build updater -- see the ARM64 branch above for why this uses msbuild.
-	msbuild ..\updater\vs\obu.vcxproj /p:Configuration=Release /p:Platform=x64 /t:Rebuild /v:minimal /nologo %UI_REDIR%
+	msbuild ..\updater\vs\obu.vcxproj /p:Configuration=Release /p:Platform=x64 /t:Rebuild /v:minimal /nologo
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: obu.vcxproj build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "..\updater\vs\x64\Release\obu.exe" (
@@ -347,68 +338,64 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: obu.vcxproj build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy ..\updater\vs\x64\Release\obu.exe ..\..\release\%TARGET%\bin %UI_REDIR%
+	copy ..\updater\vs\x64\Release\obu.exe ..\..\release\%TARGET%\bin
 	cd ..\..\release
 )
 
 REM libraries
-del /q %TARGET%\bin\a.* %UI_REDIR%
-copy ..\vm\misc\*.pem %TARGET%\lib %UI_REDIR%
+del /q %TARGET%\bin\a.*
+copy ..\vm\misc\*.pem %TARGET%\lib
 
-call "%~dp0ui.cmd" :ui_step "library: crypto"
+@call "%~dp0ui.cmd" :ui_step "library: crypto"
 REM crypto support (optional - requires mbedtls)
 cd ..\lib\crypto
 
 if [%1] == [arm64] (
-	devenv crypto.sln /rebuild "Release|ARM64" %UI_REDIR%
+	devenv crypto.sln /rebuild "Release|ARM64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: crypto.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if exist ARM64\Release\*.dll (
-		copy ARM64\Release\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
+		copy ARM64\Release\*.dll ..\..\release\%TARGET%\lib\native
 	) else (
 		echo Warning: Crypto library DLL not found - skipping (mbedtls may not be available)
 	)
 )
 
 if [%1] == [x64] (
-	devenv crypto.sln /rebuild "Release|x64" %UI_REDIR%
+	devenv crypto.sln /rebuild "Release|x64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: crypto.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if exist Release\win64\*.dll (
-		copy Release\win64\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
+		copy Release\win64\*.dll ..\..\release\%TARGET%\lib\native
 	) else (
 		echo Warning: Crypto library DLL not found - skipping (mbedtls may not be available)
 	)
 )
 cd ..\..\release
 
-call "%~dp0ui.cmd" :ui_step "library: lame"
+@call "%~dp0ui.cmd" :ui_step "library: lame"
 REM lame support
 cd ..\lib\lame
 
 if [%1] == [arm64] (
-	devenv lame.sln /rebuild "Release|ARM64" %UI_REDIR%
+	devenv lame.sln /rebuild "Release|ARM64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: lame.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "ARM64\Release\libobjk_lame.dll" (
@@ -416,20 +403,18 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: lame.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy ARM64\Release\libobjk_lame.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
+	copy ARM64\Release\libobjk_lame.dll ..\..\release\%TARGET%\lib\native
 )
 
 if [%1] == [x64] (
-	devenv lame.sln /rebuild "Release|x64" %UI_REDIR%
+	devenv lame.sln /rebuild "Release|x64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: lame.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "x64\Release\libobjk_lame.dll" (
@@ -437,24 +422,22 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: lame.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy x64\Release\libobjk_lame.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
+	copy x64\Release\libobjk_lame.dll ..\..\release\%TARGET%\lib\native
 )
 cd ..\..\release
 
-call "%~dp0ui.cmd" :ui_step "app launcher"
+@call "%~dp0ui.cmd" :ui_step "app launcher"
 REM app
 cd ..\utils\WindowsApp
 if [%1] == [arm64] (
-	devenv AppLauncher.sln /rebuild "Release|ARM64" %UI_REDIR%
+	devenv AppLauncher.sln /rebuild "Release|ARM64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: AppLauncher.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "ARM64\Release\ObLauncher.exe" (
@@ -462,20 +445,18 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: AppLauncher.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy ARM64\Release\*.exe ..\..\release\%TARGET%\app %UI_REDIR%
+	copy ARM64\Release\*.exe ..\..\release\%TARGET%\app
 )
 
 if [%1] == [x64] (
-	devenv AppLauncher.sln /rebuild "Release|x64" %UI_REDIR%
+	devenv AppLauncher.sln /rebuild "Release|x64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: AppLauncher.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "x64\Release\ObLauncher.exe" (
@@ -483,24 +464,22 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: AppLauncher.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy x64\Release\*.exe ..\..\release\%TARGET%\app %UI_REDIR%
+	copy x64\Release\*.exe ..\..\release\%TARGET%\app
 )
 cd ..\..\release
 
-call "%~dp0ui.cmd" :ui_step "library: diags"
+@call "%~dp0ui.cmd" :ui_step "library: diags"
 REM diags
 cd ..\lib\diags
 if [%1] == [arm64] (
-	devenv diag.sln /rebuild "Release|ARM64" %UI_REDIR%
+	devenv diag.sln /rebuild "Release|ARM64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: diag.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "vs\Release\ARM64\libobjk_diags.dll" (
@@ -508,20 +487,18 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: diag.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy vs\Release\ARM64\*.dll* ..\..\release\%TARGET%\lib\native %UI_REDIR%
+	copy vs\Release\ARM64\*.dll* ..\..\release\%TARGET%\lib\native
 )
 
 if [%1] == [x64] (
-	devenv diag.sln /rebuild "Release|x64" %UI_REDIR%
+	devenv diag.sln /rebuild "Release|x64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: diag.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "vs\Release\x64\libobjk_diags.dll" (
@@ -529,25 +506,23 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: diag.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy vs\Release\x64\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
+	copy vs\Release\x64\*.dll ..\..\release\%TARGET%\lib\native
 )
 cd ..\..\release
 
 
-call "%~dp0ui.cmd" :ui_step "library: odbc"
+@call "%~dp0ui.cmd" :ui_step "library: odbc"
 REM odbc support
 cd ..\lib\odbc
 if [%1] == [arm64] (
-	devenv odbc.sln /rebuild "Release|ARM64" %UI_REDIR%
+	devenv odbc.sln /rebuild "Release|ARM64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: odbc.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "ARM64\Release\libobjk_odbc.dll" (
@@ -555,20 +530,18 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: odbc.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy ARM64\Release\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
+	copy ARM64\Release\*.dll ..\..\release\%TARGET%\lib\native
 )
 
 if [%1] == [x64] (
-	devenv odbc.sln /rebuild "Release|x64" %UI_REDIR%
+	devenv odbc.sln /rebuild "Release|x64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: odbc.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "Release\win64\libobjk_odbc.dll" (
@@ -576,24 +549,22 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: odbc.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy Release\win64\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
+	copy Release\win64\*.dll ..\..\release\%TARGET%\lib\native
 )
 cd ..\..\release
 
-call "%~dp0ui.cmd" :ui_step "library: matrix"
+@call "%~dp0ui.cmd" :ui_step "library: matrix"
 REM matrix support
 cd ..\lib\matrix
 if [%1] == [arm64] (
-	devenv matrix.sln /rebuild "Release|ARM64" %UI_REDIR%
+	devenv matrix.sln /rebuild "Release|ARM64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: matrix.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "Release\ARM64\libobjk_ml.dll" (
@@ -601,20 +572,18 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: matrix.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy Release\ARM64\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
+	copy Release\ARM64\*.dll ..\..\release\%TARGET%\lib\native
 )
 
 if [%1] == [x64] (
-	devenv matrix.sln /rebuild "Release|x64" %UI_REDIR%
+	devenv matrix.sln /rebuild "Release|x64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: matrix.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "Release\x64\libobjk_ml.dll" (
@@ -622,24 +591,22 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: matrix.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy Release\x64\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
+	copy Release\x64\*.dll ..\..\release\%TARGET%\lib\native
 )
 cd ..\..\release
 
-call "%~dp0ui.cmd" :ui_step "library: opencv"
+@call "%~dp0ui.cmd" :ui_step "library: opencv"
 REM opencv support
 cd ..\lib\opencv
 if [%1] == [arm64] (
-	devenv opencv.sln /rebuild "Release|ARM64" %UI_REDIR%
+	devenv opencv.sln /rebuild "Release|ARM64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: opencv.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "arm64\Release\libobjk_opencv.dll" (
@@ -647,13 +614,12 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: opencv.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy arm64\Release\libobjk_opencv.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
+	copy arm64\Release\libobjk_opencv.dll ..\..\release\%TARGET%\lib\native
 
 	for %%f in (win\arm64\bin\opencv_*4.dll) do (
-		copy /y %%f ..\..\release\%TARGET%\bin %UI_REDIR%
+		copy /y %%f ..\..\release\%TARGET%\bin
 	)
 
 	REM The modular OpenCV build externalises its codecs. Copy every known
@@ -666,13 +632,12 @@ if [%1] == [arm64] (
 )
 
 if [%1] == [x64] (
-	devenv opencv.sln /rebuild "Release|x64" %UI_REDIR%
+	devenv opencv.sln /rebuild "Release|x64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: opencv.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "x64\Release\libobjk_opencv.dll" (
@@ -680,23 +645,22 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: opencv.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy x64\Release\libobjk_opencv.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
+	copy x64\Release\libobjk_opencv.dll ..\..\release\%TARGET%\lib\native
 
 	if exist win\x64\bin\opencv_world4120.dll (
-		copy /y win\x64\bin\opencv_world4120.dll ..\..\release\%TARGET%\bin %UI_REDIR%
+		copy /y win\x64\bin\opencv_world4120.dll ..\..\release\%TARGET%\bin
 	) else (
 		echo Warning: win\x64\bin\opencv_world4120.dll not found - OpenCV runtime unavailable
 	)
 	if exist win\x64\bin\opencv_videoio_ffmpeg4120_64.dll (
-		copy /y win\x64\bin\opencv_videoio_ffmpeg4120_64.dll ..\..\release\%TARGET%\bin %UI_REDIR%
+		copy /y win\x64\bin\opencv_videoio_ffmpeg4120_64.dll ..\..\release\%TARGET%\bin
 	)
 )
 cd ..\..\release
 
-call "%~dp0ui.cmd" :ui_step "library: onnx"
+@call "%~dp0ui.cmd" :ui_step "library: onnx"
 REM onnx support
 cd ..\lib\onnx
 
@@ -720,7 +684,6 @@ if "%NUGET_EXE%"=="" (
 	echo  ERROR: nuget.exe not found and download failed - aborting deploy
 	echo  Install NuGet CLI: choco install nuget.commandline
 	echo ============================================================
-	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 REM Retry the restore: nuget.org intermittently returns transient errors
@@ -730,14 +693,13 @@ set NUGET_MAX_ATTEMPTS=5
 set NUGET_ATTEMPT=0
 :nuget_restore_retry
 set /a NUGET_ATTEMPT+=1
-"%NUGET_EXE%" restore onnx.sln %UI_REDIR%
+"%NUGET_EXE%" restore onnx.sln
 if not errorlevel 1 goto nuget_restore_ok
 if %NUGET_ATTEMPT% geq %NUGET_MAX_ATTEMPTS% (
 	echo.
 	echo ============================================================
 	echo  ERROR: NuGet restore failed after %NUGET_MAX_ATTEMPTS% attempts - aborting deploy
 	echo ============================================================
-	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 echo NuGet restore attempt %NUGET_ATTEMPT% of %NUGET_MAX_ATTEMPTS% failed ^(transient nuget.org error?^) - retrying in 15s...
@@ -746,13 +708,12 @@ goto nuget_restore_retry
 :nuget_restore_ok
 
 if [%1] == [arm64] (
-	devenv onnx.sln /rebuild "Release-QNN|ARM64" %UI_REDIR%
+	devenv onnx.sln /rebuild "Release-QNN|ARM64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: onnx.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "ARM64\Release-QNN\libobjk_onnx.dll" (
@@ -760,13 +721,12 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: onnx.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy ARM64\Release-QNN\libobjk_onnx.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
+	copy ARM64\Release-QNN\libobjk_onnx.dll ..\..\release\%TARGET%\lib\native
 
 	if exist eq\qnn\win\onnx\arm64\bin (
-		copy /y eq\qnn\win\onnx\arm64\bin\*.dll ..\..\release\%TARGET%\bin %UI_REDIR%
+		copy /y eq\qnn\win\onnx\arm64\bin\*.dll ..\..\release\%TARGET%\bin
 		REM onnxruntime.dll ships COMPRESSED and nothing ever unpacked it, so the
 		REM copy above moved the Qnn and provider DLLs and left the core runtime
 		REM behind. libobjk_onnx.dll imports it, so loading failed with error 126
@@ -777,16 +737,14 @@ if [%1] == [arm64] (
 				echo ============================================================
 				echo  ERROR: 7-Zip not found, cannot unpack onnxruntime.7z - aborting deploy
 				echo ============================================================
-				call "%~dp0ui.cmd" :ui_fail
 				exit /b 1
 			)
-			"%ZIP_EXE%" x -y -o..\..\release\%TARGET%\bin eq\qnn\win\onnx\arm64\bin\onnxruntime.7z %UI_REDIR%
+			"%ZIP_EXE%" x -y -o..\..\release\%TARGET%\bin eq\qnn\win\onnx\arm64\bin\onnxruntime.7z
 			if errorlevel 1 (
 				echo.
 				echo ============================================================
 				echo  ERROR: onnxruntime.7z extraction failed - aborting deploy
 				echo ============================================================
-				call "%~dp0ui.cmd" :ui_fail
 				exit /b 1
 			)
 		)
@@ -799,7 +757,6 @@ if [%1] == [arm64] (
 			echo ============================================================
 			echo  ERROR: onnxruntime.dll missing from bin - aborting deploy
 			echo ============================================================
-			call "%~dp0ui.cmd" :ui_fail
 			exit /b 1
 		)
 	) else (
@@ -807,19 +764,17 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: ONNX QNN runtime tree not found for arm64 - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 )
 
 if [%1] == [x64] (
-	devenv onnx.sln /rebuild "Release-DML|x64" %UI_REDIR%
+	devenv onnx.sln /rebuild "Release-DML|x64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: onnx.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "x64\Release-DML\libobjk_onnx.dll" (
@@ -827,13 +782,12 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: onnx.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy x64\Release-DML\libobjk_onnx.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
+	copy x64\Release-DML\libobjk_onnx.dll ..\..\release\%TARGET%\lib\native
 
 	if exist packages\Microsoft.ML.OnnxRuntime.DirectML.1.22.1\runtimes\win-x64\native (
-		copy /y packages\Microsoft.ML.OnnxRuntime.DirectML.1.22.1\runtimes\win-x64\native\*.dll ..\..\release\%TARGET%\bin %UI_REDIR%
+		copy /y packages\Microsoft.ML.OnnxRuntime.DirectML.1.22.1\runtimes\win-x64\native\*.dll ..\..\release\%TARGET%\bin
 	) else (
 		echo Warning: OnnxRuntime.DirectML nuget packages not found - ONNX runtime unavailable
 	)
@@ -849,7 +803,7 @@ if [%1] == [x64] (
 	) else (
 		if exist packages\Microsoft.AI.DirectML.1.15.4\bin\x64-win\DirectML.dll (
 			echo No OS DirectML.dll - shipping the vendored redistributable
-			copy /y packages\Microsoft.AI.DirectML.1.15.4\bin\x64-win\DirectML.dll ..\..\release\%TARGET%\bin %UI_REDIR%
+			copy /y packages\Microsoft.AI.DirectML.1.15.4\bin\x64-win\DirectML.dll ..\..\release\%TARGET%\bin
 		) else (
 			echo Warning: no OS DirectML.dll and no vendored package - GPU inference unavailable
 		)
@@ -857,18 +811,17 @@ if [%1] == [x64] (
 )
 cd ..\..\release
 
-call "%~dp0ui.cmd" :ui_step "library: sdl"
+@call "%~dp0ui.cmd" :ui_step "library: sdl"
 REM sdl support
 cd ..\lib\sdl
 if [%1] == [arm64] (
 	REM sdl
-	devenv sdl\sdl.sln /rebuild "Release|ARM64" %UI_REDIR%
+	devenv sdl\sdl.sln /rebuild "Release|ARM64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: sdl.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "sdl\Release\arm64\libobjk_sdl.dll" (
@@ -876,11 +829,10 @@ if [%1] == [arm64] (
 		echo ============================================================
 		echo  ERROR: sdl.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy sdl\Release\arm64\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
-	copy lib\fonts\*.ttf ..\..\release\%TARGET%\lib\sdl\fonts %UI_REDIR%
+	copy sdl\Release\arm64\*.dll ..\..\release\%TARGET%\lib\native
+	copy lib\fonts\*.ttf ..\..\release\%TARGET%\lib\sdl\fonts
 	REM SDL2's own runtime DLLs go to bin, NOT next to libobjk_sdl.dll.
 	REM Windows resolves a dynamically-loaded DLL's imports against the
 	REM EXECUTABLE's directory; the directory holding the DLL itself is never
@@ -889,18 +841,17 @@ if [%1] == [arm64] (
 	REM Left in lib\sdl they resolve only when something has put lib\sdl on
 	REM PATH, and nothing shipped to a user does: the MSI puts only bin on
 	REM PATH. lib\sdl\fonts stays where it is -- Overlay loads it by path.
-	copy lib\arm64\*.dll ..\..\release\%TARGET%\bin %UI_REDIR%
+	copy lib\arm64\*.dll ..\..\release\%TARGET%\bin
 )
 
 if [%1] == [x64] (
 	REM sdl
-	devenv sdl\sdl.sln /rebuild "Release|x64" %UI_REDIR%
+	devenv sdl\sdl.sln /rebuild "Release|x64"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: sdl.sln build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 	if not exist "sdl\Release\x64\libobjk_sdl.dll" (
@@ -908,105 +859,102 @@ if [%1] == [x64] (
 		echo ============================================================
 		echo  ERROR: sdl.sln build incomplete - was the build interrupted?
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-	copy sdl\Release\x64\*.dll ..\..\release\%TARGET%\lib\native %UI_REDIR%
-	copy lib\fonts\*.ttf ..\..\release\%TARGET%\lib\sdl\fonts %UI_REDIR%
+	copy sdl\Release\x64\*.dll ..\..\release\%TARGET%\lib\native
+	copy lib\fonts\*.ttf ..\..\release\%TARGET%\lib\sdl\fonts
 	REM bin, not lib\sdl -- see the note on the arm64 copy above.
-	copy lib\x64\*.dll ..\..\release\%TARGET%\bin %UI_REDIR%
+	copy lib\x64\*.dll ..\..\release\%TARGET%\bin
 )
 cd ..\..\release
 
-call "%~dp0ui.cmd" :ui_step "examples"
+@call "%~dp0ui.cmd" :ui_step "examples"
 REM copy examples
-mkdir %TARGET%\examples\ %UI_REDIR%
+mkdir %TARGET%\examples\
 
-mkdir %TARGET%\examples\media\ %UI_REDIR%
-del  /s /q ..\..\programs\*.obe %UI_REDIR%
-xcopy /e ..\..\programs\deploy\*.obs %TARGET%\examples\ %UI_REDIR%
-copy ..\..\programs\deploy\README.md %TARGET%\examples\ %UI_REDIR%
+mkdir %TARGET%\examples\media\
+del  /s /q ..\..\programs\*.obe
+xcopy /e ..\..\programs\deploy\*.obs %TARGET%\examples\
+copy ..\..\programs\deploy\README.md %TARGET%\examples\
 REM The OpenGL examples live in programs\examples rather than programs\deploy,
 REM so no distribution ever carried them. They find the bundled font relative to
 REM either bin or here, so they run from where they land.
-mkdir %TARGET%\examples\opengl %UI_REDIR%
-copy ..\..\programs\examples\gl_*.obs %TARGET%\examples\opengl %UI_REDIR%
-copy ..\..\programs\examples\cube_gl.obs %TARGET%\examples\opengl %UI_REDIR%
-copy ..\..\programs\examples\gl_crystal.obj %TARGET%\examples\opengl %UI_REDIR%
-xcopy /e ..\..\programs\deploy\media\*.png %TARGET%\examples\media\ %UI_REDIR%
-xcopy /e ..\..\programs\deploy\media\*.wav %TARGET%\examples\media\ %UI_REDIR%
-xcopy /e ..\..\programs\deploy\data\* %TARGET%\examples\data\ %UI_REDIR%
+mkdir %TARGET%\examples\opengl
+copy ..\..\programs\examples\gl_*.obs %TARGET%\examples\opengl
+copy ..\..\programs\examples\cube_gl.obs %TARGET%\examples\opengl
+copy ..\..\programs\examples\gl_crystal.obj %TARGET%\examples\opengl
+xcopy /e ..\..\programs\deploy\media\*.png %TARGET%\examples\media\
+xcopy /e ..\..\programs\deploy\media\*.wav %TARGET%\examples\media\
+xcopy /e ..\..\programs\deploy\data\* %TARGET%\examples\data\
 
 REM copy ONNX demo programs
-copy ..\..\programs\frameworks\opencv_onnx\demo_phi3*.obs %TARGET%\examples\ %UI_REDIR%
+copy ..\..\programs\frameworks\opencv_onnx\demo_phi3*.obs %TARGET%\examples\
 
 REM copy ONNX models (phi3 text and phi3v vision) if downloaded
 set MODELS_SRC=..\..\programs\frameworks\opencv_onnx\data\models
 if exist "%MODELS_SRC%\phi3\directml\directml-int4-awq-block-128\model.onnx" (
-	mkdir %TARGET%\examples\data\models\phi3 %UI_REDIR%
-	xcopy /y /q "%MODELS_SRC%\phi3\directml\directml-int4-awq-block-128\*.onnx" %TARGET%\examples\data\models\phi3\ %UI_REDIR%
-	xcopy /y /q "%MODELS_SRC%\phi3\directml\directml-int4-awq-block-128\*.onnx.data" %TARGET%\examples\data\models\phi3\ %UI_REDIR%
-	xcopy /y /q "%MODELS_SRC%\phi3\directml\directml-int4-awq-block-128\*.json" %TARGET%\examples\data\models\phi3\ %UI_REDIR%
+	mkdir %TARGET%\examples\data\models\phi3
+	xcopy /y /q "%MODELS_SRC%\phi3\directml\directml-int4-awq-block-128\*.onnx" %TARGET%\examples\data\models\phi3\
+	xcopy /y /q "%MODELS_SRC%\phi3\directml\directml-int4-awq-block-128\*.onnx.data" %TARGET%\examples\data\models\phi3\
+	xcopy /y /q "%MODELS_SRC%\phi3\directml\directml-int4-awq-block-128\*.json" %TARGET%\examples\data\models\phi3\
 )
 if exist "%MODELS_SRC%\phi3v\directml-int4-rtn-block-32\model.onnx" (
-	mkdir %TARGET%\examples\data\models\phi3v %UI_REDIR%
-	xcopy /y /q "%MODELS_SRC%\phi3v\directml-int4-rtn-block-32\*.onnx" %TARGET%\examples\data\models\phi3v\ %UI_REDIR%
-	xcopy /y /q "%MODELS_SRC%\phi3v\directml-int4-rtn-block-32\*.onnx.data" %TARGET%\examples\data\models\phi3v\ %UI_REDIR%
-	xcopy /y /q "%MODELS_SRC%\phi3v\directml-int4-rtn-block-32\*.json" %TARGET%\examples\data\models\phi3v\ %UI_REDIR%
+	mkdir %TARGET%\examples\data\models\phi3v
+	xcopy /y /q "%MODELS_SRC%\phi3v\directml-int4-rtn-block-32\*.onnx" %TARGET%\examples\data\models\phi3v\
+	xcopy /y /q "%MODELS_SRC%\phi3v\directml-int4-rtn-block-32\*.onnx.data" %TARGET%\examples\data\models\phi3v\
+	xcopy /y /q "%MODELS_SRC%\phi3v\directml-int4-rtn-block-32\*.json" %TARGET%\examples\data\models\phi3v\
 )
 
-call "%~dp0ui.cmd" :ui_step "documentation"
+@call "%~dp0ui.cmd" :ui_step "documentation"
 REM build and update docs
-mkdir %TARGET%\doc %UI_REDIR%
-mkdir %TARGET%\doc\syntax %UI_REDIR%
-xcopy /e ..\..\docs\syntax\* %TARGET%\doc\syntax %UI_REDIR%
+mkdir %TARGET%\doc
+mkdir %TARGET%\doc\syntax
+xcopy /e ..\..\docs\syntax\* %TARGET%\doc\syntax
 
 REM update and process readme
-mkdir %TARGET%\style %UI_REDIR%
-copy ..\..\docs\style\*.css %TARGET%\style %UI_REDIR%
-copy ..\lib\code_doc\templates\resources\*.png %TARGET%\style %UI_REDIR%
-copy ..\..\docs\readme.html %TARGET% %UI_REDIR%
-copy ..\..\LICENSE %TARGET% %UI_REDIR%
+mkdir %TARGET%\style
+copy ..\..\docs\style\*.css %TARGET%\style
+copy ..\lib\code_doc\templates\resources\*.png %TARGET%\style
+copy ..\..\docs\readme.html %TARGET%
+copy ..\..\LICENSE %TARGET%
 
 REM copy docs (skip for ARM64 cross-compilation - can't run ARM64 binaries on x64 host)
 if [%1] == [x64] (
-	call "%~dp0code_doc64.cmd" %1 deploy %UI_REDIR%
-	if errorlevel 1 call "%~dp0ui.cmd" :ui_warn "API docs step exited with an error - the deploy continues, as it always has"
-	rmdir /s /q %1 %UI_REDIR%
+	call "%~dp0code_doc64.cmd" %1 deploy
+	@if errorlevel 1 call "%~dp0ui.cmd" :ui_warn "API docs step exited with an error - the deploy continues, as it always has"
+	rmdir /s /q %1
 ) else (
 	echo Skipping code_doc for ARM64 cross-compilation - using pre-built API docs
-	mkdir %TARGET%\doc\api %UI_REDIR%
-	powershell -Command "Expand-Archive -Path '..\..\docs\api.zip' -DestinationPath '%TARGET%\doc' -Force" %UI_REDIR%
+	mkdir %TARGET%\doc\api
+	powershell -Command "Expand-Archive -Path '..\..\docs\api.zip' -DestinationPath '%TARGET%\doc' -Force"
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: API docs extraction failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 )
 
-call "%~dp0ui.cmd" :ui_step "verify native libraries"
+@call "%~dp0ui.cmd" :ui_step "verify native libraries"
 REM Verify the native-library closure before producing an artifact. x64 can use
 REM LoadLibrary directly. ARM64 is cross-compiled on an x64 runner, so the script
 REM uses dumpbin to walk imports and require every non-system dependency locally.
-powershell.exe -executionpolicy remotesigned -file verify_native_libs.ps1 -DeployDir %TARGET% -TargetArchitecture %1 %UI_REDIR%
+powershell.exe -executionpolicy remotesigned -file verify_native_libs.ps1 -DeployDir %TARGET% -TargetArchitecture %1
 if errorlevel 1 (
 	echo.
 	echo ============================================================
 	echo  ERROR: a native library in %TARGET% cannot load - aborting deploy
 	echo ============================================================
-	call "%~dp0ui.cmd" :ui_fail
 	exit /b 1
 )
 
 :installer
 
 REM finished
-if [%2] NEQ [deploy] call "%~dp0ui.cmd" :ui_ok "deploy complete"
+@if [%2] NEQ [deploy] call "%~dp0ui.cmd" :ui_ok "deploy complete"
 if [%2] NEQ [deploy] goto end
-	call "%~dp0ui.cmd" :ui_step "package: msi + zip"
+	@call "%~dp0ui.cmd" :ui_step "package: msi + zip"
 	if [%1] == [arm64] (
 		set INSTALL_TARGET=objeck-lang-arm64
 	)
@@ -1015,28 +963,28 @@ if [%2] NEQ [deploy] goto end
 		set INSTALL_TARGET=objeck-lang-x64
 	)
 
-	rmdir /q /s %TARGET%\examples\doc %UI_REDIR%
+	rmdir /q /s %TARGET%\examples\doc
 
 	REM Create directory structure for MSI build (files must be in release-x64 or release-arm64)
 	REM Use repo-relative path (..\..\Objeck-Build) to match MSI project expectations
 	if [%1] == [arm64] (
-		rmdir /q /s ..\..\Objeck-Build\release-arm64 %UI_REDIR%
-		mkdir ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET% %UI_REDIR%
-		xcopy /e %TARGET% ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET% %UI_REDIR%
-		mkdir ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%\doc\icons %UI_REDIR%
-		copy ..\..\docs\images\setup_icons\*.ico ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%\doc\icons %UI_REDIR%
-		copy ..\..\docs\images\setup_icons\*.jpg ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%\doc\icons %UI_REDIR%
-		copy ..\..\docs\eula.rtf ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%\doc %UI_REDIR%
+		rmdir /q /s ..\..\Objeck-Build\release-arm64
+		mkdir ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%
+		xcopy /e %TARGET% ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%
+		mkdir ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%\doc\icons
+		copy ..\..\docs\images\setup_icons\*.ico ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%\doc\icons
+		copy ..\..\docs\images\setup_icons\*.jpg ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%\doc\icons
+		copy ..\..\docs\eula.rtf ..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%\doc
 	)
 
 	if [%1] == [x64] (
-		rmdir /q /s ..\..\Objeck-Build\release-x64 %UI_REDIR%
-		mkdir ..\..\Objeck-Build\release-x64\%INSTALL_TARGET% %UI_REDIR%
-		xcopy /e %TARGET% ..\..\Objeck-Build\release-x64\%INSTALL_TARGET% %UI_REDIR%
-		mkdir ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%\doc\icons %UI_REDIR%
-		copy ..\..\docs\images\setup_icons\*.ico ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%\doc\icons %UI_REDIR%
-		copy ..\..\docs\images\setup_icons\*.jpg ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%\doc\icons %UI_REDIR%
-		copy ..\..\docs\eula.rtf ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%\doc %UI_REDIR%
+		rmdir /q /s ..\..\Objeck-Build\release-x64
+		mkdir ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%
+		xcopy /e %TARGET% ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%
+		mkdir ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%\doc\icons
+		copy ..\..\docs\images\setup_icons\*.ico ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%\doc\icons
+		copy ..\..\docs\images\setup_icons\*.jpg ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%\doc\icons
+		copy ..\..\docs\eula.rtf ..\..\Objeck-Build\release-x64\%INSTALL_TARGET%\doc
 	)
 
 	REM Build MSI installer with WiX v5
@@ -1059,13 +1007,12 @@ if [%2] NEQ [deploy] goto end
 		-d Platform=%WIX_ARCH% -d Version=0.0.0 ^
 		-d SourceDir=%WIX_SOURCEDIR% ^
 		-ext WixToolset.UI.wixext -ext WixToolset.Util.wixext ^
-		..\utils\setup\objeck.wxs %UI_REDIR%
+		..\utils\setup\objeck.wxs
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: WiX MSI build failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
 
@@ -1079,18 +1026,17 @@ if [%2] NEQ [deploy] goto end
 
 	REM Create ZIP
 	if [%1] == [arm64] (
-		powershell -Command "Compress-Archive -Path '..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%' -DestinationPath '..\..\Objeck-Build\release-arm64\objeck-windows-arm64_0.0.0.zip' -Force" %UI_REDIR%
+		powershell -Command "Compress-Archive -Path '..\..\Objeck-Build\release-arm64\%INSTALL_TARGET%' -DestinationPath '..\..\Objeck-Build\release-arm64\objeck-windows-arm64_0.0.0.zip' -Force"
 	)
 	if [%1] == [x64] (
-		powershell -Command "Compress-Archive -Path '..\..\Objeck-Build\release-x64\%INSTALL_TARGET%' -DestinationPath '..\..\Objeck-Build\release-x64\objeck-windows-x64_0.0.0.zip' -Force" %UI_REDIR%
+		powershell -Command "Compress-Archive -Path '..\..\Objeck-Build\release-x64\%INSTALL_TARGET%' -DestinationPath '..\..\Objeck-Build\release-x64\objeck-windows-x64_0.0.0.zip' -Force"
 	)
 	if errorlevel 1 (
 		echo.
 		echo ============================================================
 		echo  ERROR: ZIP creation failed - aborting deploy
 		echo ============================================================
-		call "%~dp0ui.cmd" :ui_fail
 		exit /b 1
 	)
-call "%~dp0ui.cmd" :ui_ok "deploy complete, packaged"
+@call "%~dp0ui.cmd" :ui_ok "deploy complete, packaged"
 :end

--- a/core/release/ui.cmd
+++ b/core/release/ui.cmd
@@ -1,151 +1,167 @@
-@echo off
-REM ---------------------------------------------------------------------------
-REM ui.cmd -- presentation for deploy_windows.cmd: a banner, one progress line
-REM per stage, quiet tool output, and the log tail when a stage fails.
-REM
-REM   call "%~dp0ui.cmd" :ui_init %1 %2 %3     once, after UI_TOTAL is set
-REM   call "%~dp0ui.cmd" :ui_step "label"      at each stage boundary
-REM   call "%~dp0ui.cmd" :ui_warn "text"       a problem that does not stop the deploy
-REM   call "%~dp0ui.cmd" :ui_fail              immediately before each "exit /b 1"
-REM   call "%~dp0ui.cmd" :ui_ok "text"         when the run succeeds
-REM
-REM Tool output (devenv, msbuild, copy, xcopy, ...) is appended with %UI_REDIR%.
-REM Run by hand, that is >>"%UI_LOG%" 2>&1 and the console shows only stages.
-REM In CI (GITHUB_ACTIONS or CI is set), with VERBOSE=1, or with -v, it is
-REM EMPTY: every line streams exactly as it did before this file existed, so a
-REM CI failure is read from the same log it always was.
-REM
-REM Rules this file keeps:
-REM  * Every routine ends "exit /b 0". One whose last command failed would hand
-REM    errorlevel 1 to a caller whose next line may be "if errorlevel 1".
-REM  * No parenthesised blocks around expanded paths or labels: a ")" in %TEMP%
-REM    (C:\Users\Name (Work)\...) would close the block early.
-REM  * Colour codes are whole variables, empty when colour is off. Writing
-REM    %UI_E%[92m inline printed a literal "[92m" whenever ESC was empty.
-REM  * CRLF line endings: cmd can miss labels in an LF-only batch file.
-REM ---------------------------------------------------------------------------
-goto %1
+@REM ---------------------------------------------------------------------------
+@REM ui.cmd -- presentation for deploy_windows.cmd.
+@REM
+@REM   call "%~dp0ui.cmd" :ui_init %1 %2 %3   once, after UI_TOTAL is set
+@REM   call "%~dp0ui.cmd" :ui_step "label"    at each stage boundary
+@REM   call "%~dp0ui.cmd" :ui_warn "text"     a problem that does not stop the deploy
+@REM   call "%~dp0ui.cmd" :ui_ok "text"       when the run succeeds
+@REM
+@REM ui_init picks one of four modes:
+@REM   relaunch  Run by hand, the default. Sets UI_RELAUNCH=1 and the deploy
+@REM             re-runs itself under ui.ps1. cmd cannot redraw anything while
+@REM             devenv blocks it, so a second process draws live progress while
+@REM             the build writes to a log.
+@REM   child     UI_CHILD=1, set by ui.ps1. All output goes to that log, and these
+@REM             routines print only "##ui" marker lines for ui.ps1 to read.
+@REM   ci        GITHUB_ACTIONS or CI is set. Output streams exactly as it did
+@REM             before this file existed, plus plain "[ n/N] stage" lines.
+@REM   verbose   -v, --verbose or VERBOSE=1 (or no powershell.exe): streaming
+@REM             output with coloured stage lines.
+@REM
+@REM Rules this file keeps:
+@REM  * No "@echo off". Echo state is shared with the caller, and turning it off
+@REM    here silently removed every command echo from the rest of the deploy's
+@REM    CI log. Every line starts with @ instead.
+@REM  * Every routine ends "exit /b 0". One whose last command failed would hand
+@REM    errorlevel 1 to a caller whose next line may be "if errorlevel 1".
+@REM  * No parenthesised blocks around expanded labels: a ")" would end them.
+@REM  * Colour codes are whole variables, empty when colour is off.
+@REM  * %~dp0 is read once, in ui_init: inside a "call :label" %0 is the label.
+@REM  * CRLF line endings: cmd can miss labels in an LF-only batch file.
+@REM ---------------------------------------------------------------------------
+@goto %1
 
 :ui_init
-set "UI_ARCH=%~2"
-set "UI_STEP=0"
-set "UI_LABEL=setup"
-set "UI_REDIR="
-set "UI_CI=0"
-if defined GITHUB_ACTIONS set "UI_CI=1"
-if defined CI set "UI_CI=1"
-set "UI_QUIET=1"
-if "%UI_CI%"=="1" set "UI_QUIET=0"
-if "%VERBOSE%"=="1" set "UI_QUIET=0"
-if /i "%~3"=="-v" set "UI_QUIET=0"
-if /i "%~3"=="--verbose" set "UI_QUIET=0"
-if /i "%~4"=="-v" set "UI_QUIET=0"
-if /i "%~4"=="--verbose" set "UI_QUIET=0"
-set "UI_LOG=%TEMP%\objeck-deploy-%UI_ARCH%.log"
-if "%UI_QUIET%"=="1" type nul > "%UI_LOG%"
-if "%UI_QUIET%"=="1" set UI_REDIR=^>^>"%UI_LOG%" 2^>^&1
-set "UI_E="
-set "UI_RST="
-set "UI_B="
-set "UI_DIM="
-set "UI_RED="
-set "UI_GRN="
-set "UI_YEL="
-set "UI_BLU="
-set "UI_CYN="
-if "%UI_CI%"=="1" goto ui_init_nocolor
-if defined NO_COLOR goto ui_init_nocolor
-for /f %%a in ('echo prompt $E ^| cmd') do set "UI_E=%%a"
-set "UI_RST=%UI_E%[0m"
-set "UI_B=%UI_E%[1m"
-set "UI_DIM=%UI_E%[90m"
-set "UI_RED=%UI_E%[91m"
-set "UI_GRN=%UI_E%[92m"
-set "UI_YEL=%UI_E%[93m"
-set "UI_BLU=%UI_E%[94m"
-set "UI_CYN=%UI_E%[96m"
-:ui_init_nocolor
-set "UI_VER=dev"
-for /f tokens^=2^ delims^=^" %%v in ('findstr /c:"define VERSION_STRING" "%~dp0..\shared\version.h" 2^>nul') do set "UI_VER=%%v"
-call :ui_now UI_T0
-if "%UI_CI%"=="1" goto ui_init_ci
-echo.
-echo %UI_CYN%  ___   _        _              _
-echo  / _ \ ^| ^|__    (_)  ___   ___ ^| ^| __
-echo ^| ^| ^| ^|^| '_ \   ^| ^| / _ \ / __^|^| ^|/ /
-echo ^| ^|_^| ^|^| ^|_) ^|  ^| ^|^|  __/^| (__ ^|   ^<
-echo  \___/ ^|_.__/  _/ ^| \___^| \___^|^|_^|\_\
-echo               ^|__/%UI_RST%
-echo.
-echo   %UI_B%Objeck %UI_VER%%UI_RST%  %UI_DIM%windows-%UI_ARCH%, %UI_TOTAL% stages%UI_RST%
-if "%UI_QUIET%"=="0" goto ui_init_loud
-echo   %UI_DIM%tool output: %UI_LOG%%UI_RST%
-echo   %UI_DIM%pass -v or set VERBOSE=1 to stream it%UI_RST%
-:ui_init_loud
-echo.
-exit /b 0
+@set "UI_DIR=%~dp0"
+@set "UI_ARCH=%~2"
+@set "UI_STEP=0"
+@set "UI_RELAUNCH=0"
+@set "UI_MODE=verbose"
+@set "UI_E="
+@set "UI_RST="
+@set "UI_B="
+@set "UI_DIM="
+@set "UI_GRN="
+@set "UI_YEL="
+@set "UI_BLU="
+@set "UI_CYN="
+@if "%UI_CHILD%"=="1" goto ui_init_child
+@if defined GITHUB_ACTIONS goto ui_init_ci
+@if defined CI goto ui_init_ci
+@REM A bad target or a missing Visual Studio environment: say nothing, and let
+@REM the deploy's own checks print their messages as they always have.
+@if /i not "%~2"=="x64" if /i not "%~2"=="arm64" goto ui_init_off
+@if not defined VCINSTALLDIR goto ui_init_off
+@if "%VERBOSE%"=="1" goto ui_init_verbose
+@if /i "%~3"=="-v" goto ui_init_verbose
+@if /i "%~3"=="--verbose" goto ui_init_verbose
+@if /i "%~4"=="-v" goto ui_init_verbose
+@if /i "%~4"=="--verbose" goto ui_init_verbose
+@where powershell.exe >nul 2>&1
+@if errorlevel 1 goto ui_init_verbose
+@set "UI_RELAUNCH=1"
+@exit /b 0
+
+:ui_init_off
+@set "UI_MODE=off"
+@exit /b 0
+
+:ui_init_child
+@set "UI_MODE=child"
+@echo ##ui init %UI_TOTAL%
+@exit /b 0
+
 :ui_init_ci
-echo === Objeck %UI_VER% deploy: windows-%UI_ARCH%, %UI_TOTAL% stages ===
-exit /b 0
+@set "UI_MODE=ci"
+@call :ui_version
+@call :ui_now UI_T0
+@echo === Objeck %UI_VER% deploy: windows-%UI_ARCH%, %UI_TOTAL% stages ===
+@exit /b 0
+
+:ui_init_verbose
+@call :ui_version
+@call :ui_now UI_T0
+@if defined NO_COLOR goto ui_init_banner
+@for /f %%a in ('echo prompt $E ^| cmd') do @set "UI_E=%%a"
+@set "UI_RST=%UI_E%[0m"
+@set "UI_B=%UI_E%[1m"
+@set "UI_DIM=%UI_E%[90m"
+@set "UI_GRN=%UI_E%[92m"
+@set "UI_YEL=%UI_E%[93m"
+@set "UI_BLU=%UI_E%[94m"
+@set "UI_CYN=%UI_E%[96m"
+:ui_init_banner
+@echo.
+@echo %UI_CYN%  ___   _        _              _
+@echo  / _ \ ^| ^|__    (_)  ___   ___ ^| ^| __
+@echo ^| ^| ^| ^|^| '_ \   ^| ^| / _ \ / __^|^| ^|/ /
+@echo ^| ^|_^| ^|^| ^|_) ^|  ^| ^|^|  __/^| (__ ^|   ^<
+@echo  \___/ ^|_.__/  _/ ^| \___^| \___^|^|_^|\_\
+@echo               ^|__/%UI_RST%
+@echo.
+@echo   %UI_B%Objeck %UI_VER%%UI_RST%  %UI_DIM%windows-%UI_ARCH%, %UI_TOTAL% stages, streaming output%UI_RST%
+@exit /b 0
 
 :ui_step
-set /a "UI_STEP+=1"
-set "UI_LABEL=%~2"
-call :ui_elapsed
-set /a "_f=(UI_STEP-1)*28/UI_TOTAL, _e=28-_f, _p=(UI_STEP-1)*100/UI_TOTAL"
-set "_n=  %UI_STEP%"
-set "_n=%_n:~-2%/%UI_TOTAL%"
-if "%UI_CI%"=="1" goto ui_step_ci
-set "_b=############################"
-set "_d=............................"
-call set "_bar=%%_b:~0,%_f%%%%%_d:~0,%_e%%%"
-set "_p=  %_p%"
-set "_l=%UI_LABEL%                              "
-echo   %UI_BLU%[%_bar%]%UI_RST% %_p:~-3%%%  %UI_DIM%%_n%%UI_RST%  %UI_B%%_l:~0,30%%UI_RST% %UI_DIM%%UI_ELAPSED%%UI_RST%
-exit /b 0
+@if "%UI_MODE%"=="off" exit /b 0
+@set /a "UI_STEP+=1"
+@set "UI_LABEL=%~2"
+@if "%UI_MODE%"=="child" goto ui_step_child
+@call :ui_elapsed
+@set "_n=  %UI_STEP%"
+@set "_n=%_n:~-2%/%UI_TOTAL%"
+@if "%UI_MODE%"=="ci" goto ui_step_ci
+@echo.
+@echo   %UI_BLU%==^>%UI_RST% %UI_B%[%_n%] %UI_LABEL%%UI_RST%  %UI_DIM%%UI_ELAPSED%%UI_RST%
+@exit /b 0
 :ui_step_ci
-echo.
-echo [%_n%] %UI_LABEL%  (%UI_ELAPSED%)
-exit /b 0
+@echo.
+@echo [%_n%] %UI_LABEL%  (%UI_ELAPSED%)
+@exit /b 0
+:ui_step_child
+@echo ##ui step %UI_STEP% %~2
+@exit /b 0
 
 :ui_warn
-echo   %UI_YEL%!  %~2%UI_RST%
-exit /b 0
-
-:ui_fail
-call :ui_elapsed
-echo.
-echo   %UI_RED%X  FAILED at stage %UI_STEP%/%UI_TOTAL%: %UI_LABEL%%UI_RST%  %UI_DIM%after %UI_ELAPSED%%UI_RST%
-if not "%UI_QUIET%"=="1" exit /b 0
-if not exist "%UI_LOG%" exit /b 0
-echo   %UI_DIM%last 40 lines of %UI_LOG%:%UI_RST%
-powershell -NoProfile -Command "Get-Content -LiteralPath $env:UI_LOG -Tail 40 | ForEach-Object { '    ' + $_ }"
-echo   %UI_DIM%re-run with -v or VERBOSE=1 to stream every tool%UI_RST%
-exit /b 0
+@if "%UI_MODE%"=="off" exit /b 0
+@if "%UI_MODE%"=="child" goto ui_warn_child
+@echo   %UI_YEL%!  %~2%UI_RST%
+@exit /b 0
+:ui_warn_child
+@echo ##ui warn %~2
+@exit /b 0
 
 :ui_ok
-call :ui_elapsed
-if "%UI_CI%"=="1" goto ui_ok_ci
-echo   %UI_GRN%[############################]%UI_RST% 100%%
-echo.
-echo   %UI_GRN%*  %~2%UI_RST%  %UI_DIM%%UI_STEP% stages in %UI_ELAPSED%%UI_RST%
-if "%UI_QUIET%"=="1" echo   %UI_DIM%tool output: %UI_LOG%%UI_RST%
-exit /b 0
+@if "%UI_MODE%"=="off" exit /b 0
+@if "%UI_MODE%"=="child" goto ui_ok_child
+@call :ui_elapsed
+@if "%UI_MODE%"=="ci" goto ui_ok_ci
+@echo.
+@echo   %UI_GRN%*  %~2%UI_RST%  %UI_DIM%%UI_STEP% stages in %UI_ELAPSED%%UI_RST%
+@exit /b 0
 :ui_ok_ci
-echo.
-echo === %~2: %UI_STEP% stages in %UI_ELAPSED% ===
-exit /b 0
+@echo.
+@echo === %~2: %UI_STEP% stages in %UI_ELAPSED% ===
+@exit /b 0
+:ui_ok_child
+@echo ##ui ok %~2
+@exit /b 0
+
+:ui_version
+@set "UI_VER=dev"
+@for /f tokens^=2^ delims^=^" %%v in ('findstr /c:"define VERSION_STRING" "%UI_DIR%..\shared\version.h" 2^>nul') do @set "UI_VER=%%v"
+@exit /b 0
 
 :ui_elapsed
-call :ui_now _t1
-set /a "_el=_t1-UI_T0"
-if %_el% LSS 0 set /a "_el+=86400"
-set /a "_m=_el/60, _s=100+_el%%60"
-set "UI_ELAPSED=%_m%m %_s:~-2%s"
-exit /b 0
+@call :ui_now _t1
+@set /a "_el=_t1-UI_T0"
+@if %_el% LSS 0 set /a "_el+=86400"
+@set /a "_m=_el/60, _s=100+_el%%60"
+@set "UI_ELAPSED=%_m%m %_s:~-2%s"
+@exit /b 0
 
-REM %TIME% is " 9:05:03.12" or "09:05:03,12" depending on locale. 100%%a%%100
-REM reads both "9" and "09" as nine without the leading zero turning octal.
+@REM %TIME% is " 9:05:03.12" or "09:05:03,12" depending on locale. 100%%a%%100
+@REM reads both "9" and "09" as nine without the leading zero turning octal.
 :ui_now
-for /f "tokens=1-3 delims=:.," %%a in ("%TIME: =0%") do set /a "%1=(100%%a%%100)*3600+(100%%b%%100)*60+(100%%c%%100)"
-exit /b 0
+@for /f "tokens=1-3 delims=:.," %%a in ("%TIME: =0%") do @set /a "%1=(100%%a%%100)*3600+(100%%b%%100)*60+(100%%c%%100)"
+@exit /b 0

--- a/core/release/ui.cmd
+++ b/core/release/ui.cmd
@@ -1,0 +1,151 @@
+@echo off
+REM ---------------------------------------------------------------------------
+REM ui.cmd -- presentation for deploy_windows.cmd: a banner, one progress line
+REM per stage, quiet tool output, and the log tail when a stage fails.
+REM
+REM   call "%~dp0ui.cmd" :ui_init %1 %2 %3     once, after UI_TOTAL is set
+REM   call "%~dp0ui.cmd" :ui_step "label"      at each stage boundary
+REM   call "%~dp0ui.cmd" :ui_warn "text"       a problem that does not stop the deploy
+REM   call "%~dp0ui.cmd" :ui_fail              immediately before each "exit /b 1"
+REM   call "%~dp0ui.cmd" :ui_ok "text"         when the run succeeds
+REM
+REM Tool output (devenv, msbuild, copy, xcopy, ...) is appended with %UI_REDIR%.
+REM Run by hand, that is >>"%UI_LOG%" 2>&1 and the console shows only stages.
+REM In CI (GITHUB_ACTIONS or CI is set), with VERBOSE=1, or with -v, it is
+REM EMPTY: every line streams exactly as it did before this file existed, so a
+REM CI failure is read from the same log it always was.
+REM
+REM Rules this file keeps:
+REM  * Every routine ends "exit /b 0". One whose last command failed would hand
+REM    errorlevel 1 to a caller whose next line may be "if errorlevel 1".
+REM  * No parenthesised blocks around expanded paths or labels: a ")" in %TEMP%
+REM    (C:\Users\Name (Work)\...) would close the block early.
+REM  * Colour codes are whole variables, empty when colour is off. Writing
+REM    %UI_E%[92m inline printed a literal "[92m" whenever ESC was empty.
+REM  * CRLF line endings: cmd can miss labels in an LF-only batch file.
+REM ---------------------------------------------------------------------------
+goto %1
+
+:ui_init
+set "UI_ARCH=%~2"
+set "UI_STEP=0"
+set "UI_LABEL=setup"
+set "UI_REDIR="
+set "UI_CI=0"
+if defined GITHUB_ACTIONS set "UI_CI=1"
+if defined CI set "UI_CI=1"
+set "UI_QUIET=1"
+if "%UI_CI%"=="1" set "UI_QUIET=0"
+if "%VERBOSE%"=="1" set "UI_QUIET=0"
+if /i "%~3"=="-v" set "UI_QUIET=0"
+if /i "%~3"=="--verbose" set "UI_QUIET=0"
+if /i "%~4"=="-v" set "UI_QUIET=0"
+if /i "%~4"=="--verbose" set "UI_QUIET=0"
+set "UI_LOG=%TEMP%\objeck-deploy-%UI_ARCH%.log"
+if "%UI_QUIET%"=="1" type nul > "%UI_LOG%"
+if "%UI_QUIET%"=="1" set UI_REDIR=^>^>"%UI_LOG%" 2^>^&1
+set "UI_E="
+set "UI_RST="
+set "UI_B="
+set "UI_DIM="
+set "UI_RED="
+set "UI_GRN="
+set "UI_YEL="
+set "UI_BLU="
+set "UI_CYN="
+if "%UI_CI%"=="1" goto ui_init_nocolor
+if defined NO_COLOR goto ui_init_nocolor
+for /f %%a in ('echo prompt $E ^| cmd') do set "UI_E=%%a"
+set "UI_RST=%UI_E%[0m"
+set "UI_B=%UI_E%[1m"
+set "UI_DIM=%UI_E%[90m"
+set "UI_RED=%UI_E%[91m"
+set "UI_GRN=%UI_E%[92m"
+set "UI_YEL=%UI_E%[93m"
+set "UI_BLU=%UI_E%[94m"
+set "UI_CYN=%UI_E%[96m"
+:ui_init_nocolor
+set "UI_VER=dev"
+for /f tokens^=2^ delims^=^" %%v in ('findstr /c:"define VERSION_STRING" "%~dp0..\shared\version.h" 2^>nul') do set "UI_VER=%%v"
+call :ui_now UI_T0
+if "%UI_CI%"=="1" goto ui_init_ci
+echo.
+echo %UI_CYN%  ___   _        _              _
+echo  / _ \ ^| ^|__    (_)  ___   ___ ^| ^| __
+echo ^| ^| ^| ^|^| '_ \   ^| ^| / _ \ / __^|^| ^|/ /
+echo ^| ^|_^| ^|^| ^|_) ^|  ^| ^|^|  __/^| (__ ^|   ^<
+echo  \___/ ^|_.__/  _/ ^| \___^| \___^|^|_^|\_\
+echo               ^|__/%UI_RST%
+echo.
+echo   %UI_B%Objeck %UI_VER%%UI_RST%  %UI_DIM%windows-%UI_ARCH%, %UI_TOTAL% stages%UI_RST%
+if "%UI_QUIET%"=="0" goto ui_init_loud
+echo   %UI_DIM%tool output: %UI_LOG%%UI_RST%
+echo   %UI_DIM%pass -v or set VERBOSE=1 to stream it%UI_RST%
+:ui_init_loud
+echo.
+exit /b 0
+:ui_init_ci
+echo === Objeck %UI_VER% deploy: windows-%UI_ARCH%, %UI_TOTAL% stages ===
+exit /b 0
+
+:ui_step
+set /a "UI_STEP+=1"
+set "UI_LABEL=%~2"
+call :ui_elapsed
+set /a "_f=(UI_STEP-1)*28/UI_TOTAL, _e=28-_f, _p=(UI_STEP-1)*100/UI_TOTAL"
+set "_n=  %UI_STEP%"
+set "_n=%_n:~-2%/%UI_TOTAL%"
+if "%UI_CI%"=="1" goto ui_step_ci
+set "_b=############################"
+set "_d=............................"
+call set "_bar=%%_b:~0,%_f%%%%%_d:~0,%_e%%%"
+set "_p=  %_p%"
+set "_l=%UI_LABEL%                              "
+echo   %UI_BLU%[%_bar%]%UI_RST% %_p:~-3%%%  %UI_DIM%%_n%%UI_RST%  %UI_B%%_l:~0,30%%UI_RST% %UI_DIM%%UI_ELAPSED%%UI_RST%
+exit /b 0
+:ui_step_ci
+echo.
+echo [%_n%] %UI_LABEL%  (%UI_ELAPSED%)
+exit /b 0
+
+:ui_warn
+echo   %UI_YEL%!  %~2%UI_RST%
+exit /b 0
+
+:ui_fail
+call :ui_elapsed
+echo.
+echo   %UI_RED%X  FAILED at stage %UI_STEP%/%UI_TOTAL%: %UI_LABEL%%UI_RST%  %UI_DIM%after %UI_ELAPSED%%UI_RST%
+if not "%UI_QUIET%"=="1" exit /b 0
+if not exist "%UI_LOG%" exit /b 0
+echo   %UI_DIM%last 40 lines of %UI_LOG%:%UI_RST%
+powershell -NoProfile -Command "Get-Content -LiteralPath $env:UI_LOG -Tail 40 | ForEach-Object { '    ' + $_ }"
+echo   %UI_DIM%re-run with -v or VERBOSE=1 to stream every tool%UI_RST%
+exit /b 0
+
+:ui_ok
+call :ui_elapsed
+if "%UI_CI%"=="1" goto ui_ok_ci
+echo   %UI_GRN%[############################]%UI_RST% 100%%
+echo.
+echo   %UI_GRN%*  %~2%UI_RST%  %UI_DIM%%UI_STEP% stages in %UI_ELAPSED%%UI_RST%
+if "%UI_QUIET%"=="1" echo   %UI_DIM%tool output: %UI_LOG%%UI_RST%
+exit /b 0
+:ui_ok_ci
+echo.
+echo === %~2: %UI_STEP% stages in %UI_ELAPSED% ===
+exit /b 0
+
+:ui_elapsed
+call :ui_now _t1
+set /a "_el=_t1-UI_T0"
+if %_el% LSS 0 set /a "_el+=86400"
+set /a "_m=_el/60, _s=100+_el%%60"
+set "UI_ELAPSED=%_m%m %_s:~-2%s"
+exit /b 0
+
+REM %TIME% is " 9:05:03.12" or "09:05:03,12" depending on locale. 100%%a%%100
+REM reads both "9" and "09" as nine without the leading zero turning octal.
+:ui_now
+for /f "tokens=1-3 delims=:.," %%a in ("%TIME: =0%") do set /a "%1=(100%%a%%100)*3600+(100%%b%%100)*60+(100%%c%%100)"
+exit /b 0

--- a/core/release/ui.ps1
+++ b/core/release/ui.ps1
@@ -31,15 +31,19 @@ $deploy = if ($env:UI_DEPLOY_SCRIPT) { $env:UI_DEPLOY_SCRIPT } else { Join-Path 
 $live = -not [Console]::IsOutputRedirected
 
 function Glyph([int] $CodePoint) { [string][char]$CodePoint }
-$FILL = Glyph 0x2588
-$EMPTY = Glyph 0x2591
-if ($env:WT_SESSION) {
-  # Windows Terminal's fonts carry these; conhost's Consolas does not.
+if ($env:WT_SESSION -or $env:TERM_PROGRAM -eq 'vscode') {
+  # Windows Terminal's and VS Code's fonts carry these; conhost's Consolas does not.
   $OK = Glyph 0x2713; $BAD = Glyph 0x2717; $ELL = Glyph 0x2026
   $SPIN = @(0x280B, 0x2819, 0x2839, 0x2838, 0x283C, 0x2834, 0x2826, 0x2827, 0x2807, 0x280F) | ForEach-Object { Glyph $_ }
+  # The bar is one solid line for every cell, coloured by state. A full block
+  # plus a light shade (U+2588/U+2591) does not survive terminal fonts: VS Code
+  # draws the shade as a dither pattern, which read as solid in blue (6% looked
+  # full) and as nothing at all in gray.
+  $FILL = Glyph 0x2501; $EMPTY = Glyph 0x2501
 } else {
   $OK = Glyph 0x221A; $BAD = 'x'; $ELL = '...'
   $SPIN = @('|', '/', '-', '\')
+  $FILL = '#'; $EMPTY = '-'
 }
 
 $ART = @(
@@ -114,13 +118,15 @@ function Draw-Live {
   $done = [Math]::Max(0, $S.Step - 1)
   $cells = 20
   $f = [Math]::Min($cells, [int][Math]::Floor($done * $cells / $total))
-  $bar = ($FILL * $f) + ($EMPTY * ($cells - $f))
-  $pct = '{0,3}%' -f [int][Math]::Floor($done * 100 / $total)
+  # No percentage. The only progress this script can see is a stage boundary, so
+  # a number sat still through a long stage (the solution rebuild takes minutes)
+  # and then jumped. The bar counts finished stages, the counter names the
+  # running one, and the stage clock is what shows the build is alive.
   $n = if ($S.Total -gt 0) { '{0,2}/{1}' -f $S.Step, $S.Total } else { '' }
   $clock = '{0}:{1:00}' -f [int][Math]::Floor($t.TotalMinutes), $t.Seconds
 
-  # "  F BAR PCT  N  LABEL  CLOCK  ACTIVITY"
-  $fixed = 2 + 1 + 1 + $cells + 1 + $pct.Length + 2 + $n.Length + 2 + 2 + $clock.Length
+  # "  F BAR  N  LABEL  CLOCK  ACTIVITY"
+  $fixed = 2 + 1 + 1 + $cells + 2 + $n.Length + 2 + 2 + $clock.Length
   $label = $S.Label
   if ($label.Length -gt ($w - $fixed)) { $label = $label.Substring(0, [Math]::Max(0, $w - $fixed)) }
   $used = $fixed + $label.Length
@@ -133,7 +139,7 @@ function Draw-Live {
   }
 
   [Console]::Write("`r")
-  W '  '; W $frame 'Cyan'; W ' '; W $bar 'Blue'; W " $pct  "; W $n 'DarkGray'; W '  '
+  W '  '; W $frame 'Cyan'; W ' '; W ($FILL * $f) 'Blue'; W ($EMPTY * ($cells - $f)) 'DarkGray'; W '  '; W $n 'Gray'; W '  '
   W $label 'White'; W "  $clock" 'DarkGray'; W $act 'DarkGray'
   $len = $used + $act.Length
   if ($len -lt $w) { W (' ' * ($w - $len)) }
@@ -178,7 +184,15 @@ function Handle-Line([string] $Line) {
   }
 
   Remember $text
-  $S.Activity = $text -replace '\s+', ' '
+  # The live line says what is building. MSVC prefixes each line with its
+  # project number ("4>") and interleaves chatter that says nothing about
+  # progress; the log keeps all of it, and the error scan below reads $text.
+  $act = ($text -replace '^\d+>\s*', '') -replace '\s+', ' '
+  if ($act -match '^-+ (?:Rebuild All|Build) started: Project: ([^,]+)') { $act = 'building ' + $Matches[1] }
+  elseif ($act -match '^\S+\.vcxproj -> (.+)$') { $act = 'built ' + [IO.Path]::GetFileName($Matches[1]) }
+  if ($act -notmatch '^(Previous IPDB not found|Generating code|Finished generating code|All \d+ functions were compiled|\d+ of \d+ functions|Creating library |-+$)') {
+    $S.Activity = $act
+  }
 
   if ($text -cmatch '^ERROR:') { Note $BAD 'Red' $text }
   elseif ($text -cmatch '^Warning:') { Note '!' 'Yellow' $text.Substring(8).Trim() }
@@ -295,7 +309,7 @@ if ($interrupted) {
   Stage-Line $BAD 'Red' $S.Label 'interrupted' 'Red'
   NL; W "  stopped by Ctrl+C after $elapsed; the build was terminated" 'Red'; NL
 } elseif ($code -eq 0 -and $null -ne $S.Ok) {
-  W '  '; W ($FILL * 20) 'Green'; W ' 100%'; NL; NL
+  W '  '; W ($FILL * 20) 'Green'; W "  $($S.Done)/$total" 'Gray'; NL; NL
   W '  '; W "$OK $($S.Ok)" 'Green'; W "  $($S.Done) stages in $elapsed" 'DarkGray'; NL
   W "  tool output: $log" 'DarkGray'; NL
 } else {

--- a/core/release/ui.ps1
+++ b/core/release/ui.ps1
@@ -1,0 +1,316 @@
+# ---------------------------------------------------------------------------
+# ui.ps1 -- live progress for deploy_windows.cmd when it is run by hand.
+#
+# cmd cannot redraw anything while devenv or msbuild blocks it, so the deploy
+# re-runs itself under this script (ui.cmd, "relaunch" mode):
+#
+#   deploy_windows.cmd x64
+#     -> powershell -File ui.ps1 x64
+#          -> cmd /c deploy_windows.cmd x64 > %TEMP%\objeck-deploy-x64.log 2>&1
+#             with UI_CHILD=1, so ui.cmd writes "##ui" marker lines into the log
+#
+# This process is the only writer to the console. It follows the log and
+# redraws one live line ten times a second -- spinner, bar, stage timer and the
+# build's latest output line -- prints a line with its duration for each
+# finished stage, surfaces the script's own ERROR:/Warning: lines as they
+# appear, and on failure shows the compiler errors and the end of the log. Its
+# exit code is the deploy's. Ctrl+C stops the whole build tree.
+#
+# ASCII-only source on purpose: Windows PowerShell 5.1 reads a .ps1 without a
+# BOM as ANSI, so every non-ASCII glyph is built from its code point.
+# UI_DEPLOY_SCRIPT overrides the script that is run, for testing this file.
+# ---------------------------------------------------------------------------
+param([Parameter(ValueFromRemainingArguments = $true)][string[]] $DeployArgs)
+
+$ErrorActionPreference = 'Stop'
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+if ($null -eq $DeployArgs) { $DeployArgs = @() }
+$arch = if ($DeployArgs.Count -gt 0) { $DeployArgs[0] } else { 'x64' }
+$deploy = if ($env:UI_DEPLOY_SCRIPT) { $env:UI_DEPLOY_SCRIPT } else { Join-Path $here 'deploy_windows.cmd' }
+$live = -not [Console]::IsOutputRedirected
+
+function Glyph([int] $CodePoint) { [string][char]$CodePoint }
+$FILL = Glyph 0x2588
+$EMPTY = Glyph 0x2591
+if ($env:WT_SESSION) {
+  # Windows Terminal's fonts carry these; conhost's Consolas does not.
+  $OK = Glyph 0x2713; $BAD = Glyph 0x2717; $ELL = Glyph 0x2026
+  $SPIN = @(0x280B, 0x2819, 0x2839, 0x2838, 0x283C, 0x2834, 0x2826, 0x2827, 0x2807, 0x280F) | ForEach-Object { Glyph $_ }
+} else {
+  $OK = Glyph 0x221A; $BAD = 'x'; $ELL = '...'
+  $SPIN = @('|', '/', '-', '\')
+}
+
+$ART = @(
+  '  ___   _        _              _',
+  ' / _ \ | |__    (_)  ___   ___ | | __',
+  '| | | || ''_ \   | | / _ \ / __|| |/ /',
+  '| |_| || |_) |  | ||  __/| (__ |   <',
+  ' \___/ |_.__/  _/ | \___| \___||_|\_\',
+  '              |__/'
+)
+
+$version = 'dev'
+$versionH = Join-Path $here '..\shared\version.h'
+if (Test-Path -LiteralPath $versionH) {
+  $m = Select-String -LiteralPath $versionH -Pattern 'VERSION_STRING\s+L"([^"]+)"' | Select-Object -First 1
+  if ($m) { $version = $m.Matches[0].Groups[1].Value }
+}
+
+# A lingering process can still hold last run's log open; never fail on that.
+$log = Join-Path $env:TEMP "objeck-deploy-$arch.log"
+try { if (Test-Path -LiteralPath $log) { Remove-Item -LiteralPath $log -Force } }
+catch { $log = Join-Path $env:TEMP "objeck-deploy-$arch-$PID.log" }
+
+$S = @{
+  Total = 0; Step = 0; Done = 0; Label = 'starting'; Activity = ''; Ok = $null; Tick = 0; LastKey = $null
+  RunStart = [DateTime]::Now; StageStart = [DateTime]::Now
+  Errors = New-Object 'System.Collections.Generic.List[string]'
+  Tail = New-Object 'System.Collections.Generic.Queue[string]'
+}
+
+function W([string] $Text, $Color) {
+  if ($null -ne $Color) { Write-Host $Text -NoNewline -ForegroundColor $Color } else { Write-Host $Text -NoNewline }
+}
+function NL { Write-Host '' }
+function Width { if ($live) { [Math]::Max(40, [Console]::WindowWidth - 1) } else { 100 } }
+function Clear-Live { if ($live) { [Console]::Write("`r" + (' ' * (Width)) + "`r"); $S.LastKey = $null } }
+function Dur([TimeSpan] $t) { '{0}m {1:00}s' -f [int][Math]::Floor($t.TotalMinutes), $t.Seconds }
+
+function Stage-Line([string] $Glyph, $Color, [string] $Label, [string] $Right, $RightColor = 'DarkGray') {
+  Clear-Live
+  W '  '; W $Glyph $Color; W ' '; W ($Label.PadRight(32)); W $Right $RightColor; NL
+}
+
+function Finish-Stage {
+  if ($S.Step -gt 0) {
+    Stage-Line $OK 'Green' $S.Label (Dur ([DateTime]::Now - $S.StageStart))
+    $S.Done++
+  }
+}
+
+function Note([string] $Glyph, $Color, [string] $Text) {
+  Clear-Live
+  W '    '; W "$Glyph $Text" $Color; NL
+}
+
+function Draw-Live {
+  if (-not $live) { return }
+  $w = Width
+  $frame = $SPIN[$S.Tick % $SPIN.Count]
+  $S.Tick++
+  $t = [DateTime]::Now - $S.StageStart
+  # Most frames only move the spinner. Repaint that one cell unless something
+  # else on the line has changed: Write-Host is the costly part of a frame.
+  $key = '{0}|{1}|{2}|{3}|{4}|{5}' -f $w, $S.Step, $S.Total, [int][Math]::Floor($t.TotalSeconds), $S.Label, $S.Activity
+  if ($key -eq $S.LastKey) {
+    [Console]::Write("`r  ")
+    W $frame 'Cyan'
+    return
+  }
+  $S.LastKey = $key
+  $total = [Math]::Max(1, $S.Total)
+  $done = [Math]::Max(0, $S.Step - 1)
+  $cells = 20
+  $f = [Math]::Min($cells, [int][Math]::Floor($done * $cells / $total))
+  $bar = ($FILL * $f) + ($EMPTY * ($cells - $f))
+  $pct = '{0,3}%' -f [int][Math]::Floor($done * 100 / $total)
+  $n = if ($S.Total -gt 0) { '{0,2}/{1}' -f $S.Step, $S.Total } else { '' }
+  $clock = '{0}:{1:00}' -f [int][Math]::Floor($t.TotalMinutes), $t.Seconds
+
+  # "  F BAR PCT  N  LABEL  CLOCK  ACTIVITY"
+  $fixed = 2 + 1 + 1 + $cells + 1 + $pct.Length + 2 + $n.Length + 2 + 2 + $clock.Length
+  $label = $S.Label
+  if ($label.Length -gt ($w - $fixed)) { $label = $label.Substring(0, [Math]::Max(0, $w - $fixed)) }
+  $used = $fixed + $label.Length
+  $act = ''
+  $room = $w - $used - 2
+  if ($room -gt 12 -and $S.Activity) {
+    $a = $S.Activity
+    if ($a.Length -gt $room) { $a = $a.Substring(0, $room - $ELL.Length) + $ELL }
+    $act = '  ' + $a
+  }
+
+  [Console]::Write("`r")
+  W '  '; W $frame 'Cyan'; W ' '; W $bar 'Blue'; W " $pct  "; W $n 'DarkGray'; W '  '
+  W $label 'White'; W "  $clock" 'DarkGray'; W $act 'DarkGray'
+  $len = $used + $act.Length
+  if ($len -lt $w) { W (' ' * ($w - $len)) }
+}
+
+function Handle-Line([string] $Line) {
+  if ($Line -match '^##ui (\w+) ?(.*)$') {
+    $kind = $Matches[1]
+    $rest = $Matches[2].Trim()
+    switch ($kind) {
+      'init' { $S.Total = [int]$rest }
+      'step' {
+        Finish-Stage
+        $parts = $rest -split ' ', 2
+        $S.Step = [int]$parts[0]
+        $S.Label = if ($parts.Count -gt 1) { $parts[1] } else { '' }
+        $S.StageStart = [DateTime]::Now
+        $S.Activity = ''
+        $S.Errors.Clear()
+        $S.Tail.Clear()
+      }
+      'warn' { Note '!' 'Yellow' $rest }
+      'ok' { Finish-Stage; $S.Step = 0; $S.Ok = $rest }
+    }
+    return
+  }
+
+  $text = $Line.Trim()
+  if (-not $text) { return }
+  if ($text -match '^[()]+$') { return }   # the edges of an echoed if (...) block
+
+  # With echo on, cmd writes each command after a "C:\...\core\release>" prompt.
+  # Keep the command, which says what ran, without the prompt. An echoed "echo"
+  # or "rem" only repeats the line that follows it, so drop those -- otherwise an
+  # echoed error line is counted as a second error.
+  if ($text -match '^[A-Za-z]:\\[^>]*>(.*)$') {
+    $command = $Matches[1].Trim() -replace '\s+', ' '
+    if (-not $command -or $command -match '^(echo|rem)\b') { return }
+    Remember ('> ' + $command)
+    $S.Activity = $command
+    return
+  }
+
+  Remember $text
+  $S.Activity = $text -replace '\s+', ' '
+
+  if ($text -cmatch '^ERROR:') { Note $BAD 'Red' $text }
+  elseif ($text -cmatch '^Warning:') { Note '!' 'Yellow' $text.Substring(8).Trim() }
+  elseif ($text -match ':\s*(fatal\s+)?error\s+[A-Za-z]+\d+\s*:' -and $S.Errors.Count -lt 20 -and -not $S.Errors.Contains($text)) {
+    $S.Errors.Add($text)
+  }
+}
+
+function Remember([string] $Text) {
+  $S.Tail.Enqueue($Text)
+  while ($S.Tail.Count -gt 25) { [void]$S.Tail.Dequeue() }
+}
+
+# Stops the deploy and everything it started (devenv, msbuild, cl).
+function Stop-Tree($Process) {
+  $kill = New-Object System.Diagnostics.ProcessStartInfo 'taskkill.exe', "/PID $($Process.Id) /T /F"
+  $kill.UseShellExecute = $false
+  $kill.RedirectStandardOutput = $true
+  $kill.RedirectStandardError = $true
+  ([System.Diagnostics.Process]::Start($kill)).WaitForExit()
+}
+
+function CtrlC-Pressed {
+  if (-not $script:keys) { return $false }
+  try {
+    while ([Console]::KeyAvailable) {
+      $k = [Console]::ReadKey($true)
+      if ($k.Key -eq [ConsoleKey]::C -and ($k.Modifiers -band [ConsoleModifiers]::Control)) { return $true }
+    }
+  } catch { }
+  return $false
+}
+
+# ---- banner -----------------------------------------------------------------
+NL
+foreach ($row in $ART) { W $row 'Cyan'; NL }
+NL
+W '  '; W "Objeck $version" 'White'; W "  windows-$arch" 'DarkGray'; NL
+W "  tool output: $log" 'DarkGray'; NL
+W '  pass -v to stream it instead' 'DarkGray'; NL
+NL
+
+# ---- run the deploy, following its log ---------------------------------------
+$env:UI_CHILD = '1'
+$quoted = ($DeployArgs | ForEach-Object { if ($_ -match '[\s&()^]') { '"' + $_ + '"' } else { $_ } }) -join ' '
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = $env:ComSpec
+$psi.Arguments = '/d /s /c ""' + $deploy + '" ' + $quoted + ' > "' + $log + '" 2>&1"'
+$psi.UseShellExecute = $false
+$psi.WorkingDirectory = (Get-Location).ProviderPath
+
+$keys = $false
+$interrupted = $false
+$code = 1
+$proc = $null
+try {
+  if ($live) {
+    try { [Console]::CursorVisible = $false } catch { }
+    # Ctrl+C arrives as a key, not a signal, so the build tree can be stopped
+    # cleanly instead of every process on the console being interrupted at once.
+    try { [Console]::TreatControlCAsInput = $true; $keys = $true } catch { }
+  }
+
+  $proc = [System.Diagnostics.Process]::Start($psi)
+  $oem = [Text.Encoding]::GetEncoding([Globalization.CultureInfo]::CurrentCulture.TextInfo.OEMCodePage)
+  $decoder = $oem.GetDecoder()
+  $bytes = New-Object byte[] 65536
+  $chars = New-Object char[] 65536
+  $pending = ''
+  $fs = $null
+
+  while ($true) {
+    $exited = $proc.HasExited   # read before the drain, so the last bytes are not missed
+    if ($null -eq $fs -and (Test-Path -LiteralPath $log)) {
+      try { $fs = [IO.File]::Open($log, [IO.FileMode]::Open, [IO.FileAccess]::Read, [IO.FileShare]::ReadWrite -bor [IO.FileShare]::Delete) } catch { }
+    }
+    if ($null -ne $fs) {
+      while (($got = $fs.Read($bytes, 0, $bytes.Length)) -gt 0) {
+        $count = $decoder.GetChars($bytes, 0, $got, $chars, 0)
+        $pending += [string]::new($chars, 0, $count)
+        $lines = $pending.Split("`n")
+        $pending = $lines[$lines.Count - 1]
+        for ($i = 0; $i -lt $lines.Count - 1; $i++) { Handle-Line ($lines[$i].TrimEnd("`r")) }
+      }
+    }
+    if ($exited) { break }
+    if (CtrlC-Pressed) { $interrupted = $true; break }
+    Draw-Live
+    Start-Sleep -Milliseconds 100
+  }
+  if ($pending) { Handle-Line ($pending.TrimEnd("`r")) }
+
+  if ($interrupted) {
+    Stop-Tree $proc
+    $code = 130
+  } else {
+    $proc.WaitForExit()
+    $code = $proc.ExitCode
+  }
+  if ($null -ne $fs) { $fs.Dispose() }
+} finally {
+  # Whatever ended this loop -- Ctrl+C, or an error in this script -- the build
+  # must not carry on unwatched, still holding the log open.
+  if ($null -ne $proc -and -not $proc.HasExited) { Stop-Tree $proc }
+  Clear-Live
+  if ($keys) { try { [Console]::TreatControlCAsInput = $false } catch { } }
+  if ($live) { try { [Console]::CursorVisible = $true } catch { } }
+}
+
+# ---- report -------------------------------------------------------------------
+$elapsed = Dur ([DateTime]::Now - $S.RunStart)
+$total = if ($S.Total -gt 0) { $S.Total } else { $S.Step }
+if ($interrupted) {
+  Stage-Line $BAD 'Red' $S.Label 'interrupted' 'Red'
+  NL; W "  stopped by Ctrl+C after $elapsed; the build was terminated" 'Red'; NL
+} elseif ($code -eq 0 -and $null -ne $S.Ok) {
+  W '  '; W ($FILL * 20) 'Green'; W ' 100%'; NL; NL
+  W '  '; W "$OK $($S.Ok)" 'Green'; W "  $($S.Done) stages in $elapsed" 'DarkGray'; NL
+  W "  tool output: $log" 'DarkGray'; NL
+} else {
+  if ($S.Step -gt 0) { Stage-Line $BAD 'Red' $S.Label (Dur ([DateTime]::Now - $S.StageStart)) 'Red' }
+  NL
+  if ($code -ne 0) { W "  FAILED at stage $($S.Step)/$total with exit code $code, after $elapsed" 'Red' }
+  else { W "  stopped before finishing, at stage $($S.Step)/$total, after $elapsed" 'Yellow' }
+  NL
+  if ($S.Errors.Count -gt 0) {
+    NL; W '  compiler errors:' 'Red'; NL
+    foreach ($e in $S.Errors) { W "    $e"; NL }
+  }
+  NL; W '  last lines of the log:' 'DarkGray'; NL
+  $tail = @($S.Tail.ToArray())
+  for ($i = [Math]::Max(0, $tail.Count - 25); $i -lt $tail.Count; $i++) { W ('    ' + $tail[$i]); NL }
+  W "  full log: $log   (-v streams everything instead)" 'DarkGray'; NL
+}
+exit $code

--- a/core/release/ui.sh
+++ b/core/release/ui.sh
@@ -1,28 +1,34 @@
 # ---------------------------------------------------------------------------
-# ui.sh -- presentation for deploy_posix.sh: a banner, one progress line per
-# stage, quiet build output, and the log tail when a stage fails.
+# ui.sh -- presentation for deploy_posix.sh.
 #
 # Sourced, not executed, and POSIX sh only: deploy_posix.sh is #!/bin/sh, which
 # is dash on the Ubuntu runners (no arrays, no [[ ]], no local, no pipefail).
 #
 #   ui_banner "linux-x64" "2026.9.1"   once, after UI_TOTAL is set
 #   ui_step "label"                    at each stage boundary
-#   ui_q cmd args...                   run a tool, output hidden unless verbose
-#   ui_q cmd args... || ui_fail        and report it if it fails
+#   cmd args... || ui_fail             report a failed step and carry on
 #   ui_ok "deploy complete"            names any failed stages instead
 #
-# Quiet is for people at a terminal. When stdout is not a terminal -- every CI
-# leg -- or with VERBOSE=1 or -v, ui_q runs the command untouched and its output
-# streams exactly as it did before this file existed, so a CI failure is read
-# from the same log it always was. Colour and the banner are terminal-only for
-# the same reason.
+# Three modes, chosen when this file is sourced:
+#   live     stdout is a terminal (the default by hand). Everything the script
+#            and its tools print goes to $UI_LOG. The terminal gets the banner,
+#            a line per finished stage, and one live line that a background
+#            ticker redraws ten times a second -- spinner, bar, stage timer and
+#            the log's latest line -- so it keeps moving while make runs. Only
+#            this file writes to the terminal (through fd 9), so nothing tears
+#            the live line.
+#   plain    stdout is not a terminal -- every CI leg. Output streams exactly as
+#            it did before this file existed, plus "[ n/N] stage" lines. No
+#            escape codes.
+#   verbose  VERBOSE=1 or -v at a terminal: streaming output, coloured stage lines.
 # ---------------------------------------------------------------------------
 
-UI_TTY=0
+UI_MODE=plain
 C_RESET=; C_BOLD=; C_DIM=; C_RED=; C_GREEN=; C_YELLOW=; C_BLUE=; C_CYAN=
-if [ -t 1 ]; then
-	UI_TTY=1
-	if [ -z "${NO_COLOR:-}" ] && [ "${TERM:-dumb}" != "dumb" ]; then
+if [ -t 1 ] && [ "${TERM:-dumb}" != "dumb" ]; then
+	UI_MODE=live
+	if [ "${VERBOSE:-0}" = "1" ]; then UI_MODE=verbose; fi
+	if [ -z "${NO_COLOR:-}" ]; then
 		_e=$(printf '\033')
 		C_RESET="${_e}[0m"; C_BOLD="${_e}[1m"; C_DIM="${_e}[90m"
 		C_RED="${_e}[91m"; C_GREEN="${_e}[92m"; C_YELLOW="${_e}[93m"
@@ -30,50 +36,62 @@ if [ -t 1 ]; then
 	fi
 fi
 
-UI_VERBOSE=0
-if [ "${VERBOSE:-0}" = "1" ] || [ "$UI_TTY" != "1" ]; then
-	UI_VERBOSE=1
-fi
-
-# Block glyphs where the terminal is UTF-8, ASCII everywhere else.
-UI_FILL='#'; UI_EMPTY='.'; UI_L='['; UI_R=']'
-if [ "$UI_TTY" = "1" ]; then
+# Block and braille glyphs where the terminal is UTF-8, ASCII everywhere else.
+UI_FILL='#'; UI_EMPTY='.'; UI_OK='+'; UI_BAD='x'; UI_SPIN='| / - \'
+if [ "$UI_MODE" != "plain" ]; then
 	case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
-		*UTF-8*|*utf-8*|*UTF8*|*utf8*) UI_FILL='█'; UI_EMPTY='░'; UI_L=''; UI_R='' ;;
+		*UTF-8*|*utf-8*|*UTF8*|*utf8*)
+			UI_FILL='█'; UI_EMPTY='░'; UI_OK='✓'; UI_BAD='✗'
+			UI_SPIN='⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏' ;;
 	esac
 fi
 
+UI_PID=$$
 UI_STEP=0
 UI_TOTAL=1
 UI_LABEL=setup
+UI_DONE=0
 UI_FAILED=0
 UI_FAILED_LABELS=
+UI_STAGE_FAILED=0
+UI_STAGE_LINE=0
+UI_LIVE_PID=
 UI_START=$(date +%s)
+UI_STAGE_START=$UI_START
 UI_LOG="${TMPDIR:-/tmp}/objeck-deploy.log"
-if [ "$UI_VERBOSE" != "1" ]; then
+
+if [ "$UI_MODE" = "live" ]; then
 	: > "$UI_LOG"
+	exec 9>&1 >>"$UI_LOG" 2>&1
+	printf '\033[?25l' >&9
+	trap '_ui_rc=$?; ui_on_exit' EXIT
+	trap 'exit 130' INT
+	trap 'exit 143' TERM
 fi
 
-ui_elapsed() {
-	_el=$(( $(date +%s) - UI_START ))
-	printf '%dm %02ds' $((_el / 60)) $((_el % 60))
+ui_out() {
+	if [ "$UI_MODE" = "live" ]; then printf "$@" >&9; else printf "$@"; fi
 }
 
-ui_bar() {  # $1 = filled cells of 28
+ui_dur() {  # $1 = start, epoch seconds
+	_d=$(( $(date +%s) - $1 ))
+	printf '%dm %02ds' $((_d / 60)) $((_d % 60))
+}
+
+ui_bar() {  # $1 = filled cells, $2 = width
 	_bar=''
 	_i=0
 	while [ "$_i" -lt "$1" ]; do _bar="$_bar$UI_FILL"; _i=$((_i + 1)); done
-	while [ "$_i" -lt 28 ]; do _bar="$_bar$UI_EMPTY"; _i=$((_i + 1)); done
-	printf '%s%s%s' "$UI_L" "$_bar" "$UI_R"
+	while [ "$_i" -lt "$2" ]; do _bar="$_bar$UI_EMPTY"; _i=$((_i + 1)); done
+	printf '%s' "$_bar"
 }
 
 ui_banner() {  # $1 = target, $2 = version
-	if [ "$UI_TTY" != "1" ]; then
+	if [ "$UI_MODE" = "plain" ]; then
 		echo "=== Objeck $2 deploy: $1, $UI_TOTAL stages ==="
 		return 0
 	fi
-	printf '\n%s' "$C_CYAN"
-	cat <<'EOF'
+	_art=$(cat <<'EOF'
   ___   _        _              _
  / _ \ | |__    (_)  ___   ___ | | __
 | | | || '_ \   | | / _ \ / __|| |/ /
@@ -81,46 +99,95 @@ ui_banner() {  # $1 = target, $2 = version
  \___/ |_.__/  _/ | \___| \___||_|\_\
               |__/
 EOF
-	printf '%s\n' "$C_RESET"
-	printf '  %sObjeck %s%s  %s%s, %d stages%s\n' \
-		"$C_BOLD" "$2" "$C_RESET" "$C_DIM" "$1" "$UI_TOTAL" "$C_RESET"
-	if [ "$UI_VERBOSE" != "1" ]; then
-		printf '  %stool output: %s%s\n' "$C_DIM" "$UI_LOG" "$C_RESET"
-		printf '  %spass -v or set VERBOSE=1 to stream it%s\n' "$C_DIM" "$C_RESET"
+)
+	ui_out '\n%s%s%s\n\n' "$C_CYAN" "$_art" "$C_RESET"
+	ui_out '  %sObjeck %s%s  %s%s, %d stages%s\n' "$C_BOLD" "$2" "$C_RESET" "$C_DIM" "$1" "$UI_TOTAL" "$C_RESET"
+	if [ "$UI_MODE" = "live" ]; then
+		ui_out '  %stool output: %s%s\n' "$C_DIM" "$UI_LOG" "$C_RESET"
+		ui_out '  %spass -v to stream it instead%s\n' "$C_DIM" "$C_RESET"
 	fi
-	echo
+	ui_out '\n'
 }
 
-# ui_step "label" -- the bar shows stages already finished, so the first
-# stage reads 0% and 100% is printed only by ui_ok.
 ui_step() {
+	ui_live_stop
+	ui_stage_done
 	UI_STEP=$((UI_STEP + 1))
 	UI_LABEL="$1"
-	if [ "$UI_TTY" != "1" ]; then
-		printf '\n[%2d/%d] %s  (%s)\n' "$UI_STEP" "$UI_TOTAL" "$1" "$(ui_elapsed)"
-		return 0
-	fi
-	printf '  %s%s%s %3d%%  %s%2d/%d%s  %s%-30s%s %s%s%s\n' \
-		"$C_BLUE" "$(ui_bar $(( (UI_STEP - 1) * 28 / UI_TOTAL )))" "$C_RESET" \
-		$(( (UI_STEP - 1) * 100 / UI_TOTAL )) \
-		"$C_DIM" "$UI_STEP" "$UI_TOTAL" "$C_RESET" \
-		"$C_BOLD" "$1" "$C_RESET" \
-		"$C_DIM" "$(ui_elapsed)" "$C_RESET"
+	UI_STAGE_START=$(date +%s)
+	UI_STAGE_FAILED=0
+	if [ "$UI_MODE" = "live" ]; then UI_STAGE_LINE=$(wc -l < "$UI_LOG"); fi
+	case "$UI_MODE" in
+		plain)
+			printf '\n[%2d/%d] %s  (%s)\n' "$UI_STEP" "$UI_TOTAL" "$1" "$(ui_dur "$UI_START")" ;;
+		verbose)
+			printf '\n  %s==>%s %s[%2d/%d] %s%s  %s%s%s\n' "$C_BLUE" "$C_RESET" "$C_BOLD" \
+				"$UI_STEP" "$UI_TOTAL" "$1" "$C_RESET" "$C_DIM" "$(ui_dur "$UI_START")" "$C_RESET" ;;
+		live)
+			ui_live_start ;;
+	esac
 }
 
-ui_q() {
-	if [ "$UI_VERBOSE" = "1" ]; then
-		"$@"
-	else
-		"$@" >>"$UI_LOG" 2>&1
-	fi
+# The line for the stage that just finished, with its own duration.
+ui_stage_done() {
+	[ "$UI_MODE" = "live" ] || return 0
+	[ "$UI_STEP" -gt 0 ] || return 0
+	[ "$UI_STAGE_FAILED" = "0" ] || return 0
+	ui_out '  %s%s%s %-32s %s%s%s\n' "$C_GREEN" "$UI_OK" "$C_RESET" "$UI_LABEL" \
+		"$C_DIM" "$(ui_dur "$UI_STAGE_START")" "$C_RESET"
+}
+
+ui_live_start() {
+	_cols=$(stty size </dev/tty 2>/dev/null | cut -d' ' -f2)
+	case "$_cols" in ''|*[!0-9]*|0) _cols=100 ;; esac
+	_done=$((UI_STEP - 1))
+	_lbar=$(ui_bar $((_done * 20 / UI_TOTAL)) 20)
+	_lpct=$((_done * 100 / UI_TOTAL))
+	# "  F BAR PCT  NN/NN  LABEL  M:SS  ": 2+1+1+20+5+2+5+2+label+2+5+2
+	_aw=$((_cols - 47 - ${#UI_LABEL}))
+	(
+		trap 'exit 0' TERM
+		set -- $UI_SPIN
+		_n=$#
+		_t=0
+		while kill -0 "$UI_PID" 2>/dev/null; do
+			_i=$((_t % _n + 1))
+			eval "_f=\${$_i}"
+			_el=$(( $(date +%s) - UI_STAGE_START ))
+			_act=
+			if [ "$_aw" -gt 12 ]; then
+				_act=$(tail -n 5 "$UI_LOG" 2>/dev/null | awk -v w="$_aw" '
+					{ gsub(/\r/, ""); gsub(/\t/, " ") }
+					NF { l = $0 }
+					END { sub(/^ +/, "", l); if (length(l) > w) l = substr(l, 1, w - 3) "..."; print l }')
+			fi
+			printf '\r\033[2K  %s%s%s %s%s%s %3d%%  %s%2d/%d%s  %s%s%s  %s%d:%02d%s  %s%s%s' \
+				"$C_CYAN" "$_f" "$C_RESET" "$C_BLUE" "$_lbar" "$C_RESET" "$_lpct" \
+				"$C_DIM" "$UI_STEP" "$UI_TOTAL" "$C_RESET" "$C_BOLD" "$UI_LABEL" "$C_RESET" \
+				"$C_DIM" $((_el / 60)) $((_el % 60)) "$C_RESET" "$C_DIM" "$_act" "$C_RESET" >&9
+			_t=$((_t + 1))
+			sleep 0.1
+		done
+	) &
+	UI_LIVE_PID=$!
+}
+
+ui_live_stop() {
+	[ -n "$UI_LIVE_PID" ] || return 0
+	kill "$UI_LIVE_PID" 2>/dev/null
+	wait "$UI_LIVE_PID" 2>/dev/null
+	UI_LIVE_PID=
+	printf '\r\033[2K' >&9
 }
 
 ui_warn() {
-	printf '  %s!  %s%s\n' "$C_YELLOW" "$1" "$C_RESET"
+	ui_live_stop
+	ui_out '    %s! %s%s\n' "$C_YELLOW" "$1" "$C_RESET"
+	if [ "$UI_MODE" = "live" ] && [ "$UI_STEP" -gt 0 ]; then ui_live_start; fi
+	return 0
 }
 
-# ui_fail -- used as "ui_q cmd || ui_fail". $? on entry is cmd's exit status.
+# ui_fail -- used as "cmd || ui_fail". $? on entry is cmd's exit status.
 #
 # Reports and CONTINUES, because the script it wraps always continued. That is
 # load-bearing: on green CI the linux-arm64 onnx build fails (ld: cannot find
@@ -130,35 +197,60 @@ ui_fail() {
 	_rc=$?
 	UI_FAILED=$((UI_FAILED + 1))
 	UI_FAILED_LABELS="${UI_FAILED_LABELS:+$UI_FAILED_LABELS, }$UI_LABEL"
-	printf '\n  %sX  FAILED at stage %d/%d: %s%s  %s(exit %s, after %s)%s\n' \
-		"$C_RED" "$UI_STEP" "$UI_TOTAL" "$UI_LABEL" "$C_RESET" \
-		"$C_DIM" "$_rc" "$(ui_elapsed)" "$C_RESET"
-	if [ "$UI_VERBOSE" != "1" ] && [ -s "$UI_LOG" ]; then
-		printf '  %slast 40 lines of %s:%s\n' "$C_DIM" "$UI_LOG" "$C_RESET"
-		tail -n 40 "$UI_LOG" | sed 's/^/    /'
-		printf '  %sre-run with -v or VERBOSE=1 to stream every build%s\n\n' "$C_DIM" "$C_RESET"
+	if [ "$UI_MODE" = "live" ]; then
+		ui_live_stop
+		if [ "$UI_STAGE_FAILED" = "0" ]; then
+			ui_out '  %s%s %-32s%s %s%s, exit %s%s\n' "$C_RED" "$UI_BAD" "$UI_LABEL" "$C_RESET" \
+				"$C_DIM" "$(ui_dur "$UI_STAGE_START")" "$_rc" "$C_RESET"
+		fi
+		UI_STAGE_FAILED=1
+		tail -n +$((UI_STAGE_LINE + 1)) "$UI_LOG" | tail -n 15 | sed 's/^/      /' >&9
+		ui_live_start
+	else
+		printf '\n  %sX  FAILED at stage %d/%d: %s  (exit %s, after %s)%s\n' "$C_RED" \
+			"$UI_STEP" "$UI_TOTAL" "$UI_LABEL" "$_rc" "$(ui_dur "$UI_START")" "$C_RESET"
 	fi
 	return 0
 }
 
 ui_ok() {
-	if [ "$UI_FAILED" -gt 0 ]; then
-		if [ "$UI_TTY" != "1" ]; then
+	ui_live_stop
+	ui_stage_done
+	UI_DONE=1
+	_total=$(ui_dur "$UI_START")
+	if [ "$UI_MODE" = "plain" ]; then
+		if [ "$UI_FAILED" -gt 0 ]; then
 			printf '\n=== finished with %d failed stage(s): %s (%d stages in %s) ===\n' \
-				"$UI_FAILED" "$UI_FAILED_LABELS" "$UI_STEP" "$(ui_elapsed)"
-			return 0
+				"$UI_FAILED" "$UI_FAILED_LABELS" "$UI_STEP" "$_total"
+		else
+			printf '\n=== %s: %d stages in %s ===\n' "$1" "$UI_STEP" "$_total"
 		fi
-		printf '\n  %s!  finished with %d failed stage(s): %s%s  %s%d stages in %s%s\n' \
-			"$C_YELLOW" "$UI_FAILED" "$UI_FAILED_LABELS" "$C_RESET" "$C_DIM" "$UI_STEP" "$(ui_elapsed)" "$C_RESET"
-	elif [ "$UI_TTY" != "1" ]; then
-		printf '\n=== %s: %d stages in %s ===\n' "$1" "$UI_STEP" "$(ui_elapsed)"
 		return 0
+	fi
+	if [ "$UI_FAILED" -gt 0 ]; then
+		ui_out '\n  %s! finished with %d failed stage(s): %s%s  %s%d stages in %s%s\n' \
+			"$C_YELLOW" "$UI_FAILED" "$UI_FAILED_LABELS" "$C_RESET" "$C_DIM" "$UI_STEP" "$_total" "$C_RESET"
 	else
-		printf '  %s%s%s 100%%\n\n' "$C_GREEN" "$(ui_bar 28)" "$C_RESET"
-		printf '  %s*  %s%s  %s%d stages in %s%s\n' \
-			"$C_GREEN" "$1" "$C_RESET" "$C_DIM" "$UI_STEP" "$(ui_elapsed)" "$C_RESET"
+		ui_out '  %s%s%s 100%%\n\n' "$C_GREEN" "$(ui_bar 20 20)" "$C_RESET"
+		ui_out '  %s%s %s%s  %s%d stages in %s%s\n' \
+			"$C_GREEN" "$UI_OK" "$1" "$C_RESET" "$C_DIM" "$UI_STEP" "$_total" "$C_RESET"
 	fi
-	if [ "$UI_VERBOSE" != "1" ]; then
-		printf '  %stool output: %s%s\n' "$C_DIM" "$UI_LOG" "$C_RESET"
+	if [ "$UI_MODE" = "live" ]; then
+		ui_out '  %stool output: %s%s\n' "$C_DIM" "$UI_LOG" "$C_RESET"
 	fi
+	return 0
+}
+
+# live mode only: stop the ticker, explain an early exit, give the cursor back.
+ui_on_exit() {
+	ui_live_stop
+	if [ "$UI_DONE" != "1" ]; then
+		if [ "$_ui_rc" = "130" ]; then _why="interrupted"; else _why="stopped with exit $_ui_rc"; fi
+		ui_out '  %s%s %-32s %s%s\n' "$C_RED" "$UI_BAD" "$UI_LABEL" "$_why" "$C_RESET"
+		if [ "$_ui_rc" != "130" ]; then
+			tail -n +$((UI_STAGE_LINE + 1)) "$UI_LOG" | tail -n 25 | sed 's/^/      /' >&9
+		fi
+		ui_out '  %sfull log: %s%s\n' "$C_DIM" "$UI_LOG" "$C_RESET"
+	fi
+	printf '\033[?25h' >&9
 }

--- a/core/release/ui.sh
+++ b/core/release/ui.sh
@@ -1,0 +1,164 @@
+# ---------------------------------------------------------------------------
+# ui.sh -- presentation for deploy_posix.sh: a banner, one progress line per
+# stage, quiet build output, and the log tail when a stage fails.
+#
+# Sourced, not executed, and POSIX sh only: deploy_posix.sh is #!/bin/sh, which
+# is dash on the Ubuntu runners (no arrays, no [[ ]], no local, no pipefail).
+#
+#   ui_banner "linux-x64" "2026.9.1"   once, after UI_TOTAL is set
+#   ui_step "label"                    at each stage boundary
+#   ui_q cmd args...                   run a tool, output hidden unless verbose
+#   ui_q cmd args... || ui_fail        and report it if it fails
+#   ui_ok "deploy complete"            names any failed stages instead
+#
+# Quiet is for people at a terminal. When stdout is not a terminal -- every CI
+# leg -- or with VERBOSE=1 or -v, ui_q runs the command untouched and its output
+# streams exactly as it did before this file existed, so a CI failure is read
+# from the same log it always was. Colour and the banner are terminal-only for
+# the same reason.
+# ---------------------------------------------------------------------------
+
+UI_TTY=0
+C_RESET=; C_BOLD=; C_DIM=; C_RED=; C_GREEN=; C_YELLOW=; C_BLUE=; C_CYAN=
+if [ -t 1 ]; then
+	UI_TTY=1
+	if [ -z "${NO_COLOR:-}" ] && [ "${TERM:-dumb}" != "dumb" ]; then
+		_e=$(printf '\033')
+		C_RESET="${_e}[0m"; C_BOLD="${_e}[1m"; C_DIM="${_e}[90m"
+		C_RED="${_e}[91m"; C_GREEN="${_e}[92m"; C_YELLOW="${_e}[93m"
+		C_BLUE="${_e}[94m"; C_CYAN="${_e}[96m"
+	fi
+fi
+
+UI_VERBOSE=0
+if [ "${VERBOSE:-0}" = "1" ] || [ "$UI_TTY" != "1" ]; then
+	UI_VERBOSE=1
+fi
+
+# Block glyphs where the terminal is UTF-8, ASCII everywhere else.
+UI_FILL='#'; UI_EMPTY='.'; UI_L='['; UI_R=']'
+if [ "$UI_TTY" = "1" ]; then
+	case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+		*UTF-8*|*utf-8*|*UTF8*|*utf8*) UI_FILL='█'; UI_EMPTY='░'; UI_L=''; UI_R='' ;;
+	esac
+fi
+
+UI_STEP=0
+UI_TOTAL=1
+UI_LABEL=setup
+UI_FAILED=0
+UI_FAILED_LABELS=
+UI_START=$(date +%s)
+UI_LOG="${TMPDIR:-/tmp}/objeck-deploy.log"
+if [ "$UI_VERBOSE" != "1" ]; then
+	: > "$UI_LOG"
+fi
+
+ui_elapsed() {
+	_el=$(( $(date +%s) - UI_START ))
+	printf '%dm %02ds' $((_el / 60)) $((_el % 60))
+}
+
+ui_bar() {  # $1 = filled cells of 28
+	_bar=''
+	_i=0
+	while [ "$_i" -lt "$1" ]; do _bar="$_bar$UI_FILL"; _i=$((_i + 1)); done
+	while [ "$_i" -lt 28 ]; do _bar="$_bar$UI_EMPTY"; _i=$((_i + 1)); done
+	printf '%s%s%s' "$UI_L" "$_bar" "$UI_R"
+}
+
+ui_banner() {  # $1 = target, $2 = version
+	if [ "$UI_TTY" != "1" ]; then
+		echo "=== Objeck $2 deploy: $1, $UI_TOTAL stages ==="
+		return 0
+	fi
+	printf '\n%s' "$C_CYAN"
+	cat <<'EOF'
+  ___   _        _              _
+ / _ \ | |__    (_)  ___   ___ | | __
+| | | || '_ \   | | / _ \ / __|| |/ /
+| |_| || |_) |  | ||  __/| (__ |   <
+ \___/ |_.__/  _/ | \___| \___||_|\_\
+              |__/
+EOF
+	printf '%s\n' "$C_RESET"
+	printf '  %sObjeck %s%s  %s%s, %d stages%s\n' \
+		"$C_BOLD" "$2" "$C_RESET" "$C_DIM" "$1" "$UI_TOTAL" "$C_RESET"
+	if [ "$UI_VERBOSE" != "1" ]; then
+		printf '  %stool output: %s%s\n' "$C_DIM" "$UI_LOG" "$C_RESET"
+		printf '  %spass -v or set VERBOSE=1 to stream it%s\n' "$C_DIM" "$C_RESET"
+	fi
+	echo
+}
+
+# ui_step "label" -- the bar shows stages already finished, so the first
+# stage reads 0% and 100% is printed only by ui_ok.
+ui_step() {
+	UI_STEP=$((UI_STEP + 1))
+	UI_LABEL="$1"
+	if [ "$UI_TTY" != "1" ]; then
+		printf '\n[%2d/%d] %s  (%s)\n' "$UI_STEP" "$UI_TOTAL" "$1" "$(ui_elapsed)"
+		return 0
+	fi
+	printf '  %s%s%s %3d%%  %s%2d/%d%s  %s%-30s%s %s%s%s\n' \
+		"$C_BLUE" "$(ui_bar $(( (UI_STEP - 1) * 28 / UI_TOTAL )))" "$C_RESET" \
+		$(( (UI_STEP - 1) * 100 / UI_TOTAL )) \
+		"$C_DIM" "$UI_STEP" "$UI_TOTAL" "$C_RESET" \
+		"$C_BOLD" "$1" "$C_RESET" \
+		"$C_DIM" "$(ui_elapsed)" "$C_RESET"
+}
+
+ui_q() {
+	if [ "$UI_VERBOSE" = "1" ]; then
+		"$@"
+	else
+		"$@" >>"$UI_LOG" 2>&1
+	fi
+}
+
+ui_warn() {
+	printf '  %s!  %s%s\n' "$C_YELLOW" "$1" "$C_RESET"
+}
+
+# ui_fail -- used as "ui_q cmd || ui_fail". $? on entry is cmd's exit status.
+#
+# Reports and CONTINUES, because the script it wraps always continued. That is
+# load-bearing: on green CI the linux-arm64 onnx build fails (ld: cannot find
+# -lonnxruntime) and the leg still passes, so stopping here would turn a
+# tolerated failure into a red build. ui_ok names every failed stage instead.
+ui_fail() {
+	_rc=$?
+	UI_FAILED=$((UI_FAILED + 1))
+	UI_FAILED_LABELS="${UI_FAILED_LABELS:+$UI_FAILED_LABELS, }$UI_LABEL"
+	printf '\n  %sX  FAILED at stage %d/%d: %s%s  %s(exit %s, after %s)%s\n' \
+		"$C_RED" "$UI_STEP" "$UI_TOTAL" "$UI_LABEL" "$C_RESET" \
+		"$C_DIM" "$_rc" "$(ui_elapsed)" "$C_RESET"
+	if [ "$UI_VERBOSE" != "1" ] && [ -s "$UI_LOG" ]; then
+		printf '  %slast 40 lines of %s:%s\n' "$C_DIM" "$UI_LOG" "$C_RESET"
+		tail -n 40 "$UI_LOG" | sed 's/^/    /'
+		printf '  %sre-run with -v or VERBOSE=1 to stream every build%s\n\n' "$C_DIM" "$C_RESET"
+	fi
+	return 0
+}
+
+ui_ok() {
+	if [ "$UI_FAILED" -gt 0 ]; then
+		if [ "$UI_TTY" != "1" ]; then
+			printf '\n=== finished with %d failed stage(s): %s (%d stages in %s) ===\n' \
+				"$UI_FAILED" "$UI_FAILED_LABELS" "$UI_STEP" "$(ui_elapsed)"
+			return 0
+		fi
+		printf '\n  %s!  finished with %d failed stage(s): %s%s  %s%d stages in %s%s\n' \
+			"$C_YELLOW" "$UI_FAILED" "$UI_FAILED_LABELS" "$C_RESET" "$C_DIM" "$UI_STEP" "$(ui_elapsed)" "$C_RESET"
+	elif [ "$UI_TTY" != "1" ]; then
+		printf '\n=== %s: %d stages in %s ===\n' "$1" "$UI_STEP" "$(ui_elapsed)"
+		return 0
+	else
+		printf '  %s%s%s 100%%\n\n' "$C_GREEN" "$(ui_bar 28)" "$C_RESET"
+		printf '  %s*  %s%s  %s%d stages in %s%s\n' \
+			"$C_GREEN" "$1" "$C_RESET" "$C_DIM" "$UI_STEP" "$(ui_elapsed)" "$C_RESET"
+	fi
+	if [ "$UI_VERBOSE" != "1" ]; then
+		printf '  %stool output: %s%s\n' "$C_DIM" "$UI_LOG" "$C_RESET"
+	fi
+}


### PR DESCRIPTION
Gives `deploy_windows.cmd` and `deploy_posix.sh` a modern command-line look when run by hand -- a banner, a progress line that keeps moving while the compiler runs, a line per finished stage with its own duration, and the build's output kept in a log -- without changing what CI sees or what the scripts build.

## What it looks like

```
  ___   _        _              _
 / _ \ | |__    (_)  ___   ___ | | __
| | | || '_ \   | | / _ \ / __|| |/ /
| |_| || |_) |  | ||  __/| (__ |   <
 \___/ |_.__/  _/ | \___| \___||_|\_\
              |__/

  Objeck 2026.9.1  windows-x64
  tool output: C:\Users\...\Temp\objeck-deploy-x64.log
  pass -v to stream it instead

  ✓ clean tree + version stamp      0m 01s
  ✓ compiler, vm, debugger, repl    1m 37s
    ! Crypto library DLL not found - skipping
  ✓ library: crypto                 0m 12s
  ⠹ ██████░░░░░░░░░░░░░░  26%   5/15  library: lame  0:04  > devenv lame.sln /rebuild "Release|x64"
```

The last line is redrawn ten times a second: spinner, bar, the stage's own timer, and the build's latest output line. The script's `ERROR:` / `Warning:` lines are lifted out of the log as they happen. On failure it prints the stage, the compiler errors (`file(line): error C1234: ...`) and that stage's last lines, and exits with the deploy's exit code. Ctrl+C stops the whole build tree.

## How

**Windows.** cmd cannot redraw anything while `devenv` blocks it, so run by hand, `deploy_windows.cmd` re-runs itself under a small PowerShell front end, `core/release/ui.ps1`. The deploy runs as a child writing to `%TEMP%\objeck-deploy-<arch>.log`, and `ui.cmd` prints `##ui step N label` markers into that log; `ui.ps1` follows the log and is the only process writing to the console. The script change is 33 inserted lines -- a launch block at the top, 16 stage markers, two completions and one warning -- and every one starts with `@`.

**POSIX.** In a terminal, `ui.sh` sends everything the script and its tools print to the log, keeps the terminal on fd 9, and redraws the live line from a background ticker that is stopped before any other line is printed and on exit, `INT` or `TERM`.

## CI sees what it saw before

- **Windows**: `GITHUB_ACTIONS`/`CI` means no relaunch -- output streams exactly as before, plus `[ n/N] stage (elapsed)` lines and a closing summary, with no escape codes. Every added line starts with `@`, so the echo-on log shows none of them, and `ui.cmd` deliberately has no `@echo off`: the first version of this PR had one, and because echo state is shared with the caller it would have silently removed every command echo from the rest of the deploy's CI log.
- **POSIX**: when stdout is not a terminal -- every workflow -- builds stream as before, plus the stage lines; no escape codes.
- **Control flow is unchanged.** Windows already aborts on every failure. POSIX reports a failed build (`|| ui_fail`) and carries on, as it always has: the native-library check after the builds -- which keeps master's own `|| exit 1` -- decides whether the tree ships. The closing line names any failed stages.
- `deploy_windows.cmd` never read `code_doc64.cmd`'s exit status; it now prints a warning when that step fails. Warning only.

## Cost (measured)

- **POSIX**, full `deploy_posix.sh x64` in WSL on the 7950X3D: master's script **135 s**, this one **138 s** (one run each; within run-to-run noise). The ticker costs 0.45 CPU-seconds per 10 seconds (under 5% of one core); the build runs `make -j3`.
- **Windows**, full `deploy_windows.cmd x64` in a console: master's script **237 s**, this one **231 s** (one run each, in the same console harness). `ui.ps1` costs ~1.5 CPU-seconds to start PowerShell, then a steady 1.75% of one core -- 6.1 CPU-seconds over the whole build.

## Options

- `-v` / `--verbose` after the target, or `VERBOSE=1`: stream everything, as before.
- `NO_COLOR=1`: no colour.

## Verification

- **Transforms** (both scripts): the added lines are stripped and the original from `origin/master` must come back byte for byte; stage counts match `UI_TOTAL` on both paths; no UI call sits between a command and the `if errorlevel` that reads it.
- **`ui.cmd` modes**: CI (commands still echoed, 0 escape bytes, no UI line echoed), `-v`, no Visual Studio environment (silent -- the script's own guard speaks), relaunch.
- **Exit codes through the relaunch**: 0 on success, 1 on failure. A bare `exit /b` after `powershell` returns **0** under `cmd /c`; `exit /b %errorlevel%` is required, and a probe of all four variants confirmed it.
- **`ui.ps1`**: redirected success and failure; a hidden console snapshotted every 250 ms showing the spinner, bar, timer and activity advancing; Windows Terminal glyphs (braille spinner, ✓ ✗) with no `?` substitution; if `ui.ps1` itself fails, the build tree is stopped rather than left running unwatched.
- **`ui.sh` under dash**: failing step, all green, early `exit 1`, piped (CI); no ticker process left behind; a failure shows only that stage's output.
- **Real runs**: `deploy_posix.sh x64` (WSL, 18 stages, 631 files, all eight native libraries) and `deploy_windows.cmd x64`: exit 0 in 3m 49s through all 15 stages; 819 console snapshots show the stage timer and devenv's own output advancing inside every stage; 679 files, native libraries verified.

Not exercised locally: the `deploy` packaging stages (WiX, signtool, tarball), the ARM64 targets, Ctrl+C in `ui.ps1`, and `deploy_macos_arm64.sh`, which this PR does not touch.

## Found while checking completeness -- not fixed here

- **v2026.9.1 shipped without some native libraries.** release-build run 34730145701: linux-arm64 lacks `libobjk_onnx.so`; macOS-arm64 lacks `libobjk_onnx.dylib` and `libobjk_opencv.dylib`. `verify_native_libs` flagged them, but the scripts ignored its exit status. **Now fixed on master** by d7d803ff6f; this branch's `deploy_posix.sh` was regenerated on top of it (merge 23e7be7578), and a full WSL deploy of the merged branch passes all 18 stages.
- **`programs/examples/gl_crystal.obj` has never been committed**: `.gitignore`'s `*.obj` swallows it. Being fixed in #805.
- **The `search_index.json` gate never ran** -- it was only in the generated `code_doc64.cmd`. Fixed separately in #802.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
