### PR TITLE
Fix int overflow sizing Image->Normalize() output (CodeQL #362, high)

### DIFF
--- a/core/lib/opencv/opencv.cpp
+++ b/core/lib/opencv/opencv.cpp
@@ -1315,8 +1315,10 @@ extern "C" {
       channels[1] = (channels[1] - (float)mean_g) / (float)std_g;
       channels[2] = (channels[2] - (float)mean_b) / (float)std_b;
 
-      // Flatten to CHW format
-      const size_t total = float_img.rows * float_img.cols * 3;
+      // Flatten to CHW format. rows and cols are int: multiplying them first
+      // overflows past ~716 megapixels, and the loop below would then write
+      // rows * cols * 3 values into an array sized from the wrapped result.
+      const size_t total = static_cast<size_t>(float_img.rows) * static_cast<size_t>(float_img.cols) * 3;
       size_t* float_array = APITools_MakeFloatArray(context, total);
       double* float_array_buffer = reinterpret_cast<double*>(float_array + 3);
 


### PR DESCRIPTION
Fixes code-scanning alert **#362** (`cpp/integer-multiplication-cast-to-long`, security severity **high**) in `core/lib/opencv/opencv.cpp:1319`.

## The bug

`opencv_normalize` -- the native half of `Image->Normalize(mean_r, mean_g, mean_b, std_r, std_g, std_b)` -- sized its output array like this:

```cpp
const size_t total = float_img.rows * float_img.cols * 3;   // int * int * int, then widened
size_t* float_array = APITools_MakeFloatArray(context, total);
...
float_array_buffer[offset++] = ...;   // runs rows * cols * 3 times, counted in size_t
```

`rows` and `cols` are `int`, so the product is computed in 32-bit signed `int` and only then converted to `size_t`. Once `rows * cols * 3` exceeds `INT_MAX` -- above ~716 megapixels -- it overflows (undefined behaviour; in practice it wraps), while the fill loop still writes the true number of elements:

| image size | wrapped `total` | result |
|---|---|---|
| < ~716 MP | correct | fine |
| ~716 MP - ~1.43 GP | negative, sign-extended to an enormous `size_t` | allocation failure: crash |
| > ~1.43 GP | small positive | array too small for the loop: **out-of-bounds write on the VM heap** |

CWE-190 (integer overflow) leading to CWE-787 (out-of-bounds write).

## Severity and real-world impact

CodeQL's "high" is the rule's generic rating. The practical exposure here is lower:

- **Only very large images reach it.** The dimensions come from the `Image` object, and `opencv_raw_read` only builds the `cv::Mat` when the attached byte array is exactly `rows * cols * elemSize` bytes -- a check done in `size_t`, so it is not affected by this bug. Reaching the overflow therefore needs a real byte array of at least ~2.1 GB, and `Normalize` then needs ~9 GB more for the float copy.
- **The common outcome is a crash, not corruption.** Every size from ~716 MP to ~1.43 GP produces an impossible allocation. The memory-corruption case needs an image above ~1.43 GP, which is also past OpenCV's default decode limit (`CV_IO_MAX_IMAGE_PIXELS`, 2^30 pixels) for images loaded from files.
- **No existing caller is known to pass images that size**; this is preprocessing for neural-network inputs, which are typically a few hundred pixels square.

So: a denial-of-service on absurdly large input, with a narrow memory-safety path beyond that. Not introduced recently -- the line dates from 2026-04-02 (641abea8cfb). It was reported only now because the c-cpp CodeQL job started building the OpenCV library (it installs `libopencv-dev` and runs `deploy_posix.sh`), so `opencv.cpp` was analysed for the first time.

## The fix

Widen before multiplying -- the same form the ONNX preprocessing already uses (`(size_t)3 * rgb.rows * rgb.cols` in `core/lib/onnx/eq/common.h`):

```cpp
const size_t total = static_cast<size_t>(float_img.rows) * static_cast<size_t>(float_img.cols) * 3;
```

## Checked

- The other native libraries (`opencv`, `onnx`, `sdl`, `matrix`) have no other `int`-multiplied size feeding an allocation; `opencv_raw_read` / `opencv_raw_write` size their buffers with `total() * elemSize()` in `size_t`.
- `g++ -std=c++20 -fsyntax-only` of the patched file against the OpenCV 4 headers: no errors. CI builds the library on all five platforms, and CodeQL on this PR should close #362.

Not tested with an image large enough to overflow: that needs well over 10 GB of memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
