### PR TITLE
fix(release): fail POSIX deploys when a required native library is missing

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -87,12 +87,17 @@ jobs:
         # Skip apt-get upgrade — it pulls unrelated packages (e.g. the firefox
         # snap stub) that occasionally fail to install on the runner image and
         # break this job for reasons unrelated to our build.
+        #
+        # libopencv-dev and libmp3lame-dev: without them the opencv, onnx and
+        # lame native libraries never built here -- so CodeQL never saw that
+        # C++ -- and deploy_posix.sh now fails when a required library is missing.
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
           build-essential git libmbedtls-dev unixodbc-dev \
           libsdl2-dev libsdl2-image-dev libsdl2-ttf-dev libsdl2-mixer-dev \
           libreadline-dev unzip libeigen3-dev libnghttp2-dev \
-          libngtcp2-dev libngtcp2-crypto-gnutls-dev libnghttp3-dev libgnutls28-dev
+          libngtcp2-dev libngtcp2-crypto-gnutls-dev libnghttp3-dev libgnutls28-dev \
+          libopencv-dev libmp3lame-dev pkg-config
         cd core/release && ./deploy_posix.sh x64
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -239,7 +239,7 @@ jobs:
           # plain `brew install` aborts with "already installed" (red CI error
           # annotations) even though the build is fine. Skip present packages and
           # install the rest, so genuine install failures still surface.
-          for pkg in opencv onnxruntime mbedtls nghttp2 libnghttp3 gnutls cmake unixodbc sdl2 sdl2_image sdl2_ttf sdl2_mixer readline eigen lame; do
+          for pkg in opencv@4 onnxruntime mbedtls nghttp2 libnghttp3 gnutls cmake unixodbc sdl2 sdl2_image sdl2_ttf sdl2_mixer readline eigen lame; do
             if brew list --versions "$pkg" >/dev/null 2>&1; then
               echo "✓ $pkg already installed — skipping"
             else
@@ -251,6 +251,18 @@ jobs:
           # Add Homebrew bin to PATH
           export PATH="/opt/homebrew/bin:$PATH"
           echo "/opt/homebrew/bin" >> $GITHUB_PATH
+
+          # Homebrew's default `opencv` is now OpenCV 5.0, which moved functions
+          # out of cv:: (contourArea, boundingRect, getRotationMatrix2D,
+          # approxPolyDP, estimateAffinePartial2D, LMEDS), so the opencv and onnx
+          # native libraries do not compile against it. ci-build.yml was pinned to
+          # opencv@4 in 22cb90d0f7 and this workflow was not: v2026.9.1's macOS
+          # release shipped without libobjk_opencv and libobjk_onnx while CI on
+          # the same commit built both. opencv@4 is keg-only, so expose its
+          # pkg-config dir to the later steps (onnx/eq/build.sh resolves opencv4).
+          if [ -d /opt/homebrew/opt/opencv@4/lib/pkgconfig ]; then
+            echo "PKG_CONFIG_PATH=/opt/homebrew/opt/opencv@4/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> $GITHUB_ENV
+          fi
 
       - name: Build ngtcp2 with GnuTLS backend (macOS)
         if: runner.os == 'macOS'

--- a/core/lib/onnx/eq/build.sh
+++ b/core/lib/onnx/eq/build.sh
@@ -14,11 +14,32 @@ fi
 
 rm -f *.o *.so *.dll *.dylib 2>/dev/null
 
+# The vendored runtime is per architecture, under cuda/lib/<arch>/lib, and only
+# x64 is vendored. Linking that copy on aarch64 fails ("skipping incompatible
+# ... cannot find -lonnxruntime") but only after a minute compiling onnx.cpp --
+# which is how v2026.9.1's linux-arm64 release came to ship without
+# libobjk_onnx. Say so up front, and use an arm64 runtime once one is vendored.
+case "$(uname -m)" in
+	x86_64|amd64) ORT_ARCH=x64 ;;
+	aarch64|arm64) ORT_ARCH=arm64 ;;
+	*) ORT_ARCH=$(uname -m) ;;
+esac
+ORT_VENDORED="./cuda/lib/$ORT_ARCH/lib"
+
+require_vendored_ort() {
+	if [ ! -d "$ORT_VENDORED" ]; then
+		echo "ERROR: no vendored ONNX Runtime for $(uname -m): $ORT_VENDORED does not exist" >&2
+		echo "       (only cuda/lib/x64 is vendored, so libobjk_onnx cannot be built here)" >&2
+		exit 1
+	fi
+}
+
 case "$PROVIDER" in
 	cuda)
 		EP_DEFINE="-DONNX_EP_CUDA"
 		ORT_INCLUDE="-I./cuda/lib/include"
