### PR TITLE
The search_index.json gate never ran: port it into code_doc64.in, and guard the templates

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1210,6 +1210,15 @@ jobs:
       - name: Shipped examples are all indexed
         run: python3 tools/cicd/check_examples_index.py
 
+      # Same class of guard. Every Windows deploy starts by regenerating tracked
+      # files from their .in templates (update_version.ps1), so an edit made to a
+      # generated file instead of its template is thrown away by every build that
+      # matters. The search_index.json check in code_doc64.cmd was exactly that:
+      # committed to the .cmd, absent from code_doc64.in, and never run by a
+      # Windows deploy (2026-09-13).
+      - name: Generated files match their .in templates
+        run: python3 tools/cicd/check_version_templates.py
+
       # Same reason, same cost: nothing built, fails in seconds. A native call
       # whose name is written as a literal at the call site allocates a String
       # on every call -- 1655ns against 130ns for the same call with the name

--- a/core/release/code_doc64.in
+++ b/core/release/code_doc64.in
@@ -41,6 +41,18 @@ if "%PAGES%"=="0" (
 )
 echo code_doc produced %PAGES% pages
 
+REM search_index.json is hand-built by doc_html.obs, and index.html fetches it
+REM behind a .catch that swallows a parse error -- so an invalid file makes search
+REM silently return nothing while the page still looks fine. One doc comment
+REM carrying the literal text '\uXXXX' did exactly that and shipped for seven
+REM releases. Parse it before packaging.
+python -c "import json,io; json.load(io.open(r'..\html\search_index.json',encoding='utf-8'))" 2>nul
+if errorlevel 1 (
+	echo ERROR: search_index.json is not valid JSON -- refusing to package api.zip
+	exit /b 1
+)
+echo search_index.json parses
+
 	rmdir /s /q ..\doc\api
 	mkdir ..\doc\api
 	xcopy /e ..\html\* ..\doc\api

