### PR TITLE
fix(examples): commit gl_crystal.obj, which *.obj had kept out of the tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 
 # MSVC compiled objects
 *.obj
+# ...but this one is a Wavefront OBJ model that gl_model.obs loads
+!programs/examples/gl_crystal.obj
 
 # Linker artifacts
 *.exp

--- a/docs/JIT_ARM64_HANDOFF_2026_09.md
+++ b/docs/JIT_ARM64_HANDOFF_2026_09.md
@@ -81,8 +81,7 @@ GCC_PREPROCESSOR_DEFINITIONS='$(inherited) _DEBUG_JIT_JIT' SYMROOT=<dir> OBJROOT
 leaves the deploy tree alone; its listing omits emitters that print under `_DEBUG_JIT` only
 (`add_shifted_reg_reg`) and prints per call at run time, so trace a small program. A master VM
 for alternated timings comes from a `git worktree` of master built the same way. `zsh` treats a
-bare `====` as a command; separate output with `printf`. `deploy_macos_arm64.sh` fails to copy
-`programs/examples/gl_crystal.obj`, which is not in the tree, and carries on.
+bare `====` as a command; separate output with `printf`.
 
 ## 1. Where the tree is
 

--- a/programs/examples/gl_crystal.obj
+++ b/programs/examples/gl_crystal.obj
@@ -1,0 +1,64 @@
+# gl_crystal.obj -- the model gl_model.obs loads by default.
+#
+# A doubly terminated quartz crystal: a hexagonal prism standing on the Y axis
+# with a six-sided point at each end. Written by hand, so every line is legible.
+#
+#   v   14 positions: the top point, two rings of six, the bottom point
+#   f   18 faces: 6 triangles, 6 quads, 6 triangles (the quads are fanned
+#       into two triangles each by the loader, 24 triangles in all)
+#
+# No vn lines, on purpose. Plenty of real files carry no normals, and without
+# them Mesh->FromObj computes a flat normal per face from its winding -- which
+# is why each facet shades as one flat plane. No vt lines either, so the whole
+# crystal samples a single texel of the demo's texture.
+#
+# Winding is counter-clockwise seen from outside, so it survives GL_CULL_FACE.
+# Indices are 1-based.
+
+o crystal
+
+# top point
+v  0.00  1.90  0.00
+
+# upper ring, y = 0.9, counter-clockwise from +X seen from below
+v  0.60  0.90  0.00
+v  0.30  0.90  0.52
+v -0.30  0.90  0.52
+v -0.60  0.90  0.00
+v -0.30  0.90 -0.52
+v  0.30  0.90 -0.52
+
+# lower ring, y = -0.9, directly beneath the upper one
+v  0.60 -0.90  0.00
+v  0.30 -0.90  0.52
+v -0.30 -0.90  0.52
+v -0.60 -0.90  0.00
+v -0.30 -0.90 -0.52
+v  0.30 -0.90 -0.52
+
+# bottom point
+v  0.00 -1.90  0.00
+
+# top termination
+f 1 3 2
+f 1 4 3
+f 1 5 4
+f 1 6 5
+f 1 7 6
+f 1 2 7
+
+# prism sides
+f 2 3 9 8
+f 3 4 10 9
+f 4 5 11 10
+f 5 6 12 11
+f 6 7 13 12
+f 7 2 8 13
+
+# bottom termination
+f 14 8 9
+f 14 9 10
+f 14 10 11
+f 14 11 12
+f 14 12 13
+f 14 13 8


### PR DESCRIPTION
## Problem

`programs/examples/gl_crystal.obj` has never been committed on any branch (`git log --all` finds nothing for it), yet several places depend on it:

- `gl_model.obs` loads it by default and fails with *"Could not load gl_crystal.obj"*
- `run_gl.cmd` and `run_gl.sh` pass it as the default argument for `gl_model`
- `deploy_windows.cmd`, `deploy_posix.sh` and `deploy_macos_arm64.sh` copy it, so CI logs *"The system cannot find the file specified."* and *"cp: cannot stat 'programs/examples/gl_crystal.obj'"*

The cause is `.gitignore` line 10: `*.obj` is meant for MSVC object files, but it also matches this Wavefront OBJ model.

## Fix

- **`programs/examples/gl_crystal.obj`**: a new hand-written model of a doubly terminated quartz crystal (a hexagonal prism along Y with a six-sided point at each end).
  - 14 `v` lines and 18 `f` lines: 12 triangles for the two points and 6 quads for the sides. The quads cover the loader's fan path, so the model draws as 24 triangles.
  - As `gl_model.obs`'s header says, there are **no `vn` lines**, so `Mesh->FromObj` has to generate flat normals from the winding. There are no `vt` lines either.
  - Winding is counter-clockwise seen from outside, and indices are 1-based.
- **`.gitignore`**: adds `!programs/examples/gl_crystal.obj` right after `*.obj`. `git check-ignore programs/examples/gl_crystal.obj` now exits 1 (not ignored), and other `*.obj` files are still ignored.
- **`docs/JIT_ARM64_HANDOFF_2026_09.md`**: removes the note saying the macOS deploy script can't find the file.

The deploy scripts are unchanged; they already copy this file. `programs/regression/gl_context_test.obs` doesn't have the same problem: it writes its `.obj` fixtures to the temp directory at runtime.

## Verification (Windows x64, `deploy-x64` at 2026.9.1)

- **Geometry check (Python script that fans faces the same way `FromObj` does):** the mesh is closed, every edge is shared by exactly one face in each direction, all 24 triangles face outward, quads are planar, and no vertices are unused.
- **GL probe (real window, `Mesh->FromObj` on this file):**
  - `IsOk` is true, radius is 2.059223 and the size is 1.2 × 3.8 × 1.04.
  - The probe draws the model with a shader that colours each pixel by the sign of the generated normal's z. Culling off: 691 camera-facing pixels, 0 back-facing. Culling on: the same 691 and 0.
  - Control: a copy with reversed faces fails the probe (0 camera-facing and 691 back-facing with culling off).
- **`gl_model.obs`:** compiles with `-lib sdl2,sdl_gl`. When run on this file it shows a lit, flat-faceted crystal spinning on its long axis.

Not checked: Linux and macOS runs, and the CI deploy logs, which should stop reporting the missing file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