-		ORT_LIB="-L./cuda/lib/x64/lib -lonnxruntime"
+		require_vendored_ort
+		ORT_LIB="-L$ORT_VENDORED -lonnxruntime"
 		;;
 	coreml)
 		EP_DEFINE="-DONNX_EP_COREML"
@@ -38,7 +59,8 @@ case "$PROVIDER" in
 		# fails to link on a machine that has none -- even though a usable
 		# runtime is sitting in cuda/lib/x64/lib. That runtime is CPU-only, so
 		# it is exactly the right one for this mode.
-		ORT_LIB="-L./cuda/lib/x64/lib -lonnxruntime"
+		require_vendored_ort
+		ORT_LIB="-L$ORT_VENDORED -lonnxruntime"
 		;;
 	*)
 		echo "Unknown provider: $PROVIDER"
@@ -93,7 +115,7 @@ fi
 
 $CXX -O3 -std=c++17 -Wall -fPIC $EP_DEFINE $ORT_INCLUDE $EXTRA_INCLUDE \
 	-c `pkg-config --cflags $OPENCV_PC` onnx.cpp \
-	-Wno-unused-function -Wno-deprecated-declarations
+	-Wno-unused-function -Wno-deprecated-declarations || exit 1
 
 OS=$(uname -s)
 case "$OS" in
@@ -106,7 +128,16 @@ case "$OS" in
 			`pkg-config --libs $OPENCV_PC` $ORT_LIB
 		;;
 	*)
-		$CXX -O3 -shared -Wl,-soname,libobjk_onnx.so.1 -o libobjk_onnx.so *.o \
+		# RUNPATH $ORIGIN: deploy_posix.sh ships libonnxruntime.so.1 beside this
+		# library in lib/native, but the VM dlopens libobjk_onnx by absolute path,
+		# and that does not add lib/native to the search for its dependencies.
+		# Without this the shipped library loaded only under
+		# LD_LIBRARY_PATH=lib/native -- which CI and run_regression.sh set and a
+		# user who untarred the release does not: v2026.9.1 fails with
+		# "libonnxruntime.so.1: cannot open shared object file", or, on a machine
+		# with its own onnxruntime, "version `VERS_1.19.0' not found". RUNPATH is
+		# searched before ld.so.cache, so the bundled runtime wins over that one.
+		$CXX -O3 -shared -Wl,-soname,libobjk_onnx.so.1 -Wl,-rpath,'$ORIGIN' -o libobjk_onnx.so *.o \
 			`pkg-config --libs $OPENCV_PC` $ORT_LIB
 		;;
 esac

--- a/core/release/deploy_macos_arm64.sh
+++ b/core/release/deploy_macos_arm64.sh
@@ -202,8 +202,12 @@ cp libobjk_onnx.dylib ../../../release/deploy/lib/native/libobjk_onnx.dylib
 
 # Every native library this script builds must be present (and, on Linux,
 # resolvable) before the tree is packaged. Without this a failed build was
-# dropped from the release with a green exit -- the obu incident, again.
-sh ../../../release/verify_native_libs.sh ../../../release/deploy/lib/native dylib crypto diags lame ml odbc onnx opencv sdl
+# dropped from the release with a green exit -- the obu incident, again. The
+# result has to be acted on: this script has no 'set -e', and before the
+# '|| exit 1' below v2026.9.1 printed "2 native-library verification failure(s)"
+# (onnx, opencv) and shipped its .pkg, .zip and .tgz without them. All eight are
+# required on macOS; see verify_native_libs.sh.
+sh ../../../release/verify_native_libs.sh ../../../release/deploy/lib/native dylib crypto diags lame ml odbc onnx opencv sdl || exit 1
 cd ..
 
 # build macOS app launcher (.app bundle)