--- a/tools/cicd/check_version_templates.py
+++ b/tools/cicd/check_version_templates.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Assert that every file update_version.ps1 generates matches its .in template.
+
+core/release/update_version.ps1 runs at the start of every Windows deploy -- CI,
+release-build and release-publish alike -- and regenerates tracked files from
+`.in` templates before anything reads them. An edit made to a generated file
+instead of its template therefore looks right in the repository and is erased by
+every build that matters.
+
+That happened to code_doc64.cmd. The check that search_index.json parses, added
+after an invalid index shipped for seven releases, went into the .cmd and never
+into code_doc64.in, so no Windows deploy ever ran it. A local deploy showed it:
+the regenerated .cmd came back twelve lines shorter than the committed one.
+
+The template list, the substitutions and the version are all read from
+update_version.ps1 itself, so this script cannot drift from the generator. Line
+endings and trailing newlines are ignored: Set-Content writes CRLF, and the
+script then rewrites most of its outputs LF.
+
+Run from anywhere:  python3 tools/cicd/check_version_templates.py
+Exit 0 when every generated file matches its rendered template, 1 otherwise.
+"""
+import difflib
+import os
+import re
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".."))
+PS1_DIR = os.path.join(ROOT, "core", "release")
+PS1 = os.path.join(PS1_DIR, "update_version.ps1")
+
+# One generator line:
+#   (Get-Content code_doc64.in) | ForEach-Object { $_ -replace "@VERSION@", $version } | ... | Set-Content code_doc64.cmd
+LINE = re.compile(r"^\(Get-Content\s+(\S+\.in)\)\s*(.*?)\|\s*Set-Content\s+(\S+)\s*$", re.M)
+REPLACE = re.compile(r'-replace\s+"(@[A-Z_]+@)",\s*\$(\w+)')
+PLACEHOLDER = re.compile(r"@[A-Z][A-Z_]*@")
+
+
+def read(path):
+    # latin-1 round-trips every byte, which is what Get-Content/Set-Content do
+    # with the ANSI codepage; the comparison is on bytes, not characters.
+    with open(path, "rb") as f:
+        return f.read().decode("latin-1").replace("\r\n", "\n").rstrip("\n")
+
+
+def resolve(ps_relative):
+    # Paths in the .ps1 are relative to core/release and Windows-style, with the
+    # odd doubled separator ("..\..\\programs").
+    parts = [p for p in re.split(r"[\\/]+", ps_relative) if p]
+    return os.path.normpath(os.path.join(PS1_DIR, *parts))
+
+
+def rel(path):
+    return os.path.relpath(path, ROOT).replace(os.sep, "/")
+
+
+def main():
+    text = read(PS1)
+
+    scalars = dict(re.findall(r'^\$(year_end|month_end|version)\s*=\s*"(\d+)"', text, re.M))
+    missing = {"year_end", "month_end", "version"} - scalars.keys()
+    if missing:
+        print(f"ERROR: could not read {', '.join(sorted(missing))} from {rel(PS1)} -- has its format changed?")
+        return 1
+    version = "{year_end}.{month_end}.{version}".format(**scalars)
+    values = {
+        "version": version,
+        "year_end": scalars["year_end"],
+        "month_end": scalars["month_end"],
+        "version_number": version.replace(".", ""),
+        "version_windows": version.replace(".", ","),
+    }
+
+    jobs = LINE.findall(text)
+    if not jobs:
+        print(f"ERROR: found no '(Get-Content X.in) ... | Set-Content Y' lines in {rel(PS1)} -- has its format changed?")
+        return 1
+
+    failures = 0
+    for template, pipeline, output in jobs:
+        tin, out = resolve(template), resolve(output)
+        subs = REPLACE.findall(pipeline)
+        unknown = sorted({var for _, var in subs if var not in values})
+        if unknown:
+            print(f"ERROR  {rel(out)}: update_version.ps1 substitutes ${', $'.join(unknown)}, which this check does not compute")
+            failures += 1
+            continue
+        if not os.path.isfile(tin) or not os.path.isfile(out):
+            print(f"ERROR  {rel(out)}: template exists={os.path.isfile(tin)}, output exists={os.path.isfile(out)}")
+            failures += 1
+            continue
+
+        rendered = read(tin)
+        for token, var in subs:
+            rendered = rendered.replace(token, values[var])
+        committed = read(out)
+        leftover = sorted(set(PLACEHOLDER.findall(rendered)))
+
+        if rendered == committed and not leftover:
+            print(f"ok     {rel(out)}  <-  {rel(tin)}")
+            continue
+
+        failures += 1
+        print(f"DRIFT  {rel(out)} does not match {rel(tin)} rendered at {version}")
+        if leftover:
+            print(f"       unreplaced placeholders: {' '.join(leftover)}")
+        diff = list(difflib.unified_diff(rendered.split("\n"), committed.split("\n"),
+                                         f"{rel(tin)} (rendered)", f"{rel(out)} (committed)", n=1, lineterm=""))
+        for line in diff[:40]:
+            print("       " + line)
+        if len(diff) > 40:
+            print(f"       ... {len(diff) - 40} more diff lines")
+
+    if failures:
+        print()
+        print(f"{failures} generated file(s) differ from their templates. Every Windows deploy regenerates")
+        print("them with update_version.ps1, so a change made only to the output is thrown away.")
+        print("Make the change in the .in template, then regenerate (or apply it to both).")
+        return 1
+
+    print(f"all {len(jobs)} generated files match their templates (version {version})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The check that `search_index.json` parses (#799) was added to `core/release/code_doc64.cmd` -- a **generated** file. `update_version.ps1` rewrites it from `code_doc64.in` at the start of every Windows deploy, in CI, release-build and release-publish alike, so every deploy erased the gate before `code_doc64` ran. The committed copy looked right, which is why nothing noticed.

Found by a local `deploy_windows.cmd x64` run for #801: afterwards `git diff` showed the regenerated `code_doc64.cmd` twelve lines shorter than the committed one.

## Changes

- **`core/release/code_doc64.in`** -- the twelve gate lines, verbatim. The template now renders to exactly the committed `code_doc64.cmd`.
- **`tools/cicd/check_version_templates.py`** (new) -- reads the template list, the substitutions and the version from `update_version.ps1` itself (so it cannot drift from the generator), renders each `.in`, and fails on any difference from the committed output, with a diff. Line endings and trailing newlines are ignored.
- **`ci-build.yml`** -- runs it in the Tools job beside the other doc guards.

## How the .in files are used

`update_version.ps1` is the only generator, and it renders eight templates: `core/shared/version.h`, `core/release/code_doc64.cmd`, `programs/deploy/util/readme/readme.json`, and the five `objeck.rc` resource files (compiler, vm, debugger, repl, launcher builder). It also regex-edits the VS Code `package.json`, which has no template. release-build rewrites the version in the `.ps1` from the tag, so Windows renders the same version as Linux and macOS. The remaining tracked `.in` files are vendored (SDL and ODBC autoconf templates) or belong to the openai readme builder, and nothing stamps versions into them.

Of the eight, only `code_doc64.cmd` had drifted.

## Verification

- Fixed tree: all 8 generated files match (Windows Python and WSL `python3`), exit 0.
- Template reverted to master's copy: `DRIFT core/release/code_doc64.cmd`, naming the twelve lines, exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
