### PR TITLE
fix(release): ship gl_crystal.obj from every deploy, and stop when an example asset is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 
 # MSVC compiled objects
 *.obj
+# ...but this one is a Wavefront OBJ model that gl_model.obs loads
+!programs/examples/gl_crystal.obj
 
 # Linker artifacts
 *.exp

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,9 @@
 
 # MSVC compiled objects
 *.obj
-# ...but this one is a Wavefront OBJ model that gl_model.obs loads
-!programs/examples/gl_crystal.obj
+# ...but in programs/examples a .obj is a Wavefront model an example loads
+# (gl_model.obs reads gl_crystal.obj), and no build writes object files there
+!programs/examples/*.obj
 
 # Linker artifacts
 *.exp
@@ -122,6 +123,9 @@ core/release/code_doc_output.txt
 
 # Downloaded models and data (large)
 data/
+# ...but not the files every deploy copies into a distribution's examples/data.
+# data/ matches at any depth, so a new one there would never reach git.
+!programs/deploy/data/
 programs/frameworks/opencv_onnx/data/models/
 programs/frameworks/opencv_onnx/data/media/visdrone/
 

--- a/core/release/deploy_macos_arm64.sh
+++ b/core/release/deploy_macos_arm64.sh
@@ -252,6 +252,7 @@ mkdir -p core/release/deploy/examples/data
 cp programs/deploy/data/* core/release/deploy/examples/data
 cp programs/deploy/media/*.png core/release/deploy/examples/media
 cp programs/deploy/media/*.wav core/release/deploy/examples/media
+sh core/release/verify_example_assets.sh core/release/deploy/examples || exit 1
 
 cd core/release
 

--- a/core/release/deploy_msys2-clang.sh
+++ b/core/release/deploy_msys2-clang.sh
@@ -133,8 +133,19 @@ unzip docs/api.zip -d core/release/deploy-msys2-clang/doc
 mkdir core/release/deploy-msys2-clang/examples
 mkdir core/release/deploy-msys2-clang/examples/media
 cp programs/deploy/*.obs core/release/deploy-msys2-clang/examples
+cp programs/deploy/README.md core/release/deploy-msys2-clang/examples
+# This script builds libobjk_sdl against opengl32 and ships its fonts, but copied
+# none of the examples that use them, nor the data two examples read. Ship the
+# same set as the Windows and POSIX deploys.
+mkdir -p core/release/deploy-msys2-clang/examples/opengl
+cp programs/examples/gl_*.obs core/release/deploy-msys2-clang/examples/opengl
+cp programs/examples/cube_gl.obs core/release/deploy-msys2-clang/examples/opengl
+cp programs/examples/gl_crystal.obj core/release/deploy-msys2-clang/examples/opengl
+mkdir -p core/release/deploy-msys2-clang/examples/data
+cp programs/deploy/data/* core/release/deploy-msys2-clang/examples/data
 cp programs/deploy/media/*.png core/release/deploy-msys2-clang/examples/media
 cp programs/deploy/media/*.wav core/release/deploy-msys2-clang/examples/media
+sh core/release/verify_example_assets.sh core/release/deploy-msys2-clang/examples || exit 1
 
 cd core/release
 

--- a/core/release/deploy_msys2-ucrt.sh
+++ b/core/release/deploy_msys2-ucrt.sh
@@ -125,8 +125,19 @@ unzip docs/api.zip -d core/release/deploy-msys2-ucrt/doc
 mkdir core/release/deploy-msys2-ucrt/examples
 mkdir core/release/deploy-msys2-ucrt/examples/media
 cp programs/deploy/*.obs core/release/deploy-msys2-ucrt/examples
+cp programs/deploy/README.md core/release/deploy-msys2-ucrt/examples
+# This script builds libobjk_sdl against opengl32 and ships its fonts, but copied
+# none of the examples that use them, nor the data two examples read. Ship the
+# same set as the Windows and POSIX deploys.
+mkdir -p core/release/deploy-msys2-ucrt/examples/opengl
+cp programs/examples/gl_*.obs core/release/deploy-msys2-ucrt/examples/opengl
+cp programs/examples/cube_gl.obs core/release/deploy-msys2-ucrt/examples/opengl
+cp programs/examples/gl_crystal.obj core/release/deploy-msys2-ucrt/examples/opengl
+mkdir -p core/release/deploy-msys2-ucrt/examples/data
+cp programs/deploy/data/* core/release/deploy-msys2-ucrt/examples/data
 cp programs/deploy/media/*.png core/release/deploy-msys2-ucrt/examples/media
 cp programs/deploy/media/*.wav core/release/deploy-msys2-ucrt/examples/media
+sh core/release/verify_example_assets.sh core/release/deploy-msys2-ucrt/examples || exit 1
 
 cd core/release
 

--- a/core/release/deploy_posix.sh
+++ b/core/release/deploy_posix.sh
@@ -184,6 +184,7 @@ mkdir -p core/release/deploy/examples/data
 cp programs/deploy/data/* core/release/deploy/examples/data
 cp programs/deploy/media/*.png core/release/deploy/examples/media
 cp programs/deploy/media/*.wav core/release/deploy/examples/media
+sh core/release/verify_example_assets.sh core/release/deploy/examples || exit 1
 
 cd core/release
 

--- a/core/release/deploy_windows.cmd
+++ b/core/release/deploy_windows.cmd
@@ -859,6 +859,19 @@ copy ..\..\programs\examples\gl_crystal.obj %TARGET%\examples\opengl
 xcopy /e ..\..\programs\deploy\media\*.png %TARGET%\examples\media\
 xcopy /e ..\..\programs\deploy\media\*.wav %TARGET%\examples\media\
 xcopy /e ..\..\programs\deploy\data\* %TARGET%\examples\data\
+REM Nothing checks copy or xcopy, so a missing file printed "The system cannot
+REM find the file specified." and the deploy carried on -- how gl_crystal.obj,
+REM which .gitignore's *.obj kept out of git, never shipped. These are the files
+REM an example opens by name; verify_example_assets.sh holds the same list.
+for %%f in (README.md data\gender.csv data\weather.json opengl\cube_gl.obs opengl\gl_crystal.obj opengl\gl_model.obs) do (
+	if not exist "%TARGET%\examples\%%f" (
+		echo.
+		echo ============================================================
+		echo  ERROR: missing example asset %TARGET%\examples\%%f - aborting deploy
+		echo ============================================================
+		exit /b 1
+	)
+)
 
 REM copy ONNX demo programs
 copy ..\..\programs\frameworks\opencv_onnx\demo_phi3*.obs %TARGET%\examples\

--- a/core/release/verify_example_assets.sh
+++ b/core/release/verify_example_assets.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Fail a POSIX deploy if a file an example opens by name did not land in the
+# tree. The deploy scripts do not use 'set -e', so a cp that found nothing only
+# printed "cannot stat" and the deploy carried on: every deploy script copied
+# gl_crystal.obj from the day gl_model.obs shipped, and no distribution ever
+# carried it, because .gitignore's *.obj had kept it out of git.
+#
+# deploy_windows.cmd holds the same list; keep the two in step.
+#
+# usage: verify_example_assets.sh <examples_dir>
+#   e.g. verify_example_assets.sh core/release/deploy/examples
+set -u
+dir="$1"
+
+failures=0
+checked=0
+for asset in \
+  README.md \
+  data/gender.csv \
+  data/weather.json \
+  opengl/cube_gl.obs \
+  opengl/gl_crystal.obj \
+  opengl/gl_model.obs
+do
+  if [ ! -f "$dir/$asset" ]; then
+    echo "ERROR: missing example asset: $dir/$asset"
+    failures=$((failures + 1))
+    continue
+  fi
+  checked=$((checked + 1))
+done
+
+if [ "$failures" -ne 0 ]; then
+  echo "============================================================"
+  echo " ERROR: $failures example asset(s) missing - aborting deploy"
+  echo "============================================================"
+  exit 1
+fi
+echo "example assets verified: $checked in $dir"

--- a/docs/JIT_ARM64_HANDOFF_2026_09.md
+++ b/docs/JIT_ARM64_HANDOFF_2026_09.md
@@ -81,8 +81,7 @@ GCC_PREPROCESSOR_DEFINITIONS='$(inherited) _DEBUG_JIT_JIT' SYMROOT=<dir> OBJROOT
 leaves the deploy tree alone; its listing omits emitters that print under `_DEBUG_JIT` only
 (`add_shifted_reg_reg`) and prints per call at run time, so trace a small program. A master VM
 for alternated timings comes from a `git worktree` of master built the same way. `zsh` treats a
-bare `====` as a command; separate output with `printf`. `deploy_macos_arm64.sh` fails to copy
-`programs/examples/gl_crystal.obj`, which is not in the tree, and carries on.
+bare `====` as a command; separate output with `printf`.
 
 ## 1. Where the tree is
 

--- a/programs/examples/gl_crystal.obj
+++ b/programs/examples/gl_crystal.obj
@@ -1,0 +1,64 @@
+# gl_crystal.obj -- the model gl_model.obs loads by default.
+#
+# A doubly terminated quartz crystal: a hexagonal prism standing on the Y axis
+# with a six-sided point at each end. Written by hand, so every line is legible.
+#
+#   v   14 positions: the top point, two rings of six, the bottom point
+#   f   18 faces: 6 triangles, 6 quads, 6 triangles (the quads are fanned
+#       into two triangles each by the loader, 24 triangles in all)
+#
+# No vn lines, on purpose. Plenty of real files carry no normals, and without
+# them Mesh->FromObj computes a flat normal per face from its winding -- which
+# is why each facet shades as one flat plane. No vt lines either, so the whole
+# crystal samples a single texel of the demo's texture.
+#
+# Winding is counter-clockwise seen from outside, so it survives GL_CULL_FACE.
+# Indices are 1-based.
+
+o crystal
+
+# top point
+v  0.00  1.90  0.00
+
+# upper ring, y = 0.9, counter-clockwise from +X seen from below
+v  0.60  0.90  0.00
+v  0.30  0.90  0.52
+v -0.30  0.90  0.52
+v -0.60  0.90  0.00
+v -0.30  0.90 -0.52
+v  0.30  0.90 -0.52
+
+# lower ring, y = -0.9, directly beneath the upper one
+v  0.60 -0.90  0.00
+v  0.30 -0.90  0.52
+v -0.30 -0.90  0.52
+v -0.60 -0.90  0.00
+v -0.30 -0.90 -0.52
+v  0.30 -0.90 -0.52
+
+# bottom point
+v  0.00 -1.90  0.00
+
+# top termination
+f 1 3 2
+f 1 4 3
+f 1 5 4
+f 1 6 5
+f 1 7 6
+f 1 2 7
+
+# prism sides
+f 2 3 9 8
+f 3 4 10 9
+f 4 5 11 10
+f 5 6 12 11
+f 6 7 13 12
+f 7 2 8 13
+
+# bottom termination
+f 14 8 9
+f 14 9 10
+f 14 10 11
+f 14 11 12
+f 14 12 13
+f 14 13 8


### PR DESCRIPTION
## Summary

This PR is stacked on #803, which commits the model. The branch includes #803's commit (`e85080b81e`), so please merge #803 first. After that, this PR's diff is the one commit on top.

Every deploy copies `programs/examples/gl_crystal.obj`, but no distribution has ever included it. This PR makes all five deploy scripts ship it, and makes them **fail** if a file an example opens by name is missing. They stay quiet only when everything is there.

## Findings

**1. Which example loads it.** Only `programs/examples/gl_model.obs`. Its default path is `"gl_crystal.obj"`, and it says to run it from the directory that holds the file. `run_gl.cmd` and `run_gl.sh` pass the file as `gl_model`'s argument. `cube_gl.obs` and the other `gl_*.obs` examples load no `.obj`. `programs/regression/gl_context_test.obs` writes its `.obj` fixtures to the temp directory at run time.

**2. Did the model ever exist? No.** `git log --all -- '*gl_crystal*'` finds only #803's commit from today:
- `dad69095f6` (2026-08-23) added `gl_model.obs`, which refers to the model.
- `5bfc7c122c` (2026-08-25) added the copy to all three deploy scripts.
- The file itself was never committed on any branch, and no script generates it.

#803 adds a hand-written crystal. It was checked with a geometry script and a real GL probe on Windows x64 (details in #803).

**3. Other assets hidden by the same rule: none.** No other tracked file under `programs/`, `docs/` or `tools/` matches `*.obj`. The main clone has no stray `.obj` outside build directories.

**A different rule does hide shipped assets.** `data/` is meant for the root download directory, but it matches at any depth. It covers 292 tracked files, including `programs/deploy/data/gender.csv` and `weather.json`, which every deploy copies into `examples/data`. Tracked files are safe, but a *new* file in that directory would never reach git.

**4. Windows and MSYS2.**
- `deploy_windows.cmd` has the same copy (line 858) and fails with `The system cannot find the file specified.`
- The two MSYS2 scripts don't copy the model or any GL example, and they skip `programs/deploy/README.md` and `programs/deploy/data/` too. Yet both build `libobjk_sdl` against `opengl32` and ship its fonts.

**5. Why nothing stopped the deploys.** No deploy script checks a copy:
- The POSIX scripts have no `set -e`.
- `deploy_windows.cmd` never checks `copy` or `xcopy`.

The same gap affects a check that already exists. Master's `Build linux-arm64` log from today (run 34746751353) prints `ERROR: 1 native-library verification failure(s)`, and the job still passes. That's because `sh verify_native_libs.sh ...` isn't followed by `|| exit 1`. **#804 fixes that.** This PR leaves those lines alone and merges cleanly with #804 (checked with `git merge-tree`).

## Changes

| File | Change |
|---|---|
| `core/release/verify_example_assets.sh` (new) | Fails a POSIX deploy when any of these is missing from `examples/`: `README.md`, `data/gender.csv`, `data/weather.json`, `opengl/cube_gl.obs`, `opengl/gl_crystal.obj`, `opengl/gl_model.obs`. Modelled on `verify_native_libs.sh`. |
| `deploy_posix.sh`, `deploy_macos_arm64.sh` | Call it with `\|\| exit 1`. |
| `deploy_windows.cmd` | Same list, checked with `if not exist ... exit /b 1` and the script's usual error banner. |
| `deploy_msys2-ucrt.sh`, `deploy_msys2-clang.sh` | Copy the same examples as Windows and POSIX (GL examples, the model, `README.md`, `data/`), then run the same check. |
| `.gitignore` | Broadens #803's `!programs/examples/gl_crystal.obj` to `!programs/examples/*.obj`, so the next model doesn't hit the same problem. No build writes object files there. Also adds `!programs/deploy/data/`. |

## Verification

- **POSIX** (WSL Ubuntu 24.04, where `/bin/sh` is `dash`). I copied the examples into a temp directory using the deploy script's own `cp` lines, then ran the new check:
  - All files present: `example assets verified: 6`, exit 0.
  - `gl_crystal.obj` and `weather.json` removed: both named, exit 1.
  - A caller using `|| exit 1` stops at the check.
  - `sh -n` passes on all four deploy scripts and the new one. All use LF line endings.
- **Windows** (`cmd`). I took the copy lines and the new loop straight from `deploy_windows.cmd` and ran them against a scratch `TARGET`:
  - All files present: `complete tree: exit=0`.
  - `gl_crystal.obj` deleted: error banner naming the full path, `exit=1`.
- **`.gitignore`** (`git check-ignore -v -n --no-index`):
  - `programs/examples/gl_crystal.obj` and a new `programs/examples/new_model.obj` are tracked again.
  - `core/compiler/compiler.obj` is still ignored by `*.obj`.
  - `programs/deploy/data/new.json` is no longer ignored.
  - Root `data/big.bin`, `programs/frameworks/opencv_onnx/data/models/x.onnx` and `programs/examples/job-search/data/x.mhtml` are still ignored.
- Merges cleanly with master and with #804.

**Not run:**
- A full deploy on any platform. This PR's CI runs `deploy_windows.cmd`, `deploy_posix.sh` and `deploy_macos_arm64.sh`, which will exercise the new checks.
- The MSYS2 scripts beyond `dash -n`. This machine has no MSYS2 and no CI job runs them.

## #803's red CI

On #803, `Build macos-arm64` failed in `gl_context_test` on `FAILED: and does not invent time it did not take`. That's a frame-timing check: the runner logged `delta=0.100000s` after a 10 ms frame with vsync on. #803 only changes a data file, `.gitignore` and a doc, and master passes on the same base. It looks like a timing flake, so re-running the job should clear it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