--- a/core/release/deploy_posix.sh
+++ b/core/release/deploy_posix.sh
@@ -87,17 +87,32 @@ cd ../onnx/eq
 # catch returned without setting the session handle it surfaced as a silently
 # null session rather than an error. Link a CUDA-enabled onnxruntime before
 # switching this back to cuda.
-./build.sh cpu
-cp libobjk_onnx.so ../../../release/deploy/lib/native/libobjk_onnx.so
+#
+# Only an x86-64 runtime is vendored (cuda/lib/x64). Build and ship ONNX only
+# for an architecture that has one: on arm64 the link fails, and the copies
+# below put a 16 MB x86-64 libonnxruntime into the aarch64 tree -- which is what
+# the v2026.9.1 linux-arm64 tarball carries, with no libobjk_onnx beside it.
+# verify_native_libs.sh declares onnx optional on arm64 for as long as that holds.
+if [ "$1" = "arm64" ]; then
+	ORT_ARCH=arm64
+else
+	ORT_ARCH=x64
+fi
+if [ -d cuda/lib/$ORT_ARCH/lib ]; then
+	./build.sh cpu
+	cp libobjk_onnx.so ../../../release/deploy/lib/native/libobjk_onnx.so
 
-# copy ONNX Runtime shared libraries
-cp cuda/lib/x64/lib/libonnxruntime.so.1.19.0 ../../../release/deploy/lib/native/libonnxruntime.so.1.19.0
-cd ../../../release/deploy/lib/native
-ln -sf libonnxruntime.so.1.19.0 libonnxruntime.so.1
-ln -sf libonnxruntime.so.1 libonnxruntime.so
-cd ../../../../lib/onnx/eq
+	# copy ONNX Runtime shared libraries
+	cp cuda/lib/$ORT_ARCH/lib/libonnxruntime.so.1.19.0 ../../../release/deploy/lib/native/libonnxruntime.so.1.19.0
+	cd ../../../release/deploy/lib/native
+	ln -sf libonnxruntime.so.1.19.0 libonnxruntime.so.1
+	ln -sf libonnxruntime.so.1 libonnxruntime.so
+	cd ../../../../lib/onnx/eq
 
-cp cuda/lib/x64/lib/libonnxruntime_providers_shared.so ../../../release/deploy/lib/native/libonnxruntime_providers_shared.so
+	cp cuda/lib/$ORT_ARCH/lib/libonnxruntime_providers_shared.so ../../../release/deploy/lib/native/libonnxruntime_providers_shared.so
+else
+	echo "NOTE: no vendored ONNX Runtime for $ORT_ARCH (cuda/lib/$ORT_ARCH/lib) - libobjk_onnx is not built"
+fi
 cd ../../sdl
 ./build_linux.sh sdl
 cp sdl.so ../../release/deploy/lib/native/libobjk_sdl.so
@@ -109,8 +124,17 @@ cp diags.so ../../release/deploy/lib/native/libobjk_diags.so
 
 # Every native library this script builds must be present (and, on Linux,
 # resolvable) before the tree is packaged. Without this a failed build was
-# dropped from the release with a green exit -- the obu incident, again.
-sh ../../release/verify_native_libs.sh ../../release/deploy/lib/native so crypto diags lame ml odbc onnx opencv sdl
+# dropped from the release with a green exit -- the obu incident, again. The
+# result has to be acted on: this script has no 'set -e', and before the
+# '|| exit 1' below v2026.9.1 printed "native-library verification failure(s)"
+# on both Linux legs and shipped anyway. verify_native_libs.sh records which
+# libraries each platform requires, and why onnx is optional on arm64.
+if [ "$1" = "arm64" ]; then
+	NATIVE_LIBS="crypto diags lame ml odbc opencv sdl --optional onnx"
+else
+	NATIVE_LIBS="crypto diags lame ml odbc onnx opencv sdl"
+fi
+sh ../../release/verify_native_libs.sh ../../release/deploy/lib/native so $NATIVE_LIBS || exit 1
 
 cd ../../utils/launcher
 if [ ! -z "$1" ] && [ "$1" = "arm64" ]; then

--- a/core/release/verify_native_libs.sh
+++ b/core/release/verify_native_libs.sh
@@ -5,32 +5,125 @@
 # scripts had none, so a library whose build failed was silently dropped from
 # the release with a green exit.
 #
-# usage: verify_native_libs.sh <native_dir> <ext> <name>...
-#   e.g. verify_native_libs.sh deploy/lib/native so odbc crypto lame ml opencv onnx sdl diags
+# usage: verify_native_libs.sh <native_dir> <ext> <required>... [--optional <name>...]
+#   e.g. verify_native_libs.sh deploy/lib/native so crypto diags lame ml odbc opencv sdl --optional onnx
+#
+# Exits 1 on a verification failure (2 on a usage error), and the CALLER has to
+# act on it with '|| exit 1': no deploy script uses 'set -e'. For the first
+# release that ran this check none did -- v2026.9.1 printed "native-library
+# verification failure(s)" on linux-x64, linux-arm64 and macos-arm64, and every
+# one of those jobs went green and shipped.
+#
+#   required  missing, or (Linux) present with an unresolved dependency: failure
+#   optional  missing: a warning, plus a ::warning:: annotation under GitHub
+#             Actions so it reaches the run summary instead of the scrollback.
+#             Present: checked exactly like a required library -- whatever the
+#             tree ships has to load, however optional it was to ship it.
+# A library named in neither list is not checked at all, so a new native library
+# has to be added to its caller's list.
+#
+# What each platform requires (the deploy scripts pass these lists):
+#
+#   platform     required                                   optional
+#   linux-x64    crypto diags lame ml odbc onnx opencv sdl  -
+#   linux-arm64  crypto diags lame ml odbc opencv sdl       onnx
+#   macos-arm64  crypto diags lame ml odbc onnx opencv sdl  -
+#
+#   onnx is optional on linux-arm64 because the only vendored ONNX Runtime is
+#   x86-64 (core/lib/onnx/eq/cuda/lib/x64) and Ubuntu 24.04 packages none, so
+#   there is nothing to link against. Vendor an aarch64 runtime under
+#   cuda/lib/arm64/lib -- build.sh and deploy_posix.sh pick it up from there --
+#   then move onnx to the required list.
+#
+#   The two MSYS2 deploys pass all eight as required but still ignore the exit
+#   status; no CI leg runs them to hold them to it.
 set -u
+
+usage() {
+  echo "usage: verify_native_libs.sh <native_dir> <ext> <required>... [--optional <name>...]" >&2
+  exit 2
+}
+
+[ $# -ge 3 ] || usage
 dir="$1"
 ext="$2"
 shift 2
 
+required=""
+optional=""
+list=required
+for arg in "$@"; do
+  case "$arg" in
+    --optional)
+      list=optional
+      ;;
+    -*)
+      echo "verify_native_libs.sh: unknown option: $arg" >&2
+      usage
+      ;;
+    *)
+      if [ "$list" = required ]; then
+        required="$required $arg"
+      else
+        case " $required " in
+          *" $arg "*)
+            echo "verify_native_libs.sh: $arg is both required and optional" >&2
+            exit 2
+            ;;
+        esac
+        optional="$optional $arg"
+      fi
+      ;;
+  esac
+done
+
+# annotate <error|warning> <message>: surface a line on the GitHub Actions run
+annotate() {
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    echo "::$1::$2"
+  fi
+}
+
 failures=0
 checked=0
-for name in "$@"; do
-  lib="$dir/libobjk_$name.$ext"
+not_built=""
+
+# check <name> <required|optional>
+check() {
+  lib="$dir/libobjk_$1.$ext"
   if [ ! -f "$lib" ]; then
-    echo "ERROR: missing native library: $lib"
-    failures=$((failures + 1))
-    continue
+    if [ "$2" = optional ]; then
+      echo "WARNING: optional native library not built: $lib"
+      annotate warning "optional native library not built: libobjk_$1.$ext"
+      not_built="$not_built $1"
+    else
+      echo "ERROR: missing native library: $lib"
+      annotate error "missing native library: libobjk_$1.$ext"
+      failures=$((failures + 1))
+    fi
+    return
   fi
   checked=$((checked + 1))
-  # Linux: an unresolved dependency shows as "not found". macOS's otool does
-  # not report absence, and the macOS deploy has its own install_name checks.
+  # Linux: an unresolved dependency shows as "not found", and so does one that
+  # resolves to the wrong build ("version `VERS_x' not found", on stderr).
+  # macOS's otool does not report absence, and the macOS deploy has its own
+  # install_name checks.
   if [ "$ext" = "so" ] && command -v ldd >/dev/null 2>&1; then
-    if ldd "$lib" 2>/dev/null | grep -q "not found"; then
+    unresolved=$(ldd "$lib" 2>&1 | grep "not found")
+    if [ -n "$unresolved" ]; then
       echo "ERROR: unresolved dependency in $lib:"
-      ldd "$lib" | grep "not found" | sed 's/^/    /'
+      echo "$unresolved" | sed 's/^[[:space:]]*/    /'
+      annotate error "unresolved dependency in libobjk_$1.$ext"
       failures=$((failures + 1))
     fi
   fi
+}
+
+for name in $required; do
+  check "$name" required
+done
+for name in $optional; do
+  check "$name" optional
 done
 
 if [ "$failures" -ne 0 ]; then
@@ -39,4 +132,8 @@ if [ "$failures" -ne 0 ]; then
   echo "============================================================"
   exit 1
 fi
-echo "native libraries verified: $checked in $dir"
+if [ -n "$not_built" ]; then
+  echo "native libraries verified: $checked in $dir (optional, not built:$not_built)"
+else
+  echo "native libraries verified: $checked in $dir"
+fi


### PR DESCRIPTION
## Summary

`verify_native_libs.sh` exits 1 when a native library is missing or cannot load, but `deploy_posix.sh` and `deploy_macos_arm64.sh` never checked that exit code, and neither script uses `set -e`. So the check printed `ERROR: N native-library verification failure(s)` and the job still passed. v2026.9.1 was built and published this way on three of its five platforms.

This PR makes a failure in a **required** library fail the deploy. Libraries a platform can't build yet are listed explicitly as **optional**. The three separate problems the check was already reporting are also fixed, so CI stays green.

## What v2026.9.1 actually shipped

These come from listing the published assets' `lib/native`, not just from reading the CI logs.

| Asset | Missing | Also wrong |
|---|---|---|
| `objeck-linux-arm64_2026.9.1.tgz` | `libobjk_onnx.so` | Contains a 16 MB **x86-64** `libonnxruntime.so.1.19.0` and `libonnxruntime_providers_shared.so` (checked with `file`) that can't load on aarch64 |
| `objeck-macos-arm64_2026.9.1.{tgz,zip,pkg}` | `libobjk_onnx.dylib`, `libobjk_opencv.dylib` | The `.zip` and `.pkg` are built from the same tree as the `.tgz` |
| `objeck-linux-x64_2026.9.1.tgz` | nothing | `libobjk_onnx.so` has no RPATH/RUNPATH, so it **does not load** for someone who just untarred the release (see below) |

Reproduced on Ubuntu 24.04 (WSL) using the released x64 tarball, running `onnx_runtime_test.obs` from the tarball's own `bin/`:

```
$ env -u LD_LIBRARY_PATH ./obr ort.obe
>>> Runtime error loading shared library: /usr/local/onnxruntime/lib/libonnxruntime.so.1: version `VERS_1.19.0' not found (required by ../lib//native/libobjk_onnx.so) <<<     exit 1
$ LD_LIBRARY_PATH=../lib/native ./obr ort.obe
All tests passed                                                                                                                                                     exit 0
```

That machine happens to have its own ONNX Runtime installed. A machine with none gets `libonnxruntime.so.1 => not found`, which is what CI's `ldd` reported. CI never saw this at runtime because `run_regression.sh` exports `LD_LIBRARY_PATH=lib/native`.

## Root causes

1. **The check's result was ignored.** `sh verify_native_libs.sh ...` ran with no `|| exit 1`, in scripts that don't use `set -e`. (`deploy_windows.cmd` does check `verify_native_libs.ps1`.)
2. **linux-arm64 has no ONNX Runtime to link against.** `onnx/eq/build.sh` always linked `-L./cuda/lib/x64/lib`, the only runtime vendored. On aarch64 that gives `ld: skipping incompatible ... cannot find -lonnxruntime`, but only after a minute compiling `onnx.cpp`. `deploy_posix.sh` then copied the x86-64 runtime into the arm64 tree anyway. Ubuntu 24.04 doesn't package ONNX Runtime either.
3. **The macOS release was built against OpenCV 5.** Homebrew's default `opencv` is now 5.0, which moved `contourArea`, `boundingRect`, `getRotationMatrix2D`, `approxPolyDP`, `estimateAffinePartial2D` and `LMEDS` out of `cv::`. Commit 22cb90d0f7 pinned `ci-build.yml` to `opencv@4` but not `release-build.yml`. As a result, CI on master verified all 8 macOS libraries (run 34745510500), while the tag build (run 34730145701) failed with exactly those errors.
4. **linux-x64 `libobjk_onnx.so` has no `$ORIGIN` RUNPATH.** The VM `dlopen`s it by absolute path, which doesn't add `lib/native` to the search path for its dependencies.

The same problem was hidden in **CodeQL** too. The last completed run (34746751299, green) had 3 verification failures (lame, onnx, opencv), because `libopencv-dev` and `libmp3lame-dev` aren't installed. So CodeQL had never analysed that C++.

## Required vs optional, per platform

This table is also in the header of `verify_native_libs.sh`.

| Platform | Required | Optional |
|---|---|---|
| linux-x64 | crypto diags lame ml odbc onnx opencv sdl | – |
| linux-arm64 | crypto diags lame ml odbc opencv sdl | **onnx**: no aarch64 ONNX Runtime is vendored. Vendor one under `cuda/lib/arm64/lib`; `build.sh` and `deploy_posix.sh` pick it up from there. Then move onnx to required. |
| macos-arm64 | crypto diags lame ml odbc onnx opencv sdl | – |

An optional library that is **missing** produces a `WARNING` line and a GitHub `::warning::` annotation. An optional library that is **present** is checked exactly like a required one: anything the tree ships has to load.

## Changes

- **`core/release/verify_native_libs.sh`**
  - New usage: `<dir> <ext> <required>... [--optional <name>...]`. A name in both lists, an unknown option, or too few arguments exits 2.
  - Adds `::error::`/`::warning::` annotations when running under GitHub Actions.
  - Now reads `ldd`'s stderr as well, so `version ... not found` counts as unresolved.
- **`core/release/deploy_posix.sh`**
  - `|| exit 1` on the verify call, with a per-architecture list (onnx is optional on arm64 only).
  - ONNX is built, and its runtime copied, only when `cuda/lib/<arch>/lib` exists. arm64 no longer ships an x86-64 runtime.
- **`core/release/deploy_macos_arm64.sh`**: `|| exit 1`; all eight libraries required.
- **`core/lib/onnx/eq/build.sh`**
  - Links with `-Wl,-rpath,'$ORIGIN'` (produces `RUNPATH`, which is searched before `ld.so.cache`, so the bundled 1.19.0 also wins over a system install).
  - Picks `cuda/lib/<arch>/lib` and fails immediately if there isn't one.
  - Stops on a compile failure instead of going on to `clang++: no such file or directory: '*.o'`.
- **`.github/workflows/release-build.yml`**: `opencv` → `opencv@4`, and exports its keg `PKG_CONFIG_PATH` (same as `ci-build.yml`).
- **`.github/workflows/codeql.yml`**: installs `libopencv-dev libmp3lame-dev pkg-config`.

## Verification

**Unit tests for `verify_native_libs.sh` and the `build.sh` architecture gate:** 35 passed, 0 failed, run under both `dash` and `bash --posix`. They cover:
- every required/optional combination, including an optional library that is present but has an unresolved dependency;
- usage errors and GitHub annotations;
- a caller's `|| exit 1` actually stopping the script;
- the new check against the **shipped v2026.9.1 x64 `lib/native`**, where it correctly fails on onnx;
- a faked `uname -m` of aarch64, which makes `build.sh cpu`/`cuda` fail in 0 s, naming the missing `cuda/lib/arm64/lib`.

**Full `deploy_posix.sh x64` on Ubuntu 24.04**, run from `git archive` of this branch with no `LD_LIBRARY_PATH`:

- **Clean tree**
  - Exit 0, and the log shows `native libraries verified: 8`.
  - `readelf -d libobjk_onnx.so` shows `RUNPATH [$ORIGIN]`.
  - `ldd` resolves `libonnxruntime.so.1 => .../deploy/lib/native/libonnxruntime.so.1`, even though this machine's `ld.so.cache` has a different `/usr/local/onnxruntime`.
  - `onnx_runtime_test.obs`, compiled and run from the new tree's `bin/` with no `LD_LIBRARY_PATH`: `All tests passed`, exit 0. The same test against the v2026.9.1 tarball exits 1.
- **Same tree with `core/lib/lame/build_linux.sh` made to fail**
  - `ERROR: missing native library: .../libobjk_lame.so`, then `DEPLOY_EXIT=1`.
  - `deploy/bin` contains only `obc obd obi obr`, so the deploy stopped at verification before building the launchers or `obu`. Before this change it went on to package the tree.

**Not verifiable from a PR:**
- **`release-build.yml`** runs only on a tag or `workflow_dispatch`. Its macOS change is the setup `ci-build.yml`'s macOS leg already uses, and that leg builds and verifies all eight libraries.
- **The linux-arm64 and macOS paths** are covered by this PR's CI legs, not by local runs.

## Coordination with `feat/deploy-cli-ui`

`git merge-tree` against that branch (84e7d18edf) reports one conflicted file, `deploy_posix.sh`, with both hunks in the ONNX block. The verify change merges cleanly next to its `ui_step "verify native libraries"`.

To resolve, keep this PR's `ORT_ARCH` guard and apply the branch's wrapping inside it:

```sh
if [ -d cuda/lib/$ORT_ARCH/lib ]; then
	ui_q ./build.sh cpu || ui_fail
	cp libobjk_onnx.so ../../../release/deploy/lib/native/libobjk_onnx.so
	...
	cp cuda/lib/$ORT_ARCH/lib/libonnxruntime_providers_shared.so ../../../release/deploy/lib/native/libonnxruntime_providers_shared.so
else
	echo "NOTE: no vendored ONNX Runtime for $ORT_ARCH (cuda/lib/$ORT_ARCH/lib) - libobjk_onnx is not built"
fi
ui_step "library: sdl"
```

Without that guard, #801's linux-arm64 leg is green but not clean. `ui_fail` reports and continues (`return 0`, matching the old script's behaviour), so the leg prints `X FAILED at stage 11/18: library: onnx (cpu)` and ends `finished with 1 failed stage(s)`, yet the job still exits 0 (seen in #801's own CI run). After both PRs merge with this resolution, arm64 skips that stage cleanly instead. Separately, #801 should probably make a failed stage change the final exit status; otherwise the same failure can still pass unnoticed.

## Not changed

- **The MSYS2 deploys** (`deploy_msys2-clang.sh`, `deploy_msys2-ucrt.sh`) still ignore the verify result. No CI leg runs them, and their ONNX link uses the Linux `.so` runtime, so enforcing it there without a test machine would be a guess.
- **ARM64 ONNX Runtime**: vendoring one is follow-up work.

## Release-notes impact for v2026.9.1

- **Linux ARM64**: no ONNX (`API.Onnx`). The tarball carries an unusable x86-64 ONNX Runtime.
- **macOS (Apple Silicon)** `.pkg`/`.zip`/`.tgz`: no ONNX and no OpenCV (`API.OpenCV`).
- **Linux x64**: ONNX is present but loads only with `LD_LIBRARY_PATH=<install>/lib/native`. Without it, the load fails with the error shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
